### PR TITLE
Bitmap constructor from a range

### DIFF
--- a/include/containers/array.h
+++ b/include/containers/array.h
@@ -73,6 +73,11 @@ static inline bool array_container_nonzero_cardinality(
 /* Copy one container into another. We assume that they are distinct. */
 void array_container_copy(const array_container_t *src, array_container_t *dst);
 
+/*  Add all the values between min and max (included) at a distance k*step from min..
+    The container must have a size less to 4096 after this addition. s*/
+void array_container_add_from_range(array_container_t *arr, uint16_t min, uint16_t max,
+                                    uint16_t step);
+
 /* Set the cardinality to zero (does not release memory). */
 static inline void array_container_clear(array_container_t *array) {
     array->cardinality = 0;

--- a/include/containers/array.h
+++ b/include/containers/array.h
@@ -73,8 +73,8 @@ static inline bool array_container_nonzero_cardinality(
 /* Copy one container into another. We assume that they are distinct. */
 void array_container_copy(const array_container_t *src, array_container_t *dst);
 
-/*  Add all the values between min and max (included) at a distance k*step from min..
-    The container must have a size less to 4096 after this addition. s*/
+/*  Add all the values between min and max (included) at a distance k*step from min.
+    The container must have a size less to 4096 after this addition. */
 void array_container_add_from_range(array_container_t *arr, uint16_t min, uint16_t max,
                                     uint16_t step);
 

--- a/include/containers/bitset.h
+++ b/include/containers/bitset.h
@@ -203,6 +203,10 @@ static inline bool bitset_container_nonzero_cardinality(
 void bitset_container_copy(const bitset_container_t *source,
                            bitset_container_t *dest);
 
+/*  Add all the values between min and max (included) at a distance k*step from min. */
+void bitset_container_add_from_range(bitset_container_t *bitset, uint16_t min, uint16_t max,
+                                   uint16_t step);
+
 /* Get the number of bits set (force computation). This does not modify bitset.
  * To update the cardinality, you should do
  * bitset->cardinality =  bitset_container_compute_cardinality(bitset).*/

--- a/include/containers/containers.h
+++ b/include/containers/containers.h
@@ -61,7 +61,7 @@ static inline int container_get_cardinality(const void *container,
 
 /*  Create a container with all the values between min and max (included) at a
     distance k*step from min. */
-static inline void *container_from_range(int *type, uint16_t min, uint16_t max,
+static inline void *container_from_range(uint8_t *type, uint16_t min, uint16_t max,
                                                   uint16_t step) {
     uint16_t size = (max-min)/step;
     if(size < 4096) { // array container

--- a/include/containers/containers.h
+++ b/include/containers/containers.h
@@ -59,6 +59,25 @@ static inline int container_get_cardinality(const void *container,
     return 0;  // unreached
 }
 
+/*  Create a container with all the values between min and max (included) at a
+    distance k*step from min. */
+static inline void *container_from_range(int *type, uint16_t min, uint16_t max,
+                                                  uint16_t step) {
+    uint16_t size = (max-min)/step;
+    if(size < 4096) { // array container
+        *type = ARRAY_CONTAINER_TYPE_CODE;
+        array_container_t * array = array_container_create_given_capacity(size);
+        array_container_add_from_range(array, min, max, step);
+        return array;
+    }
+    else { // bitset container
+        *type = BITSET_CONTAINER_TYPE_CODE;
+        bitset_container_t *bitset = bitset_container_create();
+        bitset_container_add_from_range(bitset, min, max, step);
+        return bitset;
+    }
+}
+
 /**
  * "repair" the container after lazy operations.
  */

--- a/include/roaring.h
+++ b/include/roaring.h
@@ -19,6 +19,11 @@ typedef struct roaring_bitmap_s {
  */
 roaring_bitmap_t *roaring_bitmap_create(void);
 
+/**
+ * Add all the values between min (included) and max (excluded) that are at a
+ * distance k*step from min.
+*/
+roaring_bitmap_t *roaring_bitmap_from_range(uint32_t min, uint32_t max, uint32_t step);
 
 /**
  * Creates a new bitmap (initially empty) with a provided

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -129,6 +129,13 @@ static void array_container_append(array_container_t *arr, uint16_t pos) {
     arr->array[arr->cardinality++] = pos;
 }
 
+void array_container_add_from_range(array_container_t *arr, uint16_t min, uint16_t max,
+                                    uint16_t step) {
+    for(uint32_t value = min ; value <= max ; value += step) {
+        array_container_append(arr, value);
+    }
+}
+
 /* Add x to the set. Returns true if x was not already present.  */
 bool array_container_add(array_container_t *arr, uint16_t pos) {
     const int32_t cardinality = arr->cardinality;

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -56,6 +56,32 @@ void bitset_container_copy(const bitset_container_t *source,
            sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
 }
 
+void bitset_container_add_from_range(bitset_container_t *bitset, uint16_t min, uint16_t max,
+                                   uint16_t step) {
+    if(64%step == 0) {
+       uint64_t mask = 0;
+        for(uint64_t value = min%step ; value < 64 ; value += step) {
+            mask |= ((uint64_t)1<<value);
+        }
+        uint32_t firstword = min / 64;
+        uint32_t endword = (max - 1) / 64;
+        bitset->cardinality = (max-min+1)/step + ((max-min+1)%step!=0);
+        if (firstword == endword) {
+            bitset->array[firstword] |= mask&((~UINT64_C(0)) << (min % 64)) &
+            ((~UINT64_C(0)) >> ((-max) % 64));
+            return;
+        }
+        bitset->array[firstword] |= mask&((~UINT64_C(0)) << (min % 64));
+        for (uint32_t i = firstword + 1; i < endword; i++) bitset->array[i] = mask;
+        bitset->array[endword] |= mask&((~UINT64_C(0)) >> ((-max-1) % 64));
+    }
+    else {
+        for(uint32_t value = min ; value <= max ; value += step) {
+            bitset_container_add(bitset, value);
+        }
+    }
+}
+
 /* Free memory. */
 void bitset_container_free(bitset_container_t *bitset) {
     free(bitset->array);

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -55,6 +55,16 @@ roaring_bitmap_t *roaring_bitmap_of(size_t n_args, ...) {
     return answer;
 }
 
+roaring_bitmap_t *roaring_bitmap_from_range(uint32_t min, uint32_t max, uint32_t step) {
+    if(step == 0)
+        return NULL;
+    roaring_bitmap_t *answer = roaring_bitmap_create();
+    for(uint32_t value = min ; value < max ; value += step) {
+            roaring_bitmap_add(answer, value);
+    }
+    return answer;
+}
+
 void roaring_bitmap_printf(const roaring_bitmap_t *ra) {
     printf("{");
     for (int i = 0; i < ra->high_low_container->size; ++i) {

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -64,9 +64,9 @@ static inline int32_t next_container_bound(uint32_t value) {
 roaring_bitmap_t *roaring_bitmap_from_range(uint32_t min, uint32_t max, uint32_t step) {
     if(step == 0)
         return NULL;
-    roaring_bitmap_t *answer = roaring_bitmap_create();
     if(max <= min)
-        return answer;
+        return NULL;
+    roaring_bitmap_t *answer = roaring_bitmap_create();
     if(step >= (1<<16)) {
         for(uint32_t value = min ; value < max ; value += step) {
                 roaring_bitmap_add(answer, value);
@@ -77,7 +77,7 @@ roaring_bitmap_t *roaring_bitmap_from_range(uint32_t min, uint32_t max, uint32_t
     do {
         uint16_t key = min_tmp>>16;
         uint32_t real_max = minimum(max, max_tmp)-1;
-        int type;
+        uint8_t type;
         void *container = container_from_range(&type, min_tmp-(key<<16), real_max-(key<<16),
                                                           (uint16_t)step);
         ra_append(answer->high_low_container, key, container, type);

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -84,8 +84,9 @@ roaring_bitmap_t *roaring_bitmap_from_range(uint32_t min, uint32_t max, uint32_t
             ra_append(answer->high_low_container, key, array, ARRAY_CONTAINER_TYPE_CODE);
         }
         else { // bitset container
-            // // TODO
-            return NULL;
+            bitset_container_t *bitset = bitset_container_create();
+            bitset_container_add_from_range(bitset, min_tmp-key*(1<<16), real_max-key*(1<<16), (uint16_t)step);
+            ra_append(answer->high_low_container, key, bitset, BITSET_CONTAINER_TYPE_CODE);
         }
         min_tmp += (size+1)*step;
         max_tmp = next_container_bound(min_tmp);

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -142,12 +142,14 @@ void test_bitmap_from_range() {
     no_error = check_bitmap_from_range(5, 1, 3) && no_error; // empty range
     for(uint32_t i = 16 ; i < 1<<18 ; i*= 2) {
         uint32_t min = i-10;
-        uint32_t max = i+400;
-        for(uint32_t step = 1 ; step <= 64 ; step*=2) { // check powers of 2
-            no_error = check_bitmap_from_range(min, max, step) && no_error;
-        }
-        for(uint32_t step = 1 ; step <= 81 ; step*=3) { // check powers of 3
-            no_error = check_bitmap_from_range(min, max, step) && no_error;
+        for(uint32_t delta = 16 ; delta < 1<<18 ; delta*=2) {
+            uint32_t max = i+delta;
+            for(uint32_t step = 1 ; step <= 64 ; step*=2) { // check powers of 2
+                no_error = check_bitmap_from_range(min, max, step) && no_error;
+            }
+            for(uint32_t step = 1 ; step <= 81 ; step*=3) { // check powers of 3
+                no_error = check_bitmap_from_range(min, max, step) && no_error;
+            }
         }
     }
     assert_true(no_error);

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -138,8 +138,8 @@ bool check_bitmap_from_range(uint32_t min, uint32_t max, uint32_t step) {
 
 void test_bitmap_from_range() {
     assert_true(roaring_bitmap_from_range(1, 10, 0) == NULL); // undefined range
+    assert_true(roaring_bitmap_from_range(5, 1, 3) == NULL); // empty range
     bool no_error = true;
-    no_error = check_bitmap_from_range(5, 1, 3) && no_error; // empty range
     for(uint32_t i = 16 ; i < 1<<18 ; i*= 2) {
         uint32_t min = i-10;
         for(uint32_t delta = 16 ; delta < 1<<18 ; delta*=2) {

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -120,6 +120,32 @@ void test_example() {
     roaring_bitmap_free(r3);
 }
 
+void check_bitmap_from_range(uint32_t min, uint32_t max, uint32_t step) {
+    roaring_bitmap_t *result = roaring_bitmap_from_range(min, max, step);
+    assert_non_null(result);
+    roaring_bitmap_t *expected = roaring_bitmap_create();
+    assert_non_null(expected);
+    for(uint32_t value = min ; value < max ; value += step) {
+        roaring_bitmap_add(expected, value);
+    }
+    assert_true(roaring_bitmap_equals(expected, result));
+}
+
+void test_bitmap_from_range() {
+    assert_true(roaring_bitmap_from_range(1, 10, 0) == NULL); // undefined range
+    check_bitmap_from_range(5, 1, 3); // empty range
+    for(uint32_t i = 16 ; i < 1<<18 ; i*= 2) {
+        uint32_t min = i-10;
+        uint32_t max = i+400;
+        for(uint32_t step = 1 ; step <= 64 ; step*=2) { // check powers of 2
+            check_bitmap_from_range(min, max, step);
+        }
+        for(uint32_t step = 1 ; step <= 81 ; step*=3) { // check powers of 3
+            check_bitmap_from_range(min, max, step);
+        }
+    }
+}
+
 void test_printf() {
     roaring_bitmap_t *r1 =
         roaring_bitmap_of(8, 1, 2, 3, 100, 1000, 10000, 1000000, 20000000);
@@ -783,6 +809,7 @@ void test_remove_run_to_array() {
 int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_example),
+        cmocka_unit_test(test_bitmap_from_range),
         cmocka_unit_test(test_printf),
         cmocka_unit_test(test_printf_withbitmap),
         cmocka_unit_test(test_printf_withrun),

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -120,7 +120,7 @@ void test_example() {
     roaring_bitmap_free(r3);
 }
 
-void check_bitmap_from_range(uint32_t min, uint32_t max, uint32_t step) {
+bool check_bitmap_from_range(uint32_t min, uint32_t max, uint32_t step) {
     roaring_bitmap_t *result = roaring_bitmap_from_range(min, max, step);
     assert_non_null(result);
     roaring_bitmap_t *expected = roaring_bitmap_create();
@@ -128,22 +128,29 @@ void check_bitmap_from_range(uint32_t min, uint32_t max, uint32_t step) {
     for(uint32_t value = min ; value < max ; value += step) {
         roaring_bitmap_add(expected, value);
     }
-    assert_true(roaring_bitmap_equals(expected, result));
+    bool is_equal = roaring_bitmap_equals(expected, result);
+    if(!is_equal) {
+        fprintf(stderr, "[ERROR] check_bitmap_from_range(%u, %u, %u)\n",
+            (unsigned)min, (unsigned)max, (unsigned)step);
+    }
+    return is_equal;
 }
 
 void test_bitmap_from_range() {
     assert_true(roaring_bitmap_from_range(1, 10, 0) == NULL); // undefined range
-    check_bitmap_from_range(5, 1, 3); // empty range
+    bool no_error = true;
+    no_error = check_bitmap_from_range(5, 1, 3) && no_error; // empty range
     for(uint32_t i = 16 ; i < 1<<18 ; i*= 2) {
         uint32_t min = i-10;
         uint32_t max = i+400;
         for(uint32_t step = 1 ; step <= 64 ; step*=2) { // check powers of 2
-            check_bitmap_from_range(min, max, step);
+            no_error = check_bitmap_from_range(min, max, step) && no_error;
         }
         for(uint32_t step = 1 ; step <= 81 ; step*=3) { // check powers of 3
-            check_bitmap_from_range(min, max, step);
+            no_error = check_bitmap_from_range(min, max, step) && no_error;
         }
     }
+    assert_true(no_error);
 }
 
 void test_printf() {


### PR DESCRIPTION
This pull request implements the following function:

```c
roaring_bitmap_t *roaring_bitmap_from_range(uint32_t min, uint32_t max, uint32_t step);
```

It creates a bitmap with values in `[min, min+step, min+2*step, ..., min+k*step]` such that `k*step<max` and `(k+1)*step>=max` (similar to what does the Python `range`).

To do this efficiently, two tricks are used:
* When the container is an array, we first construct an empty array allocated with the required size, then we append all the values.
* When the container is a bitset and `step` is a divisor of 64, all the cells of the bitsets are the same, so we just compute it once.

For `min=0, max=1000000000, step=1`, we get a speedup of about 200 with this solution, in comparison with the naive idea to use `roaring_bitmap_add` for every value of the range.

There is certainly other optimizations to do.