### PR TITLE
removed optimization on 64 bit map iterator due to standard non-compliance

### DIFF
--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -715,7 +715,7 @@ class Roaring64Map{
     * for constructions such as for(auto i = b.begin();
     * i!=b.end(); ++i) {}
     */
-    const_iterator & end() const;
+    const_iterator end() const;
 
 private:
     std::map<uint32_t, Roaring> roarings;
@@ -848,9 +848,8 @@ inline Roaring64MapSetBitForwardIterator Roaring64Map::begin() const {
       return Roaring64MapSetBitForwardIterator(*this);
 }
 
-inline Roaring64MapSetBitForwardIterator & Roaring64Map::end() const {
-      static Roaring64MapSetBitForwardIterator e(*this, true);
-      return e;
+inline Roaring64MapSetBitForwardIterator Roaring64Map::end() const {
+      return Roaring64MapSetBitForwardIterator(*this, true);
 }
 
 #endif /* INCLUDE_ROARING_64_MAP_HH_ */


### PR DESCRIPTION
Get ready for something very minute:

So there exists a category of STL iterators called "singular" in the C++ standard. It is illegal to copy construct from (or do anything except reassign to) these iterators. The most common way to end up with one of these iterators is through a default iterator constructor but you'll get one if you delete the container to which an iterator originally pointed.

So the Roaring64MapSetBitForwardIterator contains two STL iterators that can become singular through deletion of the Roaring64Map they referred to. When this happens it is technically no longer legal to copy the Roaring64MapSetBitForwardIterator. This means the static iterator in Roaring64Map::end() eventually, over the coarse of a longer program, becomes uncopiable when the first Roaring64Map to enter the function is deleted.

Of course, none of what was written in the standard is a problem in a real program. When the old Roaring64Map is deleted the iterators aren't touched since it would be slow and unnecessary and everything continues to work fine. However, on Debug builds with libstdc++, the iterators are trapped to throw an exception if they are singular and copied.

So we get this exception if we copy an end iterator after a certain point in the program:
Error: attempt to copy-construct an iterator from a singular iterator.

I think we should go back to the old behavior to retain standards compliance and to make sure Debug builds always work. I looked for a way to keep the optimization but nothing reasonable presented itself to me. Oh well, it was a good idea and we can keep the behavior for 32-bit.