### PR TITLE
made Visual Studio's warnings quieter the hard way

### DIFF
--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -248,7 +248,7 @@ class Roaring64Map{
             throw std::length_error("bitmap is full, cardinality is 2^64, "
                                     "unable to represent in a 64-bit integer");
         }
-        return std::accumulate(roarings.cbegin(), roarings.cend(), 0,
+        return std::accumulate(roarings.cbegin(), roarings.cend(), (uint64_t)0,
             [](uint64_t previous, const std::pair<uint32_t, Roaring>& map_entry) {
                 return previous + map_entry.second.cardinality();
             });
@@ -461,7 +461,7 @@ class Roaring64Map{
             if (rank < sub_cardinality) {
                 *element = ((uint64_t)map_entry.first) << 32;
                 // assuming little endian
-                return map_entry.second.select(rank, ((uint32_t*)element));
+                return map_entry.second.select((uint32_t)rank, ((uint32_t*)element));
             }
             rank -= sub_cardinality;
         }
@@ -501,8 +501,8 @@ class Roaring64Map{
     size_t write(char *buf, bool portable = true) const {
         const char* orig = buf;
         // push map size
-        *((uint32_t*)buf) = roarings.size();
-        buf += sizeof(uint32_t);
+        *((uint64_t*)buf) = roarings.size();
+        buf += sizeof(uint64_t);
         std::for_each(roarings.cbegin(), roarings.cend(),
             [&buf, portable](const std::pair<uint32_t, Roaring>& map_entry) {
                 // push map key
@@ -531,9 +531,9 @@ class Roaring64Map{
     static Roaring64Map read(const char *buf, bool portable = true) {
         Roaring64Map result;
         // get map size
-        uint32_t map_size = *((uint32_t*)buf);
-        buf += sizeof(uint32_t);
-        for (uint32_t lcv = 0; lcv < map_size; lcv++) {
+        uint64_t map_size = *((uint64_t*)buf);
+        buf += sizeof(uint64_t);
+        for (uint64_t lcv = 0; lcv < map_size; lcv++) {
             // get map key
             uint32_t key = *((uint32_t*)buf);
             buf += sizeof(uint32_t);

--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -16,12 +16,12 @@ static inline void bitset_set_range(uint64_t *bitmap, uint32_t start,
     uint32_t endword = (end - 1) / 64;
     if (firstword == endword) {
         bitmap[firstword] |= ((~UINT64_C(0)) << (start % 64)) &
-                             ((~UINT64_C(0)) >> ((-end) % 64));
+                             ((~UINT64_C(0)) >> ((~end + 1) % 64));
         return;
     }
     bitmap[firstword] |= (~UINT64_C(0)) << (start % 64);
     for (uint32_t i = firstword + 1; i < endword; i++) bitmap[i] = ~UINT64_C(0);
-    bitmap[endword] |= (~UINT64_C(0)) >> ((-end) % 64);
+    bitmap[endword] |= (~UINT64_C(0)) >> ((~end + 1) % 64);
 }
 
 /*
@@ -41,7 +41,7 @@ static inline void bitset_set_lenrange(uint64_t *bitmap, uint32_t start,
     for (uint32_t i = firstword + 1; i < endword; i += 2)
         bitmap[i] = bitmap[i + 1] = ~UINT64_C(0);
     bitmap[endword] =
-        temp | (~UINT64_C(0)) >> ((-start - lenminusone - 1) % 64);
+        temp | (~UINT64_C(0)) >> (((~start + 1) - lenminusone - 1) % 64);
 }
 
 /*
@@ -54,7 +54,7 @@ static inline void bitset_flip_range(uint64_t *bitmap, uint32_t start,
     uint32_t endword = (end - 1) / 64;
     bitmap[firstword] ^= ~((~UINT64_C(0)) << (start % 64));
     for (uint32_t i = firstword; i < endword; i++) bitmap[i] = ~bitmap[i];
-    bitmap[endword] ^= ((~UINT64_C(0)) >> ((-end) % 64));
+    bitmap[endword] ^= ((~UINT64_C(0)) >> ((~end + 1) % 64));
 }
 
 /*
@@ -67,12 +67,12 @@ static inline void bitset_reset_range(uint64_t *bitmap, uint32_t start,
     uint32_t endword = (end - 1) / 64;
     if (firstword == endword) {
         bitmap[firstword] &= ~(((~UINT64_C(0)) << (start % 64)) &
-                               ((~UINT64_C(0)) >> ((-end) % 64)));
+                               ((~UINT64_C(0)) >> ((~end + 1) % 64)));
         return;
     }
     bitmap[firstword] &= ~((~UINT64_C(0)) << (start % 64));
     for (uint32_t i = firstword + 1; i < endword; i++) bitmap[i] = UINT64_C(0);
-    bitmap[endword] &= ~((~UINT64_C(0)) >> ((-end) % 64));
+    bitmap[endword] &= ~((~UINT64_C(0)) >> ((~end + 1) % 64));
 }
 
 /*

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -132,7 +132,7 @@ static inline void bitset_container_set(bitset_container_t *bitset,
     const uint64_t old_word = bitset->array[pos >> 6];
     const int index = pos & 63;
     const uint64_t new_word = old_word | (UINT64_C(1) << index);
-    bitset->cardinality += (old_word ^ new_word) >> index;
+    bitset->cardinality += (uint32_t)((old_word ^ new_word) >> index);
     bitset->array[pos >> 6] = new_word;
 }
 
@@ -142,7 +142,7 @@ static inline void bitset_container_unset(bitset_container_t *bitset,
     const uint64_t old_word = bitset->array[pos >> 6];
     const int index = pos & 63;
     const uint64_t new_word = old_word & (~(UINT64_C(1) << index));
-    bitset->cardinality -= (old_word ^ new_word) >> index;
+    bitset->cardinality -= (uint32_t)((old_word ^ new_word) >> index);
     bitset->array[pos >> 6] = new_word;
 }
 
@@ -154,9 +154,9 @@ static inline bool bitset_container_add(bitset_container_t *bitset,
     const int index = pos & 63;
     const uint64_t new_word = old_word | (UINT64_C(1) << index);
     const uint64_t increment = (old_word ^ new_word) >> index;
-    bitset->cardinality += increment;
+    bitset->cardinality += (uint32_t)increment;
     bitset->array[pos >> 6] = new_word;
-    return increment;  // 0 == false, 1 == true
+    return increment > 0;
 }
 
 /* Remove `pos' from `bitset'. Returns true if `pos' was present.  Might be
@@ -167,9 +167,9 @@ static inline bool bitset_container_remove(bitset_container_t *bitset,
     const int index = pos & 63;
     const uint64_t new_word = old_word & (~(UINT64_C(1) << index));
     const uint64_t increment = (old_word ^ new_word) >> index;
-    bitset->cardinality -= increment;
+    bitset->cardinality -= (uint32_t)increment;
     bitset->array[pos >> 6] = new_word;
-    return increment;  // 0 == false, 1 == true
+    return increment > 0;
 }
 
 /* Get the value of the ith bit.  */

--- a/src/array_util.c
+++ b/src/array_util.c
@@ -583,7 +583,7 @@ int32_t intersect_skewed_uint16(const uint16_t *small, size_t size_s,
 
     while (true) {
         if (val_l < val_s) {
-            idx_l = advanceUntil(large, idx_l, size_l, val_s);
+            idx_l = advanceUntil(large, (int32_t)idx_l, (int32_t)size_l, val_s);
             if (idx_l == size_l) break;
             val_l = large[idx_l];
         } else if (val_s < val_l) {
@@ -595,13 +595,13 @@ int32_t intersect_skewed_uint16(const uint16_t *small, size_t size_s,
             idx_s++;
             if (idx_s == size_s) break;
             val_s = small[idx_s];
-            idx_l = advanceUntil(large, idx_l, size_l, val_s);
+            idx_l = advanceUntil(large, (int32_t)idx_l, (int32_t)size_l, val_s);
             if (idx_l == size_l) break;
             val_l = large[idx_l];
         }
     }
 
-    return pos;
+    return (int32_t)pos;
 }
 
 /**
@@ -617,19 +617,19 @@ int32_t intersect_uint16(const uint16_t *A, const size_t lenA,
     while (1) {
         while (*A < *B) {
         SKIP_FIRST_COMPARE:
-            if (++A == endA) return (out - initout);
+            if (++A == endA) return (int32_t)(out - initout);
         }
         while (*A > *B) {
-            if (++B == endB) return (out - initout);
+            if (++B == endB) return (int32_t)(out - initout);
         }
         if (*A == *B) {
             *out++ = *A;
-            if (++A == endA || ++B == endB) return (out - initout);
+            if (++A == endA || ++B == endB) return (int32_t)(out - initout);
         } else {
             goto SKIP_FIRST_COMPARE;
         }
     }
-    return (out - initout);  // NOTREACHED
+    return (int32_t)(out - initout);  // NOTREACHED
 }
 
 /**
@@ -806,11 +806,11 @@ int32_t xor_uint16(const uint16_t *array_1, int32_t card_1,
   if (pos1 < card_1) {
       const size_t n_elems = card_1 - pos1;
       memcpy(out + pos_out, array_1 + pos1, n_elems * sizeof(uint16_t));
-      pos_out += n_elems;
+      pos_out += (int32_t)n_elems;
   } else if (pos2 < card_2) {
       const size_t n_elems = card_2 - pos2;
       memcpy(out + pos_out, array_2 + pos2, n_elems * sizeof(uint16_t));
-      pos_out += n_elems;
+      pos_out += (int32_t)n_elems;
   }
   return pos_out;
 }

--- a/src/bitset_util.c
+++ b/src/bitset_util.c
@@ -589,7 +589,7 @@ size_t bitset_extract_setbits_avx2(uint64_t *array, size_t length,
     for (; (i < length) && (out < safeout); ++i) {
         uint64_t w = array[i];
         while ((w != 0) && (out < safeout)) {
-            uint64_t t = w & -w;
+            uint64_t t = w & (~w + 1);
             int r = __builtin_ctzll(w);
             uint32_t val = r + base;
             memcpy(out, &val, sizeof(uint32_t)); // should be compiled as a MOV on x64
@@ -609,7 +609,7 @@ size_t bitset_extract_setbits(uint64_t *bitset, size_t length, void *vout,
     for (size_t i = 0; i < length; ++i) {
         uint64_t w = bitset[i];
         while (w != 0) {
-            uint64_t t = w & -w;
+            uint64_t t = w & (~w + 1);
             int r = __builtin_ctzll(w);
             uint32_t val = r + base;
             memcpy(out + outpos, &val, sizeof(uint32_t)); // should be compiled as a MOV on x64
@@ -629,7 +629,7 @@ size_t bitset_extract_intersection_setbits_uint16(const uint64_t *bitset1,
     for (size_t i = 0; i < length; ++i) {
         uint64_t w = bitset1[i] & bitset2[i];
         while (w != 0) {
-            uint64_t t = w & -w;
+            uint64_t t = w & (~w + 1);
             int r = __builtin_ctzll(w);
             out[outpos++] = r + base;
             w ^= t;
@@ -719,7 +719,7 @@ size_t bitset_extract_setbits_uint16(const uint64_t *bitset, size_t length,
     for (size_t i = 0; i < length; ++i) {
         uint64_t w = bitset[i];
         while (w != 0) {
-            uint64_t t = w & -w;
+            uint64_t t = w & (~w + 1);
             int r = __builtin_ctzll(w);
             out[outpos++] = r + base;
             w ^= t;

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -164,11 +164,13 @@ void array_container_union(const array_container_t *array_1,
 #else
     // compute union with smallest array first
     if (card_1 < card_2) {
-        out->cardinality = union_uint16(array_1->array, card_1, array_2->array,
-                                        card_2, out->array);
+        out->cardinality = (int32_t)union_uint16(array_1->array, card_1,
+                                                 array_2->array, (size_t)card_2,
+                                                 out->array);
     } else {
-        out->cardinality = union_uint16(array_2->array, card_2, array_1->array,
-                                        card_1, out->array);
+        out->cardinality = (int32_t)union_uint16(array_2->array, card_2,
+                                                 array_1->array, (size_t)card_1,
+                                                 out->array);
     }
 #endif
 }

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -78,13 +78,13 @@ void bitset_container_add_from_range(bitset_container_t *bitset, uint32_t min,
         if (firstword == endword) {
             bitset->array[firstword] |=
                 mask & (((~UINT64_C(0)) << (min % 64)) &
-                        ((~UINT64_C(0)) >> ((-max) % 64)));
+                        ((~UINT64_C(0)) >> ((~max + 1) % 64)));
             return;
         }
         bitset->array[firstword] = mask & ((~UINT64_C(0)) << (min % 64));
         for (uint32_t i = firstword + 1; i < endword; i++)
             bitset->array[i] = mask;
-        bitset->array[endword] = mask & ((~UINT64_C(0)) >> ((-max) % 64));
+        bitset->array[endword] = mask & ((~UINT64_C(0)) >> ((~max + 1) % 64));
     } else {
         for (uint32_t value = min; value < max; value += step) {
             bitset_container_add(bitset, value);
@@ -326,7 +326,7 @@ void bitset_container_printf(const bitset_container_t * v) {
 	for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i) {
 		uint64_t w = v->array[i];
 		while (w != 0) {
-			uint64_t t = w & -w;
+			uint64_t t = w & (~w + 1);
 			int r = __builtin_ctzll(w);
 			if(iamfirst) {// predicted to be false
 				printf("%u",base + r);
@@ -350,7 +350,7 @@ void bitset_container_printf_as_uint32_array(const bitset_container_t * v, uint3
 	for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i) {
 		uint64_t w = v->array[i];
 		while (w != 0) {
-			uint64_t t = w & -w;
+			uint64_t t = w & (~w + 1);
 			int r = __builtin_ctzll(w);
 			if(iamfirst) {// predicted to be false
 				printf("%u", r + base);
@@ -435,7 +435,7 @@ bool bitset_container_iterate(const bitset_container_t *cont, uint32_t base, roa
   for (int32_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i ) {
     uint64_t w = cont->array[i];
     while (w != 0) {
-      uint64_t t = w & -w;
+      uint64_t t = w & (~w + 1);
       int r = __builtin_ctzll(w);
       if(!iterator(r + base, ptr)) return false;
       w ^= t;
@@ -449,7 +449,7 @@ bool bitset_container_iterate64(const bitset_container_t *cont, uint32_t base, r
   for (int32_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i ) {
     uint64_t w = cont->array[i];
     while (w != 0) {
-      uint64_t t = w & -w;
+      uint64_t t = w & (~w + 1);
       int r = __builtin_ctzll(w);
       if(!iterator(high_bits | (uint64_t)(r + base), ptr)) return false;
       w ^= t;
@@ -503,7 +503,7 @@ bool bitset_container_select(const bitset_container_t *container, uint32_t *star
             uint64_t w = container->array[i];
             uint16_t base = i*64;
             while (w != 0) {
-                uint64_t t = w & -w;
+                uint64_t t = w & (~w + 1);
                 int r = __builtin_ctzll(w);
                 if(*start_rank == rank) {
                     *element = r+base;

--- a/src/containers/convert.c
+++ b/src/containers/convert.c
@@ -267,11 +267,11 @@ void *convert_run_optimize(void *c, uint8_t typecode_original,
             uint64_t cur_word_with_1s = cur_word | (cur_word - 1);
 
             int run_end = 0;
-            while (cur_word_with_1s == UINT64_C(-1) &&
+            while (cur_word_with_1s == UINT64_C(0xFFFFFFFFFFFFFFFF) &&
                    long_ctr < BITSET_CONTAINER_SIZE_IN_WORDS - 1)
                 cur_word_with_1s = c_qua_bitset->array[++long_ctr];
 
-            if (cur_word_with_1s == UINT64_C(-1)) {
+            if (cur_word_with_1s == UINT64_C(0xFFFFFFFFFFFFFFFF)) {
                 run_end = 64 + long_ctr * 64;  // exclusive, I guess
                 add_run(answer, run_start, run_end - 1);
                 bitset_container_free(c_qua_bitset);

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -49,8 +49,9 @@ bool bitset_array_container_andnot(const bitset_container_t *src_1,
     // Java did this directly, but we have option of asm or avx
     bitset_container_t *result = bitset_container_create();
     bitset_container_copy(src_1, result);
-    result->cardinality = bitset_clear_list(result->array, result->cardinality,
-                                            src_2->array, src_2->cardinality);
+    result->cardinality = (int32_t)bitset_clear_list(result->array,
+        (uint64_t)result->cardinality, src_2->array,
+        (uint64_t)src_2->cardinality);
 
     // do required type conversions.
     if (result->cardinality <= DEFAULT_MAX_SIZE) {
@@ -73,8 +74,9 @@ bool bitset_array_container_iandnot(bitset_container_t *src_1,
                                     const array_container_t *src_2,
                                     void **dst) {
     *dst = src_1;
-    src_1->cardinality = bitset_clear_list(src_1->array, src_1->cardinality,
-                                           src_2->array, src_2->cardinality);
+    src_1->cardinality = (int32_t)bitset_clear_list(src_1->array,
+        (uint64_t)src_1->cardinality, src_2->array,
+        (uint64_t)src_2->cardinality);
 
     if (src_1->cardinality <= DEFAULT_MAX_SIZE) {
         *dst = array_container_from_bitset(src_1);

--- a/src/containers/mixed_equal.c
+++ b/src/containers/mixed_equal.c
@@ -11,7 +11,7 @@ bool array_container_equal_bitset(array_container_t* container1,
     for (int32_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i) {
         uint64_t w = container2->array[i];
         while (w != 0) {
-            uint64_t t = w & -w;
+            uint64_t t = w & (~w + 1);
             uint16_t r = i * 64 + __builtin_ctzll(w);
             if (pos >= container1->cardinality) {
                 return false;

--- a/src/containers/mixed_negation.c
+++ b/src/containers/mixed_negation.c
@@ -28,8 +28,8 @@ void array_container_negation(const array_container_t *src,
     uint64_t card = UINT64_C(1 << 16);
     bitset_container_set_all(dst);
 
-    dst->cardinality =
-        bitset_clear_list(dst->array, card, src->array, src->cardinality);
+    dst->cardinality = (int32_t)bitset_clear_list(dst->array, card, src->array,
+                                                  (uint64_t)src->cardinality);
 }
 
 /* Negation across the entire range of the container

--- a/src/containers/mixed_subset.c
+++ b/src/containers/mixed_subset.c
@@ -103,7 +103,7 @@ bool bitset_container_is_subset_run(bitset_container_t* container1,
         while (w != 0 && i_run < container2->n_runs) {
             uint32_t start = container2->runs[i_run].value;
             uint32_t stop = start+container2->runs[i_run].length;
-            uint64_t t = w & -w;
+            uint64_t t = w & (~w + 1);
             uint16_t r = i_bitset * 64 + __builtin_ctzll(w);
             if (r < start) {
                 return false;

--- a/src/containers/mixed_union.c
+++ b/src/containers/mixed_union.c
@@ -17,7 +17,7 @@ void array_bitset_container_union(const array_container_t *src_1,
                                   const bitset_container_t *src_2,
                                   bitset_container_t *dst) {
     if (src_2 != dst) bitset_container_copy(src_2, dst);
-    dst->cardinality = bitset_set_list_withcard(
+    dst->cardinality = (int32_t)bitset_set_list_withcard(
         dst->array, dst->cardinality, src_1->array, src_1->cardinality);
 }
 
@@ -167,7 +167,7 @@ bool array_array_container_union(const array_container_t *src_1,
     if (*dst != NULL) {
         bitset_container_t *ourbitset = (bitset_container_t *)*dst;
         bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
-        ourbitset->cardinality =
+        ourbitset->cardinality = (int32_t)
             bitset_set_list_withcard(ourbitset->array, src_1->cardinality,
                                      src_2->array, src_2->cardinality);
         if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -18,7 +18,7 @@ bool array_bitset_container_xor(const array_container_t *src_1,
                                 const bitset_container_t *src_2, void **dst) {
     bitset_container_t *result = bitset_container_create();
     bitset_container_copy(src_2, result);
-    result->cardinality = bitset_flip_list_withcard(
+    result->cardinality = (int32_t)bitset_flip_list_withcard(
         result->array, result->cardinality, src_1->array, src_1->cardinality);
 
     // do required type conversions.
@@ -199,7 +199,7 @@ bool array_array_container_xor(const array_container_t *src_1,
     *dst = bitset_container_from_array(src_1);
     bool returnval = true;  // expect a bitset
     bitset_container_t *ourbitset = (bitset_container_t *)*dst;
-    ourbitset->cardinality = bitset_flip_list_withcard(
+    ourbitset->cardinality = (uint32_t)bitset_flip_list_withcard(
         ourbitset->array, src_1->cardinality, src_2->array, src_2->cardinality);
     if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {
         // need to convert!
@@ -261,7 +261,7 @@ bool bitset_bitset_container_xor(const bitset_container_t *src_1,
 bool bitset_array_container_ixor(bitset_container_t *src_1,
                                  const array_container_t *src_2, void **dst) {
     *dst = src_1;
-    src_1->cardinality = bitset_flip_list_withcard(
+    src_1->cardinality = (uint32_t)bitset_flip_list_withcard(
         src_1->array, src_1->cardinality, src_2->array, src_2->cardinality);
 
     if (src_1->cardinality <= DEFAULT_MAX_SIZE) {

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -55,7 +55,7 @@ static bool realloc_array(roaring_array_t *ra, size_t new_capacity) {
 	ra->containers = newcontainers;
 	ra->keys = newkeys;
 	ra->typecodes = newtypecodes;
-	ra->allocation_size = new_capacity;
+	ra->allocation_size = (int32_t)new_capacity;
 	free(oldbigalloc);
     return true;
 }

--- a/src/roaring_priority_queue.c
+++ b/src/roaring_priority_queue.c
@@ -39,7 +39,7 @@ static void pq_free(roaring_pq_t *pq) {
 }
 
 static void percolate_down(roaring_pq_t *pq, uint32_t i) {
-    uint32_t size = pq->size;
+    uint32_t size = (uint32_t)pq->size;
     uint32_t hsize = size >> 1;
     roaring_pq_element_t ai = pq->elements[i];
     while (i < hsize) {


### PR DESCRIPTION
"Roaring" should not refer to the amount of warning text generated. This fixes a number of the warnings about code style (and one real bug) which are generated by Visual Studio on the default warning level. Note that this isn't quite all of them, only those in the path of my application.