### PR TITLE
Implement get_element_of_rank.

### DIFF
--- a/include/containers/array.h
+++ b/include/containers/array.h
@@ -213,7 +213,7 @@ bool array_container_equals(array_container_t *container1,
  * accordingly.
  * Otherwise, it returns false and update start_rank.
  */
-static inline bool array_container_select(array_container_t *container,
+static inline bool array_container_select(const array_container_t *container,
                                           uint32_t *start_rank, uint32_t rank, uint32_t *element) {
     int card = array_container_cardinality(container);
     if(*start_rank + card <= rank) {

--- a/include/containers/array.h
+++ b/include/containers/array.h
@@ -213,7 +213,7 @@ bool array_container_equals(array_container_t *container1,
  * accordingly.
  * Otherwise, it returns false and update start_rank.
  */
-static inline bool array_get_element_of_rank(array_container_t *container,
+static inline bool array_container_select(array_container_t *container,
                                           uint32_t *start_rank, uint32_t rank, uint32_t *element) {
     int card = array_container_cardinality(container);
     if(*start_rank + card <= rank) {

--- a/include/containers/array.h
+++ b/include/containers/array.h
@@ -207,4 +207,23 @@ static inline int32_t array_container_size_in_bytes(
 bool array_container_equals(array_container_t *container1,
                             array_container_t *container2);
 
+/**
+ * If the element of given rank is in this container, supposing that the first
+ * element has rank start_rank, then the function returns true and sets element
+ * accordingly.
+ * Otherwise, it returns false and update start_rank.
+ */
+static inline bool array_get_element_of_rank(array_container_t *container,
+                                          uint32_t *start_rank, uint32_t rank, uint32_t *element) {
+    int card = array_container_cardinality(container);
+    if(*start_rank + card <= rank) {
+        *start_rank += card;
+        return false;
+    }
+    else {
+        *element = container->array[rank-*start_rank];
+        return true;
+    }
+}
+
 #endif /* INCLUDE_CONTAINERS_ARRAY_H_ */

--- a/include/containers/bitset.h
+++ b/include/containers/bitset.h
@@ -387,6 +387,6 @@ bool bitset_container_equals(bitset_container_t *container1,
  * accordingly.
  * Otherwise, it returns false and update start_rank.
  */
-bool bitset_get_element_of_rank(bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element);
+bool bitset_container_select(bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element);
 
 #endif /* INCLUDE_CONTAINERS_BITSET_H_ */

--- a/include/containers/bitset.h
+++ b/include/containers/bitset.h
@@ -381,4 +381,12 @@ static inline int32_t bitset_container_size_in_bytes(
 bool bitset_container_equals(bitset_container_t *container1,
                              bitset_container_t *container2);
 
+/**
+ * If the element of given rank is in this container, supposing that the first
+ * element has rank start_rank, then the function returns true and sets element
+ * accordingly.
+ * Otherwise, it returns false and update start_rank.
+ */
+bool bitset_get_element_of_rank(bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element);
+
 #endif /* INCLUDE_CONTAINERS_BITSET_H_ */

--- a/include/containers/bitset.h
+++ b/include/containers/bitset.h
@@ -387,6 +387,6 @@ bool bitset_container_equals(bitset_container_t *container1,
  * accordingly.
  * Otherwise, it returns false and update start_rank.
  */
-bool bitset_container_select(bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element);
+bool bitset_container_select(const bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element);
 
 #endif /* INCLUDE_CONTAINERS_BITSET_H_ */

--- a/include/containers/containers.h
+++ b/include/containers/containers.h
@@ -1295,15 +1295,15 @@ static inline void *container_range_of_ones(uint32_t range_start,
  * accordingly.
  * Otherwise, it returns false and update start_rank.
  */
-static inline bool container_get_element_of_rank(void *container, uint8_t typecode,
+static inline bool container_select(void *container, uint8_t typecode,
                                                 uint32_t *start_rank, uint32_t rank, uint32_t *element) {
     switch (typecode) {
         case BITSET_CONTAINER_TYPE_CODE:
-            return bitset_get_element_of_rank((bitset_container_t *)container, start_rank, rank, element);
+            return bitset_container_select((bitset_container_t *)container, start_rank, rank, element);
         case ARRAY_CONTAINER_TYPE_CODE:
-            return array_get_element_of_rank((array_container_t *)container, start_rank, rank, element);
+            return array_container_select((array_container_t *)container, start_rank, rank, element);
         case RUN_CONTAINER_TYPE_CODE:
-            return run_get_element_of_rank((run_container_t *)container, start_rank, rank, element);
+            return run_container_select((run_container_t *)container, start_rank, rank, element);
         default:
             assert(false);
             __builtin_unreachable();

--- a/include/containers/containers.h
+++ b/include/containers/containers.h
@@ -1289,4 +1289,25 @@ static inline void *container_range_of_ones(uint32_t range_start,
     return run_container_create_range(range_start, range_end);
 }
 
+/**
+ * If the element of given rank is in this container, supposing that the first
+ * element has rank start_rank, then the function returns true and sets element
+ * accordingly.
+ * Otherwise, it returns false and update start_rank.
+ */
+static inline bool container_get_element_of_rank(void *container, uint8_t typecode,
+                                                uint32_t *start_rank, uint32_t rank, uint32_t *element) {
+    switch (typecode) {
+        case BITSET_CONTAINER_TYPE_CODE:
+            return bitset_get_element_of_rank((bitset_container_t *)container, start_rank, rank, element);
+        case ARRAY_CONTAINER_TYPE_CODE:
+            return array_get_element_of_rank((array_container_t *)container, start_rank, rank, element);
+        case RUN_CONTAINER_TYPE_CODE:
+            return run_get_element_of_rank((run_container_t *)container, start_rank, rank, element);
+        default:
+            assert(false);
+            __builtin_unreachable();
+    }
+}
+
 #endif

--- a/include/containers/containers.h
+++ b/include/containers/containers.h
@@ -1295,8 +1295,9 @@ static inline void *container_range_of_ones(uint32_t range_start,
  * accordingly.
  * Otherwise, it returns false and update start_rank.
  */
-static inline bool container_select(void *container, uint8_t typecode,
+static inline bool container_select(const void *container, uint8_t typecode,
                                                 uint32_t *start_rank, uint32_t rank, uint32_t *element) {
+    container = container_unwrap_shared(container, &typecode);
     switch (typecode) {
         case BITSET_CONTAINER_TYPE_CODE:
             return bitset_container_select((bitset_container_t *)container, start_rank, rank, element);

--- a/include/containers/run.h
+++ b/include/containers/run.h
@@ -293,6 +293,6 @@ static inline run_container_t *run_container_create_range(uint32_t start,
  * accordingly.
  * Otherwise, it returns false and update start_rank.
  */
-bool run_container_select(run_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element);
+bool run_container_select(const run_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element);
 
 #endif /* INCLUDE_CONTAINERS_RUN_H_ */

--- a/include/containers/run.h
+++ b/include/containers/run.h
@@ -293,6 +293,6 @@ static inline run_container_t *run_container_create_range(uint32_t start,
  * accordingly.
  * Otherwise, it returns false and update start_rank.
  */
-bool run_get_element_of_rank(run_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element);
+bool run_container_select(run_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element);
 
 #endif /* INCLUDE_CONTAINERS_RUN_H_ */

--- a/include/containers/run.h
+++ b/include/containers/run.h
@@ -287,4 +287,12 @@ static inline run_container_t *run_container_create_range(uint32_t start,
     return rc;
 }
 
+/**
+ * If the element of given rank is in this container, supposing that the first
+ * element has rank start_rank, then the function returns true and sets element
+ * accordingly.
+ * Otherwise, it returns false and update start_rank.
+ */
+bool run_get_element_of_rank(run_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element);
+
 #endif /* INCLUDE_CONTAINERS_RUN_H_ */

--- a/include/roaring.h
+++ b/include/roaring.h
@@ -264,7 +264,7 @@ void roaring_bitmap_flip_inplace(roaring_bitmap_t *x1, uint64_t range_start,
    function returns true and set element to the element of given rank.
    Otherwise, it returns false.
  */
-bool roaring_bitmap_get_element_of_rank(roaring_bitmap_t *ra, uint32_t rank,
+bool roaring_bitmap_select(roaring_bitmap_t *ra, uint32_t rank,
                                         uint32_t *element);
 
 #ifdef __cplusplus

--- a/include/roaring.h
+++ b/include/roaring.h
@@ -259,6 +259,14 @@ roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *x1,
 void roaring_bitmap_flip_inplace(roaring_bitmap_t *x1, uint64_t range_start,
                                  uint64_t range_end);
 
+/**
+ * If the size of the roaring bitmap is strictly greater than rank, then this
+   function returns true and set element to the element of given rank.
+   Otherwise, it returns false.
+ */
+bool roaring_bitmap_get_element_of_rank(roaring_bitmap_t *ra, uint32_t rank,
+                                        uint32_t *element);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/roaring.h
+++ b/include/roaring.h
@@ -264,7 +264,7 @@ void roaring_bitmap_flip_inplace(roaring_bitmap_t *x1, uint64_t range_start,
    function returns true and set element to the element of given rank.
    Otherwise, it returns false.
  */
-bool roaring_bitmap_select(roaring_bitmap_t *ra, uint32_t rank,
+bool roaring_bitmap_select(const roaring_bitmap_t *ra, uint32_t rank,
                                         uint32_t *element);
 
 #ifdef __cplusplus

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -616,7 +616,7 @@ bool bitset_container_equals(bitset_container_t *container1, bitset_container_t 
 	return true;
 }
 
-bool bitset_container_select(bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
+bool bitset_container_select(const bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
     int card = bitset_container_cardinality(container);
     if(rank >= *start_rank + card) {
         *start_rank += card;

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -615,3 +615,34 @@ bool bitset_container_equals(bitset_container_t *container1, bitset_container_t 
 	}
 	return true;
 }
+
+bool bitset_get_element_of_rank(bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
+    int card = bitset_container_cardinality(container);
+    if(rank >= *start_rank + card) {
+        *start_rank += card;
+        return false;
+    }
+    const uint64_t *array = container->array;
+    int32_t size;
+    for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; i += 1) {
+        size = hamming(array[i]);
+        if(rank <= *start_rank + size) {
+            uint64_t w = container->array[i];
+            uint16_t base = i*64;
+            while (w != 0) {
+                uint64_t t = w & -w;
+                int r = __builtin_ctzl(w);
+                if(*start_rank == rank) {
+                    *element = r+base;
+                    return true;
+                }
+                w ^= t;
+                *start_rank += 1;
+            }
+        }
+        else
+            *start_rank += size;
+    }
+    assert(false);
+    __builtin_unreachable();
+}

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -616,7 +616,7 @@ bool bitset_container_equals(bitset_container_t *container1, bitset_container_t 
 	return true;
 }
 
-bool bitset_get_element_of_rank(bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
+bool bitset_container_select(bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
     int card = bitset_container_cardinality(container);
     if(rank >= *start_rank + card) {
         *start_rank += card;

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -713,7 +713,7 @@ void run_container_smart_append_exclusive(run_container_t *src,
     }
 }
 
-bool run_get_element_of_rank(run_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
+bool run_container_select(run_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
     for(int i = 0; i < container->n_runs; i++) {
         uint16_t length = container->runs[i].length;
         if(rank <= *start_rank + length) {

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -713,7 +713,7 @@ void run_container_smart_append_exclusive(run_container_t *src,
     }
 }
 
-bool run_container_select(run_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
+bool run_container_select(const run_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
     for(int i = 0; i < container->n_runs; i++) {
         uint16_t length = container->runs[i].length;
         if(rank <= *start_rank + length) {

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -712,3 +712,17 @@ void run_container_smart_append_exclusive(run_container_t *src,
         src->n_runs++;
     }
 }
+
+bool run_get_element_of_rank(run_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
+    for(int i = 0; i < container->n_runs; i++) {
+        uint16_t length = container->runs[i].length;
+        if(rank <= *start_rank + length) {
+            uint16_t value = container->runs[i].value;
+            *element = value + rank-(*start_rank);
+            return true;
+        }
+        else
+            *start_rank += length+1;
+    }
+    return false;
+}

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1019,7 +1019,7 @@ void roaring_bitmap_repair_after_lazy(roaring_bitmap_t *ra) {
     }
 }
 
-bool roaring_bitmap_get_element_of_rank(roaring_bitmap_t *bm, uint32_t rank, uint32_t *element) {
+bool roaring_bitmap_select(roaring_bitmap_t *bm, uint32_t rank, uint32_t *element) {
     void *container;
     uint8_t typecode;
     uint16_t key;
@@ -1029,7 +1029,7 @@ bool roaring_bitmap_get_element_of_rank(roaring_bitmap_t *bm, uint32_t rank, uin
     while(!valid && i < bm->high_low_container->size) {
         container = bm->high_low_container->containers[i];
         typecode = bm->high_low_container->typecodes[i];
-        valid = container_get_element_of_rank(container, typecode, &start_rank, rank, element) ;
+        valid = container_select(container, typecode, &start_rank, rank, element) ;
         i++;
     }
 

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1019,7 +1019,7 @@ void roaring_bitmap_repair_after_lazy(roaring_bitmap_t *ra) {
     }
 }
 
-bool roaring_bitmap_select(roaring_bitmap_t *bm, uint32_t rank, uint32_t *element) {
+bool roaring_bitmap_select(const roaring_bitmap_t *bm, uint32_t rank, uint32_t *element) {
     void *container;
     uint8_t typecode;
     uint16_t key;

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1018,3 +1018,26 @@ void roaring_bitmap_repair_after_lazy(roaring_bitmap_t *ra) {
         ra->high_low_container->typecodes[i] = new_typecode;
     }
 }
+
+bool roaring_bitmap_get_element_of_rank(roaring_bitmap_t *bm, uint32_t rank, uint32_t *element) {
+    void *container;
+    uint8_t typecode;
+    uint16_t key;
+    uint32_t start_rank = 0;
+    int i=0;
+    bool valid = false;
+    while(!valid && i < bm->high_low_container->size) {
+        container = bm->high_low_container->containers[i];
+        typecode = bm->high_low_container->typecodes[i];
+        valid = container_get_element_of_rank(container, typecode, &start_rank, rank, element) ;
+        i++;
+    }
+
+    if(valid) {
+        key = bm->high_low_container->keys[i-1];
+        *element |= (key << 16);
+        return true;
+    }
+    else
+        return false;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 add_cpp_test(cpp_unit)
 add_c_test(array_container_unit)
+add_c_test(bitset_container_unit)
 add_c_test(mixed_container_unit)
 add_c_test(run_container_unit)
 add_c_test(toplevel_unit)

--- a/tests/array_container_unit.c
+++ b/tests/array_container_unit.c
@@ -152,10 +152,33 @@ void to_uint32_array_test() {
     }
 }
 
+void get_element_of_rank_test() {
+    array_container_t* B = array_container_create();
+    assert_non_null(B);
+    uint16_t base = 27;
+    for(uint16_t value = base; value < base+200 ; value += 5) {
+        array_container_add(B, value);
+    }
+    uint32_t i = 0;
+    uint32_t element=0;
+    uint32_t start_rank;
+    for(uint16_t value = base; value < base+200 ; value += 5) {
+        start_rank = 12;
+        assert_true(array_get_element_of_rank(B, &start_rank, i+12, &element));
+        assert_int_equal(element, value);
+        i++;
+    }
+    start_rank = 12;
+    assert_false(array_get_element_of_rank(B, &start_rank, i+12, &element));
+    assert_int_equal(start_rank, i+12);
+    array_container_free(B);
+}
+
 int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(printf_test), cmocka_unit_test(add_contains_test),
         cmocka_unit_test(and_or_test), cmocka_unit_test(to_uint32_array_test),
+        cmocka_unit_test(get_element_of_rank_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/array_container_unit.c
+++ b/tests/array_container_unit.c
@@ -152,7 +152,7 @@ void to_uint32_array_test() {
     }
 }
 
-void get_element_of_rank_test() {
+void select_test() {
     array_container_t* B = array_container_create();
     assert_non_null(B);
     uint16_t base = 27;
@@ -164,12 +164,12 @@ void get_element_of_rank_test() {
     uint32_t start_rank;
     for(uint16_t value = base; value < base+200 ; value += 5) {
         start_rank = 12;
-        assert_true(array_get_element_of_rank(B, &start_rank, i+12, &element));
+        assert_true(array_container_select(B, &start_rank, i+12, &element));
         assert_int_equal(element, value);
         i++;
     }
     start_rank = 12;
-    assert_false(array_get_element_of_rank(B, &start_rank, i+12, &element));
+    assert_false(array_container_select(B, &start_rank, i+12, &element));
     assert_int_equal(start_rank, i+12);
     array_container_free(B);
 }
@@ -178,7 +178,7 @@ int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(printf_test), cmocka_unit_test(add_contains_test),
         cmocka_unit_test(and_or_test), cmocka_unit_test(to_uint32_array_test),
-        cmocka_unit_test(get_element_of_rank_test),
+        cmocka_unit_test(select_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/bitset_container_unit.c
+++ b/tests/bitset_container_unit.c
@@ -208,11 +208,34 @@ void to_uint32_array_test() {
     }
 }
 
+void get_element_of_rank_test() {
+    bitset_container_t* B = bitset_container_create();
+    assert_non_null(B);
+    uint16_t base = 27;
+    for(uint16_t value = base; value < base+200 ; value += 5) {
+        bitset_container_add(B, value);
+    }
+    uint32_t i = 0;
+    uint32_t element=0;
+    uint32_t start_rank;
+    for(uint16_t value = base; value < base+200 ; value += 5) {
+        start_rank = 12;
+        assert_true(bitset_get_element_of_rank(B, &start_rank, i+12, &element));
+        assert_int_equal(element, value);
+        i++;
+    }
+    start_rank = 12;
+    assert_false(bitset_get_element_of_rank(B, &start_rank, i+12, &element));
+    assert_int_equal(start_rank, i+12);
+    bitset_container_free(B);
+}
+
 int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(printf_test), cmocka_unit_test(set_get_test),
         cmocka_unit_test(and_or_test), cmocka_unit_test(xor_test),
         cmocka_unit_test(andnot_test), cmocka_unit_test(to_uint32_array_test),
+        cmocka_unit_test(get_element_of_rank_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/bitset_container_unit.c
+++ b/tests/bitset_container_unit.c
@@ -208,7 +208,7 @@ void to_uint32_array_test() {
     }
 }
 
-void get_element_of_rank_test() {
+void select_test() {
     bitset_container_t* B = bitset_container_create();
     assert_non_null(B);
     uint16_t base = 27;
@@ -220,12 +220,12 @@ void get_element_of_rank_test() {
     uint32_t start_rank;
     for(uint16_t value = base; value < base+200 ; value += 5) {
         start_rank = 12;
-        assert_true(bitset_get_element_of_rank(B, &start_rank, i+12, &element));
+        assert_true(bitset_container_select(B, &start_rank, i+12, &element));
         assert_int_equal(element, value);
         i++;
     }
     start_rank = 12;
-    assert_false(bitset_get_element_of_rank(B, &start_rank, i+12, &element));
+    assert_false(bitset_container_select(B, &start_rank, i+12, &element));
     assert_int_equal(start_rank, i+12);
     bitset_container_free(B);
 }
@@ -235,7 +235,7 @@ int main() {
         cmocka_unit_test(printf_test), cmocka_unit_test(set_get_test),
         cmocka_unit_test(and_or_test), cmocka_unit_test(xor_test),
         cmocka_unit_test(andnot_test), cmocka_unit_test(to_uint32_array_test),
-        cmocka_unit_test(get_element_of_rank_test),
+        cmocka_unit_test(select_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/run_container_unit.c
+++ b/tests/run_container_unit.c
@@ -143,7 +143,7 @@ void to_uint32_array_test() {
     }
 }
 
-void get_element_of_rank_test() {
+void select_test() {
     run_container_t* B = run_container_create();
     assert_non_null(B);
     uint16_t base = 27;
@@ -155,12 +155,12 @@ void get_element_of_rank_test() {
     uint32_t start_rank;
     for(uint16_t value = base; value < base+200 ; value += 5) {
         start_rank = 12;
-        assert_true(run_get_element_of_rank(B, &start_rank, i+12, &element));
+        assert_true(run_container_select(B, &start_rank, i+12, &element));
         assert_int_equal(element, value);
         i++;
     }
     start_rank = 12;
-    assert_false(run_get_element_of_rank(B, &start_rank, i+12, &element));
+    assert_false(run_container_select(B, &start_rank, i+12, &element));
     assert_int_equal(start_rank, i+12);
     run_container_free(B);
 }
@@ -169,7 +169,7 @@ int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(printf_test), cmocka_unit_test(add_contains_test),
         cmocka_unit_test(and_or_test), cmocka_unit_test(to_uint32_array_test),
-        cmocka_unit_test(get_element_of_rank_test),
+        cmocka_unit_test(select_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/run_container_unit.c
+++ b/tests/run_container_unit.c
@@ -143,10 +143,33 @@ void to_uint32_array_test() {
     }
 }
 
+void get_element_of_rank_test() {
+    run_container_t* B = run_container_create();
+    assert_non_null(B);
+    uint16_t base = 27;
+    for(uint16_t value = base; value < base+200 ; value += 5) {
+        run_container_add(B, value);
+    }
+    uint32_t i = 0;
+    uint32_t element=0;
+    uint32_t start_rank;
+    for(uint16_t value = base; value < base+200 ; value += 5) {
+        start_rank = 12;
+        assert_true(run_get_element_of_rank(B, &start_rank, i+12, &element));
+        assert_int_equal(element, value);
+        i++;
+    }
+    start_rank = 12;
+    assert_false(run_get_element_of_rank(B, &start_rank, i+12, &element));
+    assert_int_equal(start_rank, i+12);
+    run_container_free(B);
+}
+
 int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(printf_test), cmocka_unit_test(add_contains_test),
         cmocka_unit_test(and_or_test), cmocka_unit_test(to_uint32_array_test),
+        cmocka_unit_test(get_element_of_rank_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -1501,7 +1501,7 @@ void test_inplace_rand_flips() {
 }
 
 // randomized test for rank query
-void get_element_of_rank_tests() {
+void select_test() {
     srand(1234);
     const int min_runs = 1;
     const uint32_t range = 2000000;
@@ -1538,13 +1538,13 @@ void get_element_of_rank_tests() {
         uint32_t element;
         for(uint32_t i = 0 ; i < true_card ; i++) {
             if(input[i]) {
-                assert_true(roaring_bitmap_get_element_of_rank(r, rank, &element));
+                assert_true(roaring_bitmap_select(r, rank, &element));
                 assert_int_equal(i, element);
                 rank++;
             }
         }
         for(uint32_t n = 0 ; n < 10 ; n++) {
-            assert_false(roaring_bitmap_get_element_of_rank(r, true_card+n, &element));
+            assert_false(roaring_bitmap_select(r, true_card+n, &element));
         }
 
         roaring_bitmap_free(r);
@@ -1603,7 +1603,7 @@ int main() {
         cmocka_unit_test(test_inplace_negation_run1),
         cmocka_unit_test(test_inplace_negation_run2),
         cmocka_unit_test(test_inplace_rand_flips),
-        cmocka_unit_test(get_element_of_rank_tests),
+        cmocka_unit_test(select_test),
         // cmocka_unit_test(test_run_to_bitset),
         // cmocka_unit_test(test_run_to_array),
     };


### PR DESCRIPTION
The goal here is to add this function:

```c
bool roaring_bitmap_get_element_of_rank(roaring_bitmap_t *ra, uint32_t rank, uint32_t *element);
```

It retrieves an element of given rank in the roaring bitmap.
To do so, we simply iterate on all the containers until we find the desired rank (or we reach the end if the rank is greater than the bitmap's size).


Some factorization of the code could be made, particularly in the tests. For instance, we could have a function returning a randomly generated bitmap. We could also factorize the code for some container tests into a generic file (e.g. `container_unit.c`).
But I think this should be the object of an other pull request.

Future work regarding rank queries can be:
* Implement rank range queries (e.g. to get a new bitmap containing all the elements between the 10th element and the 27th).
* Implement rank queries in the other way (we have an element and we want to know its rank).