### PR TITLE
Fix roaring_bitmap_intersect.

### DIFF
--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -77,8 +77,8 @@ static inline bool bitset_lenrange_empty(uint64_t *bitmap, uint32_t start,
     int firstword = start / 64;
     uint32_t endword = (start + lenminusone) / 64;
     if (firstword == endword) {
-      if((bitmap[firstword] & ((~UINT64_C(0)) >> ((63 - lenminusone) % 64))
-              << (start % 64)) != 0) return false;
+      return (bitmap[firstword] & ((~UINT64_C(0)) >> ((63 - lenminusone) % 64))
+              << (start % 64)) == 0;
     }
     if(((bitmap[firstword] & ((~UINT64_C(0)) << (start%64)))) != 0) return false;
     for (int i = firstword + 1; i < endword; i++) {


### PR DESCRIPTION
There was a bug when testing the intersection between a bitset and a run container with only one run.

For example, this test was failing:
```c
void test_intersect_small_run_bitset() {
    roaring_bitmap_t *rb1 = roaring_bitmap_from_range(0, 1, 1);
    roaring_bitmap_t *rb2 = roaring_bitmap_from_range(1, 8194, 2);
    assert_false(roaring_bitmap_intersect(rb1, rb2));
    roaring_bitmap_free(rb1);
    roaring_bitmap_free(rb2);
}
```

I did not add this piece of code in the test suite of CRoaring, because more extensive tests may be better.