### PR TITLE
addressed getSizeInBytes() bug and made serialized 64-bit maps simpler

### DIFF
--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -105,6 +105,7 @@ void test_example(bool copy_on_write) {
     char *serializedbytes = (char *)malloc(expectedsize);
     roaring_bitmap_portable_serialize(r1, serializedbytes);
     roaring_bitmap_t *t = roaring_bitmap_portable_deserialize(serializedbytes);
+    assert_true(expectedsize == roaring_bitmap_portable_size_in_bytes(t));
     assert_true(roaring_bitmap_equals(r1, t));
     roaring_bitmap_free(t);
     free(serializedbytes);
@@ -201,11 +202,11 @@ void test_example_cpp(bool copy_on_write) {
     Roaring i1_2 = r1 & r2;
 
     // we can write a bitmap to a pointer and recover it later
-
     uint32_t expectedsize = r1.getSizeInBytes();
     char *serializedbytes = new char[expectedsize];
     r1.write(serializedbytes);
     Roaring t = Roaring::read(serializedbytes);
+    assert_true(expectedsize == t.getSizeInBytes());
     assert_true(r1 == t);
     delete[] serializedbytes;
 
@@ -307,11 +308,11 @@ void test_example_cpp_64(bool copy_on_write) {
     Roaring64Map i1_2 = r1 & r2;
 
     // we can write a bitmap to a pointer and recover it later
-
-    uint32_t expectedsize = r1.getSizeInBytes();
+    size_t expectedsize = r1.getSizeInBytes();
     char *serializedbytes = new char[expectedsize];
     r1.write(serializedbytes);
     Roaring64Map t = Roaring64Map::read(serializedbytes);
+    assert_true(expectedsize == t.getSizeInBytes());
     assert_true(r1 == t);
     delete[] serializedbytes;
 


### PR DESCRIPTION
With this update I'm changing to an on-disk format for 64-bit maps that doesn't store the size of the interior Roarings.

This is what I wanted to do originally by modifying the C API to return the amount of bytes read but I noticed I could achieve the same thing by using getSizeInBytes() after retrieval of each Roaring.

Note that although this breaks compatibility with old serialized maps, I think it's less of an issue since the getSizeInBytes() bug made it difficult to serialize in the first place!

Also if the C API was ever changed to return the bytes read, there would be no further need to modify the on-disk format. I think it is here to stay.