### PR TITLE
Use comparable types in bitset util functions

### DIFF
--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -52,7 +52,7 @@ static inline int bitset_range_cardinality(uint64_t *bitmap, uint32_t start,
  */
 static inline int bitset_lenrange_cardinality(uint64_t *bitmap, uint32_t start,
                                               uint32_t lenminusone) {
-    int firstword = start / 64;
+    uint32_t firstword = start / 64;
     uint32_t endword = (start + lenminusone) / 64;
     if (firstword == endword) {
         return hamming(bitmap[firstword] &
@@ -74,14 +74,14 @@ static inline int bitset_lenrange_cardinality(uint64_t *bitmap, uint32_t start,
  */
 static inline bool bitset_lenrange_empty(uint64_t *bitmap, uint32_t start,
         uint32_t lenminusone) {
-    int firstword = start / 64;
+    uint32_t firstword = start / 64;
     uint32_t endword = (start + lenminusone) / 64;
     if (firstword == endword) {
       if((bitmap[firstword] & ((~UINT64_C(0)) >> ((63 - lenminusone) % 64))
               << (start % 64)) != 0) return false;
     }
     if(((bitmap[firstword] & ((~UINT64_C(0)) << (start%64)))) != 0) return false;
-    for (int i = firstword + 1; i < endword; i++) {
+    for (uint32_t i = firstword + 1; i < endword; i++) {
      if(bitmap[i] != 0) return false;
     }
     if((bitmap[endword] & (~UINT64_C(0)) >> (((~start + 1) - lenminusone - 1) % 64)) != 0) return false;


### PR DESCRIPTION
Prevents compile errors with `-Wsign-compare` enabled. This is what I'm getting with Rust while trying to merge https://github.com/saulius/croaring-rs/pull/24:

```
running: "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-m64" "-I" "../croaring-sys/CRoaring" "-Wall" "-Wextra" "-Werror" "-Wno-unused-parameter" "-Wno-type-lim
its" "-o" "/Users/sg/repos/croaring-rs/systest/target/debug/build/systest-90d26495522f312e/out/all.o" "-c" "/Users/sg/repos/croaring-rs/systest/target/debug/build/systest-90d2649
5522f312e/out/all.c"
cargo:warning=In file included from /Users/sg/repos/croaring-rs/systest/target/debug/build/systest-90d26495522f312e/out/all.c:3:
cargo:warning=../croaring-sys/CRoaring/roaring.h:625:19: error: comparison of integers of different signs: 'int' and 'uint32_t' (aka 'unsigned int') [-Werror,-Wsign-compare]
cargo:warning=    if (firstword == endword) {
cargo:warning=        ~~~~~~~~~ ^  ~~~~~~~
cargo:warning=../croaring-sys/CRoaring/roaring.h:647:19: error: comparison of integers of different signs: 'int' and 'uint32_t' (aka 'unsigned int') [-Werror,-Wsign-compare]
cargo:warning=    if (firstword == endword) {
cargo:warning=        ~~~~~~~~~ ^  ~~~~~~~
cargo:warning=../croaring-sys/CRoaring/roaring.h:652:35: error: comparison of integers of different signs: 'int' and 'uint32_t' (aka 'unsigned int') [-Werror,-Wsign-compare]
cargo:warning=    for (int i = firstword + 1; i < endword; i++) {
cargo:warning=                                ~ ^ ~~~~~~~
cargo:warning=3 errors generated.
```

Similar change to https://github.com/RoaringBitmap/CRoaring/commit/bad954101d5e4e12b7e21e51e1937224fb745fb4.

Maybe `Wsign-compare` should be turned on in CMake?

@lemire 