### PR TITLE
Implement is_subset function, close #55

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -28,6 +28,7 @@ $SCRIPTPATH/include/roaring/containers/bitset.h
 $SCRIPTPATH/include/roaring/containers/run.h
 $SCRIPTPATH/include/roaring/containers/convert.h
 $SCRIPTPATH/include/roaring/containers/mixed_equal.h
+$SCRIPTPATH/include/roaring/containers/mixed_subset.h
 $SCRIPTPATH/include/roaring/containers/mixed_andnot.h
 $SCRIPTPATH/include/roaring/containers/mixed_intersection.h
 $SCRIPTPATH/include/roaring/containers/mixed_negation.h

--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -205,6 +205,12 @@ bool array_container_equals(array_container_t *container1,
                             array_container_t *container2);
 
 /**
+ * Return true if container1 is a subset of container2.
+ */
+bool array_container_is_subset(array_container_t *container1,
+                            array_container_t *container2);
+
+/**
  * If the element of given rank is in this container, supposing that the first
  * element has rank start_rank, then the function returns true and sets element
  * accordingly.

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -387,6 +387,12 @@ bool bitset_container_equals(bitset_container_t *container1,
                              bitset_container_t *container2);
 
 /**
+* Return true if container1 is a subset of container2.
+*/
+bool bitset_container_is_subset(bitset_container_t *container1,
+                          bitset_container_t *container2);
+
+/**
  * If the element of given rank is in this container, supposing that the first
  * element has rank start_rank, then the function returns true and sets element
  * accordingly.

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -9,6 +9,7 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/convert.h>
 #include <roaring/containers/mixed_equal.h>
+#include <roaring/containers/mixed_subset.h>
 #include <roaring/containers/mixed_intersection.h>
 #include <roaring/containers/mixed_negation.h>
 #include <roaring/containers/mixed_union.h>
@@ -533,6 +534,54 @@ static inline bool container_equals(const void *c1, uint8_t type1,
                                           (array_container_t *)c2);
         case CONTAINER_PAIR(RUN_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE):
             return run_container_equals((run_container_t *)c1,
+                                        (run_container_t *)c2);
+        default:
+            assert(false);
+            __builtin_unreachable();
+            return false;
+    }
+}
+
+/**
+ * Returns true if the container c1 is a subset of the container c2. Note that
+ * c1 can be a subset of c2 even if they have a different type.
+ */
+static inline bool container_is_subset(const void *c1, uint8_t type1,
+                                    const void *c2, uint8_t type2) {
+    c1 = container_unwrap_shared(c1, &type1);
+    c2 = container_unwrap_shared(c2, &type2);
+    switch (CONTAINER_PAIR(type1, type2)) {
+        case CONTAINER_PAIR(BITSET_CONTAINER_TYPE_CODE,
+                            BITSET_CONTAINER_TYPE_CODE):
+            return bitset_container_is_subset((bitset_container_t *)c1,
+                                           (bitset_container_t *)c2);
+        case CONTAINER_PAIR(BITSET_CONTAINER_TYPE_CODE,
+                            RUN_CONTAINER_TYPE_CODE):
+            return bitset_container_is_subset_run((bitset_container_t *)c1,
+                                            (run_container_t *)c2);
+        case CONTAINER_PAIR(RUN_CONTAINER_TYPE_CODE,
+                            BITSET_CONTAINER_TYPE_CODE):
+            return run_container_is_subset_bitset((run_container_t *)c1,
+                                               (bitset_container_t *)c2);
+        case CONTAINER_PAIR(BITSET_CONTAINER_TYPE_CODE,
+                            ARRAY_CONTAINER_TYPE_CODE):
+            return false; // by construction, size(c1) > size(c2)
+        case CONTAINER_PAIR(ARRAY_CONTAINER_TYPE_CODE,
+                            BITSET_CONTAINER_TYPE_CODE):
+            return array_container_is_subset_bitset((array_container_t *)c1,
+                                                (bitset_container_t *)c2);
+        case CONTAINER_PAIR(ARRAY_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE):
+            return array_container_is_subset_run((array_container_t *)c1,
+                                              (run_container_t *)c2);
+        case CONTAINER_PAIR(RUN_CONTAINER_TYPE_CODE, ARRAY_CONTAINER_TYPE_CODE):
+            return run_container_is_subset_array((run_container_t *)c1,
+                                              (array_container_t *)c2);
+        case CONTAINER_PAIR(ARRAY_CONTAINER_TYPE_CODE,
+                            ARRAY_CONTAINER_TYPE_CODE):
+            return array_container_is_subset((array_container_t *)c1,
+                                          (array_container_t *)c2);
+        case CONTAINER_PAIR(RUN_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE):
+            return run_container_is_subset((run_container_t *)c1,
                                         (run_container_t *)c2);
         default:
             assert(false);

--- a/include/roaring/containers/mixed_subset.h
+++ b/include/roaring/containers/mixed_subset.h
@@ -1,0 +1,43 @@
+/*
+ * mixed_subset.h
+ *
+ */
+
+#ifndef CONTAINERS_MIXED_SUBSET_H_
+#define CONTAINERS_MIXED_SUBSET_H_
+
+#include <roaring/containers/array.h>
+#include <roaring/containers/bitset.h>
+#include <roaring/containers/run.h>
+
+/**
+ * Return true if container1 is a subset of container2.
+ */
+bool array_container_is_subset_bitset(array_container_t* container1,
+                                  bitset_container_t* container2);
+
+/**
+* Return true if container1 is a subset of container2.
+ */
+bool run_container_is_subset_array(run_container_t* container1,
+                                array_container_t* container2);
+
+/**
+* Return true if container1 is a subset of container2.
+ */
+bool array_container_is_subset_run(array_container_t* container1,
+                                run_container_t* container2);
+
+/**
+* Return true if container1 is a subset of container2.
+ */
+bool run_container_is_subset_bitset(run_container_t* container1,
+                                 bitset_container_t* container2);
+
+/**
+* Return true if container1 is a subset of container2.
+*/
+bool bitset_container_is_subset_run(bitset_container_t* container1,
+                              run_container_t* container2);
+
+#endif /* CONTAINERS_MIXED_SUBSET_H_ */

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -363,6 +363,12 @@ bool run_container_equals(run_container_t *container1,
                           run_container_t *container2);
 
 /**
+* Return true if container1 is a subset of container2.
+*/
+bool run_container_is_subset(run_container_t *container1,
+                        run_container_t *container2);
+
+/**
  * Used in a start-finish scan that appends segments, for XOR and NOT
  */
 

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -311,6 +311,11 @@ bool roaring_iterate(const roaring_bitmap_t *ra, roaring_iterator iterator,
 bool roaring_bitmap_equals(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2);
 
 /**
+ * Return true if all the elements of ra1 are also in ra2.
+ */
+bool roaring_bitmap_is_subset(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2);
+
+/**
  * (For expert users who seek high performance.)
  *
  * Computes the union between two bitmaps and returns new bitmap. The caller is

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -316,6 +316,15 @@ bool roaring_bitmap_equals(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2);
 bool roaring_bitmap_is_subset(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2);
 
 /**
+ * Return true if all the elements of ra1 are also in ra2 and ra3 is strictly greater
+ * than ra2.
+ */
+inline bool roaring_bitmap_is_strict_subset(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2) {
+    return (roaring_bitmap_get_cardinality(ra2) > roaring_bitmap_get_cardinality(ra1)
+    && roaring_bitmap_is_subset(ra1, ra2));
+}
+
+/**
  * (For expert users who seek high performance.)
  *
  * Computes the union between two bitmaps and returns new bitmap. The caller is

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -316,8 +316,8 @@ bool roaring_bitmap_equals(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2);
 bool roaring_bitmap_is_subset(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2);
 
 /**
- * Return true if all the elements of ra1 are also in ra2 and ra3 is strictly greater
- * than ra2.
+ * Return true if all the elements of ra1 are also in ra2 and ra2 is strictly greater
+ * than ra1.
  */
 inline bool roaring_bitmap_is_strict_subset(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2) {
     return (roaring_bitmap_get_cardinality(ra2) > roaring_bitmap_get_cardinality(ra1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(ROARING_SRC
     containers/mixed_intersection.c
     containers/mixed_union.c
     containers/mixed_equal.c
+    containers/mixed_subset.c
     containers/mixed_negation.c
     containers/mixed_xor.c
     containers/mixed_andnot.c
@@ -29,5 +30,5 @@ set(ROARING_SRC
 
 add_library(${ROARING_LIB_NAME} ${ROARING_LIB_TYPE} ${ROARING_SRC})
 install(TARGETS ${ROARING_LIB_NAME} DESTINATION lib)
-set_target_properties(${ROARING_LIB_NAME} PROPERTIES 
+set_target_properties(${ROARING_LIB_NAME} PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "..")

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -411,6 +411,32 @@ bool array_container_equals(array_container_t *container1,
     return true;
 }
 
+bool array_container_is_subset(array_container_t *container1,
+                            array_container_t *container2) {
+    if (container1->cardinality > container2->cardinality) {
+        return false;
+    }
+    int i1 = 0, i2 = 0;
+    while(i1 < container1->cardinality && i2 < container2->cardinality) {
+        if(container1->array[i1] == container2->array[i2]) {
+            i1++;
+            i2++;
+        }
+        else if(container1->array[i1] > container2->array[i2]) {
+            i2++;
+        }
+        else { // container1->array[i1] < container2->array[i2]
+            return false;
+        }
+    }
+    if(i1 == container1->cardinality) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
 int32_t array_container_read(int32_t cardinality, array_container_t *container,
                              const char *buf) {
     if (container->capacity < cardinality) {

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -484,6 +484,21 @@ bool bitset_container_equals(bitset_container_t *container1, bitset_container_t 
 	return true;
 }
 
+bool bitset_container_is_subset(bitset_container_t *container1,
+                          bitset_container_t *container2) {
+    if((container1->cardinality != BITSET_UNKNOWN_CARDINALITY) && (container2->cardinality != BITSET_UNKNOWN_CARDINALITY)) {
+        if(container1->cardinality > container2->cardinality) {
+            return false;
+        }
+    }
+    for(int32_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i ) {
+		if((container1->array[i] & container2->array[i]) != container1->array[i]) {
+			return false;
+		}
+	}
+	return true;
+}
+
 bool bitset_container_select(const bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
     int card = bitset_container_cardinality(container);
     if(rank >= *start_rank + card) {

--- a/src/containers/mixed_subset.c
+++ b/src/containers/mixed_subset.c
@@ -1,0 +1,133 @@
+#include <roaring/containers/mixed_subset.h>
+#include <roaring/array_util.h>
+
+bool array_container_is_subset_bitset(array_container_t* container1,
+                                  bitset_container_t* container2) {
+    if (container2->cardinality != BITSET_UNKNOWN_CARDINALITY) {
+        if (container2->cardinality < container1->cardinality) {
+            return false;
+        }
+    }
+    for (int i = 0; i < container1->cardinality; ++i) {
+        if(!bitset_container_contains(container2, container1->array[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool run_container_is_subset_array(run_container_t* container1,
+                                array_container_t* container2) {
+    if (run_container_cardinality(container1) > container2->cardinality)
+        return false;
+    int32_t start_pos = -1, stop_pos = -1;
+    for (int i = 0; i < container1->n_runs; ++i) {
+        int32_t start = container1->runs[i].value;
+        int32_t stop = start+container1->runs[i].length;
+        start_pos = advanceUntil(container2->array, stop_pos, container2->cardinality, start);
+        stop_pos = advanceUntil(container2->array, start_pos, container2->cardinality, stop);
+        if(stop_pos == container2->cardinality || start_pos == container2->cardinality) {
+            return false;
+        }
+        else if(stop_pos-start_pos != stop-start ||
+            container2->array[start_pos] != start || container2->array[stop_pos] != stop) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool array_container_is_subset_run(array_container_t* container1,
+                                run_container_t* container2) {
+    if (container1->cardinality > run_container_cardinality(container2))
+        return false;
+    int i_array = 0, i_run = 0;
+    run_container_printf(container2); printf("\n");
+    while(i_array < container1->cardinality && i_run < container2->n_runs) {
+        uint32_t start = container2->runs[i_run].value;
+        uint32_t stop = start+container2->runs[i_run].length;
+        if(container1->array[i_array] < start) {
+            return false;
+        }
+        else if (container1->array[i_array] > stop) {
+            i_run ++;
+        }
+        else { // the value of the array is in the run
+            i_array++;
+        }
+    }
+    if(i_array == container1->cardinality) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+bool run_container_is_subset_bitset(run_container_t* container1,
+                                 bitset_container_t* container2) {
+    // todo: this code could be much faster
+    if (container2->cardinality != BITSET_UNKNOWN_CARDINALITY) {
+        if (container2->cardinality < run_container_cardinality(container1)) {
+            return false;
+        }
+    } else {
+        int32_t card = bitset_container_compute_cardinality(
+            container2);  // modify container2?
+        if (card < run_container_cardinality(container1)) {
+            return false;
+        }
+    }
+    for (int i = 0; i < container1->n_runs; ++i) {
+        uint32_t run_start = container1->runs[i].value;
+        uint32_t le = container1->runs[i].length;
+        for (uint32_t j = run_start; j <= run_start + le; ++j) {
+            if (!bitset_container_contains(container2, j)) {
+                return false;
+            }
+        }
+    }
+    return true;
+ }
+
+bool bitset_container_is_subset_run(bitset_container_t* container1,
+                              run_container_t* container2) {
+    // todo: this code could be much faster
+    if (container1->cardinality != BITSET_UNKNOWN_CARDINALITY) {
+        if (container1->cardinality > run_container_cardinality(container2)) {
+            return false;
+        }
+    }
+    int32_t i_bitset=0, i_run=0;
+    while(i_bitset < BITSET_CONTAINER_SIZE_IN_WORDS && i_run < container2->n_runs) {
+        uint64_t w = container1->array[i_bitset];
+        while (w != 0 && i_run < container2->n_runs) {
+            uint32_t start = container2->runs[i_run].value;
+            uint32_t stop = start+container2->runs[i_run].length;
+            uint64_t t = w & -w;
+            uint16_t r = i_bitset * 64 + __builtin_ctzll(w);
+            if (r < start) {
+                return false;
+            }
+            else if(r > stop) {
+                i_run++;
+                continue;
+            }
+            else {
+                w ^= t;
+            }
+        }
+        if(w == 0) {
+            i_bitset++;
+        }
+        else {
+            return false;
+        }
+    }
+    if(i_bitset < BITSET_CONTAINER_SIZE_IN_WORDS) {
+        return false;
+    }
+    else {
+        return true;
+    }
+}

--- a/src/containers/mixed_subset.c
+++ b/src/containers/mixed_subset.c
@@ -25,8 +25,8 @@ bool run_container_is_subset_array(run_container_t* container1,
         int32_t start = container1->runs[i].value;
         int32_t stop = start+container1->runs[i].length;
         start_pos = advanceUntil(container2->array, stop_pos, container2->cardinality, start);
-        stop_pos = advanceUntil(container2->array, start_pos, container2->cardinality, stop);
-        if(stop_pos == container2->cardinality || start_pos == container2->cardinality) {
+        stop_pos = advanceUntil(container2->array, stop_pos, container2->cardinality, stop);
+        if(start_pos == container2->cardinality) {
             return false;
         }
         else if(stop_pos-start_pos != stop-start ||
@@ -124,9 +124,12 @@ bool bitset_container_is_subset_run(bitset_container_t* container1,
         }
     }
     if(i_bitset < BITSET_CONTAINER_SIZE_IN_WORDS) {
-        return false;
+        // terminated iterating on the run containers, check that rest of bitset is empty
+        for(; i_bitset < BITSET_CONTAINER_SIZE_IN_WORDS ; i_bitset++) {
+            if(container1->array[i_bitset] != 0) {
+                return false;
+            }
+        }
     }
-    else {
-        return true;
-    }
+    return true;
 }

--- a/src/containers/mixed_subset.c
+++ b/src/containers/mixed_subset.c
@@ -42,7 +42,6 @@ bool array_container_is_subset_run(array_container_t* container1,
     if (container1->cardinality > run_container_cardinality(container2))
         return false;
     int i_array = 0, i_run = 0;
-    run_container_printf(container2); printf("\n");
     while(i_array < container1->cardinality && i_run < container2->n_runs) {
         uint32_t start = container2->runs[i_run].value;
         uint32_t stop = start+container2->runs[i_run].length;

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -636,6 +636,47 @@ bool run_container_equals(run_container_t *container1,
     return true;
 }
 
+bool run_container_is_subset(run_container_t *container1,
+                        run_container_t *container2){
+    int i1 = 0, i2 = 0;
+    while(i1 < container1->n_runs && i2 < container2->n_runs) {
+        int start1 = container1->runs[i1].value;
+        int stop1 = start1 + container1->runs[i1].length;
+        int start2 = container2->runs[i2].value;
+        int stop2 = start2 + container2->runs[i2].length;
+        if(start1 < start2) {
+            return false;
+        }
+        else { // start1 >= start2
+            if(stop1 < stop2) {
+                i1++;
+            }
+            else if(stop1 == stop2) {
+                i1++;
+                i2++;
+            }
+            else { // stop1 > stop2
+                i2++;
+            }
+        }
+    }
+    if(i1 == container1->n_runs) {
+        return true;
+    }
+    else {
+        return false;
+    }
+
+
+
+    for (int32_t i = 0; i < container1->n_runs; ++i) {
+        if ((container1->runs[i].value != container2->runs[i].value) ||
+            (container1->runs[i].length != container2->runs[i].length))
+            return false;
+    }
+    return true;
+}
+
 // TODO: write smart_append_exclusive version to match the overloaded 1 param
 // Java version (or  is it even used?)
 

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -8,6 +8,7 @@
 #include <roaring/roaring_array.h>
 
 extern inline bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val);
+extern inline bool roaring_bitmap_is_strict_subset(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2);
 
 
 // this is like roaring_bitmap_add, but it populates pointer arguments in such a way

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,5 +13,6 @@ add_c_test(toplevel_unit)
 add_c_test(realdata_unit)
 add_c_test(util_unit)
 add_c_test(format_portability_unit)
+add_c_test(container_comparison_unit)
 
 add_subdirectory(vendor/cmocka)

--- a/tests/container_comparison_unit.c
+++ b/tests/container_comparison_unit.c
@@ -1,0 +1,182 @@
+/*
+ * container_comparison_unit.c
+ *
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <roaring/containers/containers.h>
+#include <roaring/containers/array.h>
+#include <roaring/containers/bitset.h>
+#include <roaring/containers/run.h>
+#include <roaring/containers/mixed_equal.h>
+#include <roaring/containers/mixed_subset.h>
+
+#include "test.h"
+
+static inline void container_checked_add(void *container, uint16_t val,
+                                  uint8_t typecode) {
+    uint8_t new_type;
+    void *new_container = container_add(container, val, typecode, &new_type);
+    assert_int_equal(typecode, new_type);
+    assert_true(container == new_container);
+}
+
+static inline void *container_create(uint8_t typecode) {
+    void *result = NULL;
+    switch (typecode) {
+        case BITSET_CONTAINER_TYPE_CODE:
+            result = bitset_container_create();
+            break;
+        case ARRAY_CONTAINER_TYPE_CODE:
+            result = array_container_create();
+            break;
+        case RUN_CONTAINER_TYPE_CODE:
+            result = run_container_create();
+            break;
+        default:
+            assert(false);
+            __builtin_unreachable();
+    }
+    assert_non_null(result);
+    return result;
+}
+
+void generic_equal_test(uint8_t type1, uint8_t type2) {
+    void *container1 = container_create(type1);
+    void *container2 = container_create(type2);
+    assert_true(container_equals(container1, type1, container2, type2));
+    for(int i = 0 ; i < 100 ; i++) {
+        container_checked_add(container1, i*10, type1);
+        container_checked_add(container2, i*10, type2);
+        assert_true(container_equals(container1, type1, container2, type2));
+    }
+    container_checked_add(container1, 273, type1);
+    assert_false(container_equals(container1, type1, container2, type2));
+    container_checked_add(container2, 854, type2);
+    assert_false(container_equals(container1, type1, container2, type2));
+    container_checked_add(container1, 854, type1);
+    assert_false(container_equals(container1, type1, container2, type2));
+    container_checked_add(container2, 273, type2);
+    assert_true(container_equals(container1, type1, container2, type2));
+    container_free(container1, type1);
+    container_free(container2, type2);
+}
+
+void equal_array_array_test() {
+    generic_equal_test(ARRAY_CONTAINER_TYPE_CODE, ARRAY_CONTAINER_TYPE_CODE);
+}
+
+void equal_bitset_bitset_test() {
+    generic_equal_test(BITSET_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+}
+
+void equal_run_run_test() {
+    generic_equal_test(RUN_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+}
+
+void equal_array_bitset_test() {
+    generic_equal_test(ARRAY_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+}
+
+void equal_bitset_array_test() {
+    generic_equal_test(BITSET_CONTAINER_TYPE_CODE, ARRAY_CONTAINER_TYPE_CODE);
+}
+
+void equal_array_run_test() {
+    generic_equal_test(ARRAY_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+}
+
+void equal_run_array_test() {
+    generic_equal_test(RUN_CONTAINER_TYPE_CODE, ARRAY_CONTAINER_TYPE_CODE);
+}
+
+void equal_bitset_run_test() {
+    generic_equal_test(BITSET_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+}
+
+void equal_run_bitset_test() {
+    generic_equal_test(RUN_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+}
+
+void generic_subset_test(uint8_t type1, uint8_t type2) {
+    void *container1 = container_create(type1);
+    void *container2 = container_create(type2);
+    assert_true(container_is_subset(container1, type1, container2, type2));
+    for(int i = 0 ; i < 100 ; i++) {
+        container_checked_add(container1, i*11, type1);
+        container_checked_add(container2, i*11, type2);
+        assert_true(container_is_subset(container1, type1, container2, type2));
+    }
+    for(int i = 0 ; i < 100 ; i++) {
+        container_checked_add(container2, i*7, type2);
+        assert_true(container_is_subset(container1, type1, container2, type2));
+    }
+    for(int i = 0 ; i < 100 ; i++) {
+        if(i%7==0 || i%11==0) continue;
+        container_checked_add(container1, i*5, type1);
+        assert_false(container_is_subset(container1, type1, container2, type2));
+        container_checked_add(container2, i*5, type2);
+        assert_true(container_is_subset(container1, type1, container2, type2));
+    }
+    container_free(container1, type1);
+    container_free(container2, type2);
+}
+
+void subset_array_array_test() {
+    generic_subset_test(ARRAY_CONTAINER_TYPE_CODE, ARRAY_CONTAINER_TYPE_CODE);
+}
+
+void subset_bitset_bitset_test() {
+    generic_subset_test(BITSET_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+}
+
+void subset_run_run_test() {
+    generic_subset_test(RUN_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+}
+
+void subset_array_bitset_test() {
+    generic_subset_test(ARRAY_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+}
+
+void subset_array_run_test() {
+    generic_subset_test(ARRAY_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+}
+
+void subset_run_array_test() {
+    generic_subset_test(RUN_CONTAINER_TYPE_CODE, ARRAY_CONTAINER_TYPE_CODE);
+}
+
+void subset_bitset_run_test() {
+    generic_subset_test(BITSET_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+}
+
+void subset_run_bitset_test() {
+    generic_subset_test(RUN_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+}
+
+int main() {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(equal_array_array_test),
+        cmocka_unit_test(equal_bitset_bitset_test),
+        cmocka_unit_test(equal_run_run_test),
+        cmocka_unit_test(equal_array_bitset_test),
+        cmocka_unit_test(equal_bitset_array_test),
+        cmocka_unit_test(equal_array_run_test),
+        cmocka_unit_test(equal_run_array_test),
+        cmocka_unit_test(equal_bitset_run_test),
+        cmocka_unit_test(equal_run_bitset_test),
+        cmocka_unit_test(subset_array_array_test),
+        cmocka_unit_test(subset_bitset_bitset_test),
+        cmocka_unit_test(subset_run_run_test),
+        cmocka_unit_test(subset_array_bitset_test),
+        cmocka_unit_test(subset_array_run_test),
+        cmocka_unit_test(subset_run_array_test),
+        cmocka_unit_test(subset_bitset_run_test),
+        cmocka_unit_test(subset_run_bitset_test),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
The main contribution of this pull request is the addition of the two functions: 

```c
/**
 * Return true if all the elements of ra1 are also in ra2.
 */
bool roaring_bitmap_is_subset(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2);

/**
 * Return true if all the elements of ra1 are also in ra2 and ra2 is strictly greater
 * than ra1.
 */
bool roaring_bitmap_is_strict_subset(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2);
```

They are implemented following the same spirit than `roaring_bitmap_equals`:

* The function `roaring_bitmap_is_subset` iterates on the containers of the two bitmaps. When two containers have a same key, they are compared.
* The comparison of these two containers is done in the generic function `container_is_subset`. It calls the right function according to the type of the two containers.
* Functions to compare containers are implemented as `bitset_container_is_subset`, `bitset_container_is_subset_run`, `run_container_is_subset_bitset`, `array_container_is_subset_bitset`, `array_container_is_subset_run`, `run_container_is_subset_array`, `array_container_is_subset` and `run_container_is_subset`.


Unit tests for these functions are in file `container_comparison_unit.c`. I also added the unit tests for `container_equals` since they were missing and they follow the same structure.

There is also a test in `toplevel_unit.c`.

----

**Future work**

We can still do optimization, for instance on functions `bitset_container_is_subset_run` and `run_container_is_subset_bitset`. The same kind of optimization can also be done on function `run_container_equals_bitset` which existed prior to this pull request.