### PR TITLE
Implement ordered_writer and roaring_bitmap_add_ordered for faster construction

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -38,6 +38,7 @@ $SCRIPTPATH/include/roaring/containers/containers.h
 $SCRIPTPATH/include/roaring/roaring_array.h
 $SCRIPTPATH/include/roaring/misc/configreport.h
 $SCRIPTPATH/include/roaring/roaring.h
+$SCRIPTPATH/include/roaring/ordered_writer.h
 "
 
 for i in ${ALLCHEADERS} ${ALLCFILES}; do

--- a/include/roaring/ordered_writer.h
+++ b/include/roaring/ordered_writer.h
@@ -17,6 +17,6 @@ void roaring_bitmap_writer_free(roaring_bitmap_writer_t *writer);
 
 void roaring_bitmap_writer_flush(roaring_bitmap_writer_t *writer);
 
-void roaring_bitmap_writer_add(roaring_bitmap_writer_t *writer, const uint32_t val);
+bool roaring_bitmap_writer_add(roaring_bitmap_writer_t *writer, const uint32_t val);
 
 #endif

--- a/include/roaring/ordered_writer.h
+++ b/include/roaring/ordered_writer.h
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <roaring/roaring.h>
+
+typedef struct roaring_bitmap_writer_s {
+    uint64_t *bitmap;
+    roaring_bitmap_t *target;
+    uint32_t current_key;
+    uint64_t cardinality;
+    bool dirty;
+} roaring_bitmap_writer_t;
+
+roaring_bitmap_writer_t *roaring_bitmap_writer_create(roaring_bitmap_t *target);
+
+void roaring_bitmap_writer_free(roaring_bitmap_writer_t *writer);
+
+void roaring_bitmap_writer_flush(roaring_bitmap_writer_t *writer);
+
+void roaring_bitmap_writer_add(roaring_bitmap_writer_t *writer, const uint32_t val);

--- a/include/roaring/ordered_writer.h
+++ b/include/roaring/ordered_writer.h
@@ -13,6 +13,8 @@ typedef struct roaring_bitmap_writer_s {
 
 roaring_bitmap_writer_t *roaring_bitmap_writer_create(roaring_bitmap_t *target);
 
+void roaring_bitmap_writer_set(roaring_bitmap_writer_t *result, roaring_bitmap_t *target);
+
 void roaring_bitmap_writer_free(roaring_bitmap_writer_t *writer);
 
 void roaring_bitmap_writer_flush(roaring_bitmap_writer_t *writer);

--- a/include/roaring/ordered_writer.h
+++ b/include/roaring/ordered_writer.h
@@ -5,7 +5,6 @@ typedef struct roaring_bitmap_writer_s {
     uint64_t *bitmap;
     roaring_bitmap_t *target;
     uint32_t current_key;
-    uint64_t cardinality;
     bool dirty;
 } roaring_bitmap_writer_t;
 

--- a/include/roaring/ordered_writer.h
+++ b/include/roaring/ordered_writer.h
@@ -1,3 +1,6 @@
+#ifndef ROARING_ORDERED_WRITER
+#define ROARING_ORDERED_WRITER
+
 #include <assert.h>
 #include <roaring/roaring.h>
 
@@ -15,3 +18,5 @@ void roaring_bitmap_writer_free(roaring_bitmap_writer_t *writer);
 void roaring_bitmap_writer_flush(roaring_bitmap_writer_t *writer);
 
 void roaring_bitmap_writer_add(roaring_bitmap_writer_t *writer, const uint32_t val);
+
+#endif

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -11,6 +11,7 @@ extern "C" {
 #include <roaring/roaring_array.h>
 #include <roaring/roaring_types.h>
 #include <roaring/roaring_version.h>
+#include <roaring/ordered_writer.h>
 #include <stdbool.h>
 
 typedef struct roaring_bitmap_s {
@@ -225,6 +226,13 @@ void roaring_bitmap_free(roaring_bitmap_t *r);
  */
 void roaring_bitmap_add_many(roaring_bitmap_t *r, size_t n_args,
                              const uint32_t *vals);
+
+/**
+ * Add ordered values from pointer vals, faster than repeatedly calling
+ * roaring_bitmap_add_many for ordered values
+ *
+ */
+void roaring_bitmap_add_ordered(roaring_bitmap_t *r, size_t n_args, const uint32_t *vals, roaring_bitmap_writer_t *writer);
 
 /**
  * Add value x

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -231,7 +231,7 @@ void roaring_bitmap_add_many(roaring_bitmap_t *r, size_t n_args,
  * roaring_bitmap_add_many for ordered values
  *
  */
-void roaring_bitmap_add_ordered(roaring_bitmap_t *r, size_t n_args, const uint32_t *vals);
+bool roaring_bitmap_add_ordered(roaring_bitmap_t *r, size_t n_args, const uint32_t *vals);
 
 /**
  * Add value x

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -11,7 +11,6 @@ extern "C" {
 #include <roaring/roaring_array.h>
 #include <roaring/roaring_types.h>
 #include <roaring/roaring_version.h>
-#include <roaring/ordered_writer.h>
 #include <stdbool.h>
 
 typedef struct roaring_bitmap_s {
@@ -232,7 +231,7 @@ void roaring_bitmap_add_many(roaring_bitmap_t *r, size_t n_args,
  * roaring_bitmap_add_many for ordered values
  *
  */
-void roaring_bitmap_add_ordered(roaring_bitmap_t *r, size_t n_args, const uint32_t *vals, roaring_bitmap_writer_t *writer);
+void roaring_bitmap_add_ordered(roaring_bitmap_t *r, size_t n_args, const uint32_t *vals);
 
 /**
  * Add value x

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,9 @@ set(ROARING_SRC
     containers/run.c
     roaring.c
     roaring_priority_queue.c
-    roaring_array.c)
+    roaring_array.c
+    ordered_writer.c
+    )
 
 add_library(${ROARING_LIB_NAME} ${ROARING_LIB_TYPE} ${ROARING_SRC})
 target_include_directories(${ROARING_LIB_NAME}

--- a/src/ordered_writer.c
+++ b/src/ordered_writer.c
@@ -38,12 +38,14 @@ void roaring_bitmap_writer_flush(roaring_bitmap_writer_t *writer) {
     memset(bitmap, 0, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
 }
 
-void roaring_bitmap_writer_add(roaring_bitmap_writer_t *writer, const uint32_t val) {
+bool roaring_bitmap_writer_add(roaring_bitmap_writer_t *writer, const uint32_t val) {
     const uint16_t hb = val >> 16;
     const uint16_t lb = val & 0xFFFF;
 
     if (hb != writer->current_key) {
-        assert(hb > writer->current_key);
+        if (hb <= writer->current_key) {
+            return false;
+        }
         roaring_bitmap_writer_flush(writer);
     }
 
@@ -54,4 +56,6 @@ void roaring_bitmap_writer_add(roaring_bitmap_writer_t *writer, const uint32_t v
 
     writer->current_key = hb;
     writer->dirty = true;
+
+    return true;
 }

--- a/src/ordered_writer.c
+++ b/src/ordered_writer.c
@@ -50,8 +50,6 @@ bool roaring_bitmap_writer_add(roaring_bitmap_writer_t *writer, const uint32_t v
     }
 
     uint64_t *bitmap = writer->bitmap;
-
-    const int index = lb & 63;
     bitmap[lb >> 6] |= (UINT64_C(1) << (lb & 63));
 
     writer->current_key = hb;

--- a/src/ordered_writer.c
+++ b/src/ordered_writer.c
@@ -1,0 +1,62 @@
+#include <assert.h>
+#include <roaring/roaring.h>
+
+roaring_bitmap_writer_t *roaring_bitmap_writer_create(roaring_bitmap_t *target) {
+    roaring_bitmap_writer_t *result = (roaring_bitmap_writer_t *) malloc(sizeof(roaring_bitmap_writer_t));
+    result->bitmap = (uint64_t *) malloc(sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+    memset(result->bitmap, 0, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+    result->target = target;
+    result->current_key = 0;
+    result->cardinality = 0;
+    result->dirty = false;
+    return result;
+}
+
+void roaring_bitmap_writer_free(roaring_bitmap_writer_t *writer) {
+    free(writer->bitmap);
+    free(writer);
+}
+
+void roaring_bitmap_writer_flush(roaring_bitmap_writer_t *writer) {
+    if (!(writer->dirty)) {
+        return;
+    }
+
+    uint64_t *bitmap = writer->bitmap;
+    roaring_bitmap_t *target = writer->target;
+
+    bitset_container_t *newac = bitset_container_create();
+
+    newac->cardinality = -1;
+    memcpy(newac->array, bitmap, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+
+    uint8_t new_typecode = BITSET_CONTAINER_TYPE_CODE;
+    void *newcontainer = container_repair_after_lazy(newac, &new_typecode);
+
+    ra_append(&target->high_low_container, writer->current_key, newcontainer, new_typecode);
+
+    memset(bitmap, 0, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+}
+
+void roaring_bitmap_writer_add(roaring_bitmap_writer_t *writer, const uint32_t val) {
+    const uint16_t hb = val >> 16;
+    const uint16_t lb = val & 0xFFFF;
+
+    if (hb != writer->current_key) {
+        assert(hb > writer->current_key);
+        roaring_bitmap_writer_flush(writer);
+    }
+
+    uint64_t *bitmap = writer->bitmap;
+
+    uint64_t shift = 6;
+    uint64_t offset;
+    uint64_t p = lb;
+    ASM_SHIFT_RIGHT(p, shift, offset);
+    uint64_t load = bitmap[offset];
+    ASM_SET_BIT_INC_WAS_CLEAR(load, p, writer->cardinality);
+    bitmap[offset] = load;
+
+    writer->current_key = hb;
+    writer->dirty = true;
+}

--- a/src/ordered_writer.c
+++ b/src/ordered_writer.c
@@ -12,6 +12,13 @@ roaring_bitmap_writer_t *roaring_bitmap_writer_create(roaring_bitmap_t *target) 
     return result;
 }
 
+void roaring_bitmap_writer_set(roaring_bitmap_writer_t *result, roaring_bitmap_t *target) {
+    memset(result->bitmap, 0, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+    result->target = target;
+    result->current_key = 0;
+    result->dirty = false;
+}
+
 void roaring_bitmap_writer_free(roaring_bitmap_writer_t *writer) {
     free(writer->bitmap);
     free(writer);
@@ -38,7 +45,7 @@ void roaring_bitmap_writer_flush(roaring_bitmap_writer_t *writer) {
     memset(bitmap, 0, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
 }
 
-bool roaring_bitmap_writer_add(roaring_bitmap_writer_t *writer, const uint32_t val) {
+inline bool roaring_bitmap_writer_add(roaring_bitmap_writer_t *writer, const uint32_t val) {
     const uint16_t hb = val >> 16;
     const uint16_t lb = val & 0xFFFF;
 

--- a/src/ordered_writer.c
+++ b/src/ordered_writer.c
@@ -1,5 +1,7 @@
 #include <assert.h>
 #include <roaring/roaring.h>
+#include <roaring/ordered_writer.h>
+#include <roaring/utilasm.h>
 
 roaring_bitmap_writer_t *roaring_bitmap_writer_create(roaring_bitmap_t *target) {
     roaring_bitmap_writer_t *result = (roaring_bitmap_writer_t *) malloc(sizeof(roaring_bitmap_writer_t));

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -3,6 +3,7 @@
 #include <roaring/roaring.h>
 #include <roaring/roaring_array.h>
 #include <roaring/bitset_util.h>
+#include <roaring/ordered_writer.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -3,7 +3,6 @@
 #include <roaring/roaring.h>
 #include <roaring/roaring_array.h>
 #include <roaring/bitset_util.h>
-#include <roaring/ordered_writer.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
This tries to port OrderedWriter from Java implementation (the behaviour of ordered_writer.c is quite the same).
This implements a new function on roaring.h: `roaring_bitmap_add_ordered` which allocates and uses an ordered_writer.

There is still work to do which I need help (this is my first C "serious" code, so there might be other mistakes). 
