### PR TITLE
cmake: Add cmake macros for inclusion into larger cmake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 option(BUILD_STATIC "Build a static library" OFF) # turning it on disables the production of a dynamic library
 option(BUILD_LTO "Build library with Link Time Optimization" OFF)
 option(SANITIZE "Sanitize addresses" OFF)
+option(ENABLE_ROARING_TESTS "If OFF, disable unit tests altogether" ON)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 
@@ -59,9 +60,10 @@ configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/tests/config.h.in"
 #################################
 
 add_subdirectory(src)
-add_subdirectory(benchmarks)
-add_subdirectory(tests)
-
+if(ENABLE_ROARING_TESTS)
+  add_subdirectory(benchmarks)
+  add_subdirectory(tests)
+endif()
 # Being terse is good, but knowing how the build is configured is important
 # and should not be hard to figure out.
 MESSAGE( STATUS "CMAKE_SYSTEM_PROCESSOR: " ${CMAKE_SYSTEM_PROCESSOR})
@@ -72,6 +74,6 @@ MESSAGE( STATUS "BUILD_STATIC: " ${BUILD_STATIC} )
 MESSAGE( STATUS "BUILD_LTO: " ${BUILD_LTO} )
 MESSAGE( STATUS "SANITIZE: " ${SANITIZE} )
 MESSAGE( STATUS "CMAKE_C_COMPILER: " ${CMAKE_C_COMPILER} ) # important to know which compiler is used
-MESSAGE (STATUS "CMAKE_C_FLAGS: " ${CMAKE_C_FLAGS} ) # important to know the flags
+MESSAGE( STATUS "CMAKE_C_FLAGS: " ${CMAKE_C_FLAGS} ) # important to know the flags
 MESSAGE( STATUS "CMAKE_C_FLAGS_DEBUG: " ${CMAKE_C_FLAGS_DEBUG} )
 MESSAGE( STATUS "CMAKE_C_FLAGS_RELEASE: " ${CMAKE_C_FLAGS_RELEASE} )

--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ make
 (You can replace the ``build`` directory with any other directory name.)
 
 By default, on all platforms, we build a dynamic library. You can generate a static library by adding ``-DBUILD_STATIC=ON`` to the command line.
+By default all tests are built on all platforms, to skip building and running tests add `` -DENABLE_ROARING_TESTS=OFF `` to the command line.
 
 As with all ``cmake`` projects, you can specify the compilers you wish to use by adding (for example) ``-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++`` to the ``cmake`` command line.
 


### PR DESCRIPTION
Add -DENABLE_ROARING_TESTS=OFF to build only libroaring.a
which plays nicely with larger cmake projects that only want to build
and test their own projects tests.

Example run:

cmake -DENABLE_ROARING_TESTS=OFF -DBUILD_STATIC=ON ..

make -j8
Scanning dependencies of target roaring
[  5%] Building C object src/CMakeFiles/roaring.dir/containers/array.c.o
[ 11%] Building C object src/CMakeFiles/roaring.dir/array_util.c.o
[ 16%] Building C object src/CMakeFiles/roaring.dir/bitset_util.c.o
[ 27%] Building C object src/CMakeFiles/roaring.dir/containers/bitset.c.o
[ 27%] Building C object src/CMakeFiles/roaring.dir/containers/containers.c.o
[ 33%] Building C object src/CMakeFiles/roaring.dir/containers/convert.c.o
[ 38%] Building C object src/CMakeFiles/roaring.dir/containers/mixed_intersection.c.o
[ 44%] Building C object src/CMakeFiles/roaring.dir/containers/mixed_union.c.o
[ 50%] Building C object src/CMakeFiles/roaring.dir/containers/mixed_equal.c.o
[ 55%] Building C object src/CMakeFiles/roaring.dir/containers/mixed_subset.c.o
[ 61%] Building C object src/CMakeFiles/roaring.dir/containers/mixed_negation.c.o
[ 72%] Building C object src/CMakeFiles/roaring.dir/containers/mixed_xor.c.o
[ 72%] Building C object src/CMakeFiles/roaring.dir/containers/mixed_andnot.c.o
[ 77%] Building C object src/CMakeFiles/roaring.dir/roaring_priority_queue.c.o
[ 83%] Building C object src/CMakeFiles/roaring.dir/roaring_array.c.o
[ 88%] Building C object src/CMakeFiles/roaring.dir/roaring.c.o
[ 94%] Building C object src/CMakeFiles/roaring.dir/containers/run.c.o
[100%] Linking C static library libroaring.a
[100%] Built target roaring

* Add docs for disabling unit tests