### PR TITLE
Fix roaring_bitmap_remove by avoiding a double free.

### DIFF
--- a/src/roaring.c
+++ b/src/roaring.c
@@ -190,7 +190,6 @@ void roaring_bitmap_remove(roaring_bitmap_t *r, uint32_t val) {
             ra_set_container_at_index(r->high_low_container, i, container2,
                                               newtypecode);
         } else {
-            container_free(container2, newtypecode);
             ra_remove_at_index(r->high_low_container, i);
         }
     }

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -177,12 +177,18 @@ void can_remove_from_copies(bool copy_on_write) {
 }
 
 
+void test_basic_add() {
+    roaring_bitmap_t *bm = roaring_bitmap_create();
+    roaring_bitmap_add(bm, 0);
+    roaring_bitmap_remove(bm, 0);
+}
+
 void test_remove_from_copies_true() {
   can_remove_from_copies(true);
 }
 
 void test_remove_from_copies_false() {
-  can_remove_from_copies(true);
+  can_remove_from_copies(false);
 }
 
 
@@ -1469,6 +1475,7 @@ void test_inplace_rand_flips() {
 
 int main() {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_basic_add),
         cmocka_unit_test(test_remove_withrun),
         cmocka_unit_test(test_remove_from_copies_true),
         cmocka_unit_test(test_remove_from_copies_false),


### PR DESCRIPTION
The container was freed twice: in `roaring_bitmap_remove` and in `ra_remove_at_index`.
The double free was crashing the program with the simple test I added.

I also think there was a typo in `test_remove_from_copies_false`, I fixed it.