### PR TITLE
fix ra_clear, it should reset size and allocated size

### DIFF
--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -191,10 +191,12 @@ void ra_reset(roaring_array_t *ra) {
 }
 
 void ra_clear_without_containers(roaring_array_t *ra) {
-    free(ra->containers);   // keys and typecodes are allocated with containers
-    ra->keys = NULL;        // paranoid
-    ra->containers = NULL;  // paranoid
-    ra->typecodes = NULL;   // paranoid
+    free(ra->containers);    // keys and typecodes are allocated with containers
+    ra->size = 0;
+    ra->allocation_size = 0;
+    ra->containers = NULL;
+    ra->keys = NULL;
+    ra->typecodes = NULL;
 }
 
 void ra_clear(roaring_array_t *ra) {


### PR DESCRIPTION
After calling ra_clear the state of roaring_array_t may be not correct and this can break the usage of other functions on the cleared array.

ra_clear already resets all pointers to NULL, it is safer to reset also `size` and `allocation_size` to zero.

It is then possible to call other functions on the cleared array without any risk.
