### PR TITLE
Included malloc.h in portability.h

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -7,6 +7,7 @@
 #define INCLUDE_PORTABILITY_H_
 
 #include <stdint.h>
+#include <malloc.h>
 
 #if __SIZEOF_LONG_LONG__ != 8
 #error This code assumes  64-bit long longs (by use of the GCC intrinsics). Your system is not currently supported.


### PR DESCRIPTION
Needed by Microsoft CodeGen for `_aligned_malloc` as per #46