### PR TITLE
Disables including malloc.h on FreeBSD, where it doesn't exist

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -23,7 +23,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>  // will provide posix_memalign with _POSIX_C_SOURCE as defined above
-#ifndef __APPLE__
+#if !(defined(__APPLE__)) && !(defined(__FreeBSD__))
 #include <malloc.h>  // this should never be needed but there are some reports that it is needed.
 #endif
 


### PR DESCRIPTION
On FreeBSD 11 the compilation fails with:
```
/usr/include/malloc.h:3:2: error: "<malloc.h> has been
      replaced by <stdlib.h>"
```
This PR disables including `malloc.h` on FreeBSD, which makes `make` and `make test` succeed.