### PR TITLE
Accumulator for Roaring64Map::getSizeInBytes() is size_t based.

### DIFF
--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -679,7 +679,7 @@ class Roaring64Map {
         return std::accumulate(
             roarings.cbegin(), roarings.cend(),
             sizeof(uint64_t) + roarings.size() * sizeof(uint32_t),
-            [=](uint64_t previous,
+            [=](size_t previous,
                 const std::pair<uint32_t, Roaring> &map_entry) {
                 // add in bytes used by each Roaring
                 return previous + map_entry.second.getSizeInBytes(portable);


### PR DESCRIPTION
The accumulator in Roaring64Map::getSizeInBytes() should be operating on size_t; the `previous` value provided had size uint64_t which is not right.  On systems where size_t is not the same as uint64_t (for example compiling for Windows 32bit) this will result in a warning:
```
c:\program files (x86)\microsoft visual studio\2017\professional\vc\tools\msvc\14.13.26128\include\numeric(25): warning C4244: '=': conversion from 'uint64_t' to 'unsigned int', possible loss of data
```