### PR TITLE
Clarify Windows C++ support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ of the latest hardware. Roaring bitmaps are already available on a variety of pl
 # Requirements
 
 - The library should build on a  Linux-like operating system (including MacOS).
-- We also support Microsoft Visual studio.
+- We also support Microsoft Visual Studio (C only).
 - Though most reasonable processors should be supported, we expect a recent Intel processor: Haswell (2013) or better but support all x64/x86 processors. The library builds without problem on ARM processors.
-- Recent C compiler supporting the C11 standard (GCC 4.8 or better or clang), there is also an optional C++ class that requires a C++ compiler supporting the C++11 standard.
+- Recent C compiler supporting the C11 standard (GCC 4.8 or better or clang), there is also an optional C++ class that requires a C++ compiler supporting the C++11 standard (but note Microsoft Visual C++ is not supported).
 - CMake (to contribute to the project, users can rely on amalgamation/unity builds).
 - clang-format (optional).
 


### PR DESCRIPTION
This commit adds a caveat to the README that C++ is not supported on Microsoft Visual Studio.  Between the example using CRoaring from C++ later in the README and these statements toward the beginning, I expected Visual C++ to work (observing it supports C++11), and thought it was a bug that it did not:

> Portable Roaring bitmaps in C (and C++) with full support for your favorite compiler (GNU GCC, LLVM's clang, Visual Studio). 

> . . . there is also an optional C++ class that requires a C++ compiler supporting the C++11 standard.

However, I tried to be conservative/unobtrusive; the Visual Studio support is hopefully now explicit without detracting from the README as a whole.