### PR TITLE
Fixed infinite loop in roaring_bitmap_from_range()

### DIFF
--- a/src/roaring.c
+++ b/src/roaring.c
@@ -147,6 +147,10 @@ static inline uint32_t minimum_uint32(uint32_t a, uint32_t b) {
     return (a < b) ? a : b;
 }
 
+static inline uint64_t minimum_uint64(uint64_t a, uint64_t b) {
+    return (a < b) ? a : b;
+}
+
 roaring_bitmap_t *roaring_bitmap_from_range(uint64_t min, uint64_t max,
                                             uint32_t step) {
     if(max >= UINT64_C(0x100000000)) {
@@ -161,11 +165,11 @@ roaring_bitmap_t *roaring_bitmap_from_range(uint64_t min, uint64_t max,
         }
         return answer;
     }
-    uint32_t min_tmp = min;
+    uint64_t min_tmp = min;
     do {
         uint32_t key = min_tmp >> 16;
         uint32_t container_min = min_tmp & 0xFFFF;
-        uint32_t container_max = minimum_uint32(max - (key << 16), 1 << 16);
+        uint32_t container_max = minimum_uint64(max - (key << 16), 1 << 16);
         uint8_t type;
         void *container = container_from_range(&type, container_min,
                                                container_max, (uint16_t)step);

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -651,6 +651,11 @@ void test_bitmap_from_range() {
             }
         }
     }
+
+    // max range
+    roaring_bitmap_t *r = roaring_bitmap_from_range(0, UINT64_MAX, 1);
+    assert_true(roaring_bitmap_get_cardinality(r) == UINT64_C(0x100000000));
+    roaring_bitmap_free(r);
 }
 
 void test_printf() {


### PR DESCRIPTION
Range [0, 2^32) caused integer overflow and infinite loop.