### PR TITLE
Fix memory leak in roaring_bitmap_or_many.

### DIFF
--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1546,15 +1546,15 @@ roaring_bitmap_t *roaring_bitmap_lazy_or(const roaring_bitmap_t *x1,
     uint8_t container_result_type = 0;
     const int length1 = x1->high_low_container.size,
               length2 = x2->high_low_container.size;
-    roaring_bitmap_t *answer =
-        roaring_bitmap_create_with_capacity(length1 + length2);
-    answer->copy_on_write = x1->copy_on_write && x2->copy_on_write;
     if (0 == length1) {
         return roaring_bitmap_copy(x2);
     }
     if (0 == length2) {
         return roaring_bitmap_copy(x1);
     }
+    roaring_bitmap_t *answer =
+        roaring_bitmap_create_with_capacity(length1 + length2);
+    answer->copy_on_write = x1->copy_on_write && x2->copy_on_write;
     int pos1 = 0, pos2 = 0;
     uint8_t container_type_1, container_type_2;
     uint16_t s1 = ra_get_key_at_index(&x1->high_low_container, pos1);

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -2776,6 +2776,20 @@ void test_subset() {
     roaring_bitmap_free(rb2);
 }
 
+void test_or_many_memory_leak() {
+    for(int i=0; i<10; i++) {
+        roaring_bitmap_t *bm1 = roaring_bitmap_create();
+        for(int j=0; j<10; j++) {
+            roaring_bitmap_t *bm2 = roaring_bitmap_create();
+            const roaring_bitmap_t *buff[] = {bm1, bm2};
+            roaring_bitmap_t *bm3 = roaring_bitmap_or_many(2, buff);
+            roaring_bitmap_free(bm2);
+            roaring_bitmap_free(bm3);
+        }
+        roaring_bitmap_free(bm1);
+    }
+}
+
 int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(can_copy_empty_true),
@@ -2858,6 +2872,7 @@ int main() {
         cmocka_unit_test(test_flip_run_container_removal2),
         cmocka_unit_test(select_test),
         cmocka_unit_test(test_subset),
+        cmocka_unit_test(test_or_many_memory_leak),
         // cmocka_unit_test(test_run_to_bitset),
         // cmocka_unit_test(test_run_to_array),
     };


### PR DESCRIPTION
When the length of one of the bitmaps was 0, then the bitmap created by `roaring_bitmap_create_with_capacity` was never freed nor returned.