### PR TITLE
Eliminate unneeded calloc() calls

### DIFF
--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -43,7 +43,7 @@ void bitset_container_set_all(bitset_container_t *bitset) {
 /* Create a new bitset. Return NULL in case of failure. */
 bitset_container_t *bitset_container_create(void) {
     bitset_container_t *bitset =
-        (bitset_container_t *)calloc(1, sizeof(bitset_container_t));
+        (bitset_container_t *)malloc(sizeof(bitset_container_t));
 
     if (!bitset) {
         return NULL;
@@ -105,7 +105,7 @@ void bitset_container_free(bitset_container_t *bitset) {
 /* duplicate container. */
 bitset_container_t *bitset_container_clone(const bitset_container_t *src) {
     bitset_container_t *bitset =
-        (bitset_container_t *)calloc(1, sizeof(bitset_container_t));
+        (bitset_container_t *)malloc(sizeof(bitset_container_t));
 
     if (!bitset) {
         return NULL;


### PR DESCRIPTION
As there's no aligned_calloc(), which would allow to eliminate memset() that's more expensive the only way to optimize is use memset() still, but remove unneeded calloc() calls.

This should fix #65 