### PR TITLE
Improvements to allocation policy of array structs

### DIFF
--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -479,13 +479,14 @@ static inline void *container_add(void *container, uint16_t val,
             return container;
         case ARRAY_CONTAINER_TYPE_CODE: {
             array_container_t *ac = (array_container_t *)container;
-            array_container_add(ac, val);
-            if (array_container_cardinality(ac) > DEFAULT_MAX_SIZE) {
-                *new_typecode = BITSET_CONTAINER_TYPE_CODE;
-                return bitset_container_from_array(ac);
-            } else {
+            if (array_container_try_add(ac, val, DEFAULT_MAX_SIZE) != -1) {
                 *new_typecode = ARRAY_CONTAINER_TYPE_CODE;
                 return ac;
+            } else {
+                bitset_container_t* bitset = bitset_container_from_array(ac);
+                bitset_container_add(bitset, val);
+                *new_typecode = BITSET_CONTAINER_TYPE_CODE;
+                return bitset;
             }
         } break;
         case RUN_CONTAINER_TYPE_CODE:

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -19,8 +19,9 @@ void array_bitset_container_andnot(const array_container_t *src_1,
                                    const bitset_container_t *src_2,
                                    array_container_t *dst) {
     // follows Java implementation as of June 2016
-    if (dst->capacity < src_1->cardinality)
-        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
+    if (dst->capacity < src_1->cardinality) {
+        array_container_grow(dst, src_1->cardinality, false);
+    }
     int32_t newcard = 0;
     const int32_t origcard = src_1->cardinality;
     for (int i = 0; i < origcard; ++i) {
@@ -372,8 +373,9 @@ void array_run_container_andnot(const array_container_t *src_1,
                                 const run_container_t *src_2,
                                 array_container_t *dst) {
     // basically following Java impl as of June 2016
-    if (src_1->cardinality > dst->capacity)
-        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
+    if (src_1->cardinality > dst->capacity) {
+        array_container_grow(dst, src_1->cardinality, false);
+    }
 
     if (src_2->n_runs == 0) {
         memmove(dst->array, src_1->array,

--- a/src/containers/mixed_intersection.c
+++ b/src/containers/mixed_intersection.c
@@ -13,8 +13,9 @@
 void array_bitset_container_intersection(const array_container_t *src_1,
                                          const bitset_container_t *src_2,
                                          array_container_t *dst) {
-    if (dst->capacity < src_1->cardinality)
-        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
+    if (dst->capacity < src_1->cardinality) {
+        array_container_grow(dst, src_1->cardinality, false);
+    }
     int32_t newcard = 0;  // dst could be src_1
     const int32_t origcard = src_1->cardinality;
     for (int i = 0; i < origcard; ++i) {
@@ -71,8 +72,9 @@ void array_run_container_intersection(const array_container_t *src_1,
         if (dst != src_1) array_container_copy(src_1, dst);
         return;
     }
-    if (dst->capacity < src_1->cardinality)
-        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
+    if (dst->capacity < src_1->cardinality) {
+        array_container_grow(dst, src_1->cardinality, false);
+    }
     if (src_2->n_runs == 0) {
         return;
     }

--- a/src/containers/mixed_union.c
+++ b/src/containers/mixed_union.c
@@ -214,7 +214,7 @@ bool array_array_container_inplace_union(array_container_t *src_1,
         if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {
             // need to convert!
             if(src_1->capacity < ourbitset->cardinality) {
-              array_container_grow(src_1, ourbitset->cardinality, INT32_MAX, false);
+              array_container_grow(src_1, ourbitset->cardinality, false);
             }
 
             bitset_extract_setbits_uint16(ourbitset->array, BITSET_CONTAINER_SIZE_IN_WORDS,

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -215,9 +215,13 @@ void ra_clear(roaring_array_t *ra) {
 
 bool extend_array(roaring_array_t *ra, int32_t k) {
     int32_t desired_size = ra->size + k;
+    assert(desired_size <= MAX_CONTAINERS);
     if (desired_size > ra->allocation_size) {
         int32_t new_capacity =
             (ra->size < 1024) ? 2 * desired_size : 5 * desired_size / 4;
+        if (new_capacity > MAX_CONTAINERS) {
+            new_capacity = MAX_CONTAINERS;
+        }
 
         return realloc_array(ra, new_capacity);
     }

--- a/tests/array_container_unit.c
+++ b/tests/array_container_unit.c
@@ -174,11 +174,25 @@ void select_test() {
     array_container_free(B);
 }
 
+void capacity_test() {
+    array_container_t* array = array_container_create();
+    for (uint32_t i = 0; i < DEFAULT_MAX_SIZE; i++) {
+        array_container_add(array, (uint16_t)i);
+        assert_true(array->capacity <= DEFAULT_MAX_SIZE);
+    }
+    for (uint32_t i = DEFAULT_MAX_SIZE; i < 65536; i++) {
+        array_container_add(array, (uint16_t)i);
+        assert_true(array->capacity <= 65536);
+    }
+    array_container_free(array);
+}
+
 int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(printf_test), cmocka_unit_test(add_contains_test),
         cmocka_unit_test(and_or_test), cmocka_unit_test(to_uint32_array_test),
         cmocka_unit_test(select_test),
+        cmocka_unit_test(capacity_test)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
array_container_add(): check that array must be converted to bitset
_before_ adding value, not after. This allows to limit array capacity
with DEFAULT_MAX_SIZE most of the time.

array.c: do not allocate space for more than DEFAULT_MAX_SIZE values
(soft limit, which can be exceeded in negation and some pairwise
operations; in this case we try to limit capacity with 64K)

roaring_array.c: do not allocate space for more than MAX_CONTAINERS