### PR TITLE
Made changes allowing headers to be included in multiple compilation units

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -72,7 +72,6 @@ echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${AMAL_H}"
 echo "Creating ${AMAL_C}..."
 echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${AMAL_C}"
 {
-    echo "#line 1 \"${AMAL_C}\""
     echo "#include \"${AMAL_H}\""
 
     for h in ${ALLCFILES}; do
@@ -108,7 +107,6 @@ ALLCPPHEADERS="$SCRIPTPATH/cpp/roaring.hh"
 echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${AMAL_HH}"
 {
     echo "#include \"${AMAL_H}\""
-    echo "#include \"${AMAL_C}\""
 
     for h in ${ALLCPPHEADERS}; do
         dofile $h
@@ -122,6 +120,7 @@ echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${DEMOCPP}"
 cat <<< '
 #include <iostream>
 #include "roaring.hh"
+#include "roaring.c"
 int main() {
   Roaring r1;
   for (uint32_t i = 100; i < 1000; i++) {

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -506,11 +506,11 @@ public:
 };
 
 
-RoaringSetBitForwardIterator Roaring::begin() const {
+inline RoaringSetBitForwardIterator Roaring::begin() const {
       return RoaringSetBitForwardIterator(*this);
 }
 
-RoaringSetBitForwardIterator Roaring::end() const {
+inline RoaringSetBitForwardIterator Roaring::end() const {
       return RoaringSetBitForwardIterator(*this, true);
 }
 

--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -244,7 +244,7 @@ void array_container_andnot(const array_container_t *array_1,
 
 /* Append x to the set. Assumes that the value is larger than any preceding
  * values.  */
-static void array_container_append(array_container_t *arr, uint16_t pos) {
+static inline void array_container_append(array_container_t *arr, uint16_t pos) {
     const int32_t capacity = arr->capacity;
 
     if (array_container_full(arr)) {

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -74,7 +74,7 @@ void *run_container_deserialize(const char *buf, size_t buf_len);
 /*
  * Effectively deletes the value at index index, repacking data.
  */
-static void recoverRoomAtIndex(run_container_t *run, uint16_t index) {
+static inline void recoverRoomAtIndex(run_container_t *run, uint16_t index) {
     memmove(run->runs + index, run->runs + (1 + index),
             (run->n_runs - index - 1) * sizeof(rle16_t));
     run->n_runs--;


### PR DESCRIPTION
Including the C++ amalgamation in multiple compilation units causes some linker errors due to a few missing "inline"s.