### PR TITLE
Embedded C object inside C++ object

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ of the latest hardware. Roaring bitmaps are already available on a variety of pl
 - The library should build on a  Linux-like operating system (including MacOS).
 - We also support Microsoft Visual studio.
 - Though most reasonable processors should be supported, we expect a recent Intel processor: Haswell (2013) or better but support all x64/x86 processors. The library builds without problem on ARM processors.
-- Recent C compiler supporting the C11 standard (GCC 4.8 or better or clang), there is also an optional C++ class that requires a C++ compiler
-- CMake (to contribute to the project, users can rely on amalgamation/unity builds)
-- clang-format (optional)
+- Recent C compiler supporting the C11 standard (GCC 4.8 or better or clang), there is also an optional C++ class that requires a C++ compiler supporting the C++11 standard.
+- CMake (to contribute to the project, users can rely on amalgamation/unity builds).
+- clang-format (optional).
 
 Serialization on big endian hardware may not be compatible with serialization on little endian hardware.
 

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -168,7 +168,6 @@ void roaring_bitmap_andnot_inplace(roaring_bitmap_t *x1,
  */
 void roaring_bitmap_free(roaring_bitmap_t *r);
 
-
 /**
  * Add value n_args from pointer vals, faster than repeatedly calling roaring_bitmap_add
  *

--- a/include/roaring/roaring_array.h
+++ b/include/roaring/roaring_array.h
@@ -1,5 +1,8 @@
 #ifndef INCLUDE_ROARING_ARRAY_H
 #define INCLUDE_ROARING_ARRAY_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <assert.h>
 #include <stdbool.h>
@@ -270,5 +273,9 @@ void ra_remove_at_index_and_free(roaring_array_t *ra, int32_t i);
 //
 void ra_copy_range(roaring_array_t *ra, uint32_t begin, uint32_t end,
                    uint32_t new_begin);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -117,6 +117,7 @@ roaring_bitmap_t *roaring_bitmap_of_ptr(size_t n_args, const uint32_t *vals) {
     return answer;
 }
 
+
 roaring_bitmap_t *roaring_bitmap_of(size_t n_args, ...) {
     // todo: could be greatly optimized but we do not expect this call to ever include long lists
     roaring_bitmap_t *answer = roaring_bitmap_create();


### PR DESCRIPTION
changed the pointer to a CRoaring object inside of the C++ class into the object itself,
avoiding a malloc and free in the constructor/destructor,
this makes little difference to the 32-bit C++ class but speeds up adds to the 64-bit class by a few percent,
also did a few minor things

Bug fix:
    C++ iterators now stop at max uint32_t instead of comparing equal to the end iterator at this point
Performance:
   removed virtual keyword for C++ iterator class's destructor since it will cause most compilers
   to generate a vtable for each object, bloating it up
   (the lack of the keyword is safe in this case unless a user subclasses the iterator
   and that subclass is deleted through a pointer with the type of the base class)
Feature:
    added a toString member function to the C++ classes which makes STL strings