### PR TITLE
Windows: Use #define for __builtin_unreachable()

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -149,7 +149,8 @@ static inline int __builtin_popcountll(unsigned long long input_num) {
 #endif
 }
 
-static inline void __builtin_unreachable() { __assume(0); }
+/* Use #define so this is effective even under /Ob0 (no inline) */
+#define __builtin_unreachable() __assume(0)
 #endif
 
 #endif


### PR DESCRIPTION
If we use inline functions then compile with /Ob0 (disable inline), as
many debug builds will do, this method will no longer have its
intended effect since the __assume(0) will be hidden inside the (not
inlined) function.