### PR TITLE
Fix flip_inplace by removing a double free.

### DIFF
--- a/src/roaring.c
+++ b/src/roaring.c
@@ -966,7 +966,7 @@ static void inplace_flip_container(roaring_array_t *x1_arr, uint16_t hb,
             ra_set_container_at_index(x1_arr, i, flipped_container, ctype_out);
         } else {
             container_free(flipped_container, ctype_out);
-            ra_remove_at_index_and_free(x1_arr, i);
+            ra_remove_at_index(x1_arr, i);
         }
 
     } else {
@@ -1016,7 +1016,7 @@ static void inplace_fully_flip_container(roaring_array_t *x1_arr, uint16_t hb) {
             ra_set_container_at_index(x1_arr, i, flipped_container, ctype_out);
         } else {
             container_free(flipped_container, ctype_out);
-            ra_remove_at_index_and_free(x1_arr, i);
+            ra_remove_at_index(x1_arr, i);
         }
 
     } else {

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -1923,6 +1923,36 @@ void test_inplace_rand_flips() {
     free(input);
 }
 
+void test_flip_array_container_removeal() {
+    roaring_bitmap_t *bm = roaring_bitmap_create();
+    for(unsigned val=0; val<100; val++) {
+        roaring_bitmap_add(bm, val);
+    }
+    roaring_bitmap_flip_inplace(bm, 0, 100);
+    roaring_bitmap_free(bm);
+}
+
+void test_flip_bitset_container_removeal() {
+    roaring_bitmap_t *bm = roaring_bitmap_create();
+    for(unsigned val=0; val<10000; val++) {
+        roaring_bitmap_add(bm, val);
+    }
+    roaring_bitmap_flip_inplace(bm, 0, 10000);
+    roaring_bitmap_free(bm);
+}
+
+void test_flip_run_container_removeal() {
+    roaring_bitmap_t *bm = roaring_bitmap_from_range(0, 10000, 1);
+    roaring_bitmap_flip_inplace(bm, 0, 10000);
+    roaring_bitmap_free(bm);
+}
+
+void test_flip_run_container_removeal2(){
+    roaring_bitmap_t *bm = roaring_bitmap_from_range(0, 66002, 1);
+    roaring_bitmap_flip_inplace(bm, 0, 987653576);
+    roaring_bitmap_free(bm);
+}
+
 // randomized test for rank query
 void select_test() {
     srand(1234);
@@ -1983,6 +2013,7 @@ void select_test() {
     free(input);
 }
 
+
 int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_stats), cmocka_unit_test(test_addremove),
@@ -2038,6 +2069,10 @@ int main() {
         cmocka_unit_test(test_inplace_negation_run1),
         cmocka_unit_test(test_inplace_negation_run2),
         cmocka_unit_test(test_inplace_rand_flips),
+        cmocka_unit_test(test_flip_array_container_removeal),
+        cmocka_unit_test(test_flip_bitset_container_removeal),
+        cmocka_unit_test(test_flip_run_container_removeal),
+        cmocka_unit_test(test_flip_run_container_removeal2),
         cmocka_unit_test(select_test),
         // cmocka_unit_test(test_run_to_bitset),
         // cmocka_unit_test(test_run_to_array),


### PR DESCRIPTION
The method `roaring_bitmap_flip_inplace` was causing a segmenntation fault when
a container of the bitmap had to be removed. It was due to a double free.

This PR fixes this by replacing two calls to `ra_remove_at_index_and_free` by calls
to `ra_remove_at_index`, in file `roaring.c`.
According to the tests, it does not introduce any memory leak, but we should check
carefully.