### PR TITLE
Add ROARING_ARCH build option to control march=

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(ROARING_LIB_NAME roaring)
 
 option(ROARING_DISABLE_X64 "Forcefully disable x64 optimizations even if hardware supports it (this disables AVX) " OFF)
 option(ROARING_DISABLE_AVX "Forcefully disable AVX even if hardware supports it" OFF)
+option(ROARING_DISABLE_NATIVE "Forcefully disable -march optimizations" OFF)
+set(ROARING_ARCH "native" CACHE STRING "If ROARING_DISABLE_NATIVE is OFF, the architecture to optimize for (-march)")
 
 IF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
 SET(ROARING_DISABLE_AVX ON) # for ARM processors, there is no hope of having AVX support
@@ -69,6 +71,8 @@ MESSAGE( STATUS "CMAKE_SYSTEM_PROCESSOR: " ${CMAKE_SYSTEM_PROCESSOR})
 MESSAGE( STATUS "CMAKE_BUILD_TYPE: " ${CMAKE_BUILD_TYPE} ) # this tends to be "sticky" so you can remain unknowingly in debug mode
 MESSAGE( STATUS "ROARING_DISABLE_X64: " ${ROARING_DISABLE_X64} ) # options in cmake are "sticky" so old options can remain even if that is counterintuitive
 MESSAGE( STATUS "ROARING_DISABLE_AVX: " ${ROARING_DISABLE_AVX} ) # options in cmake are "sticky" so old options can remain even if that is counterintuitive
+MESSAGE( STATUS "ROARING_DISABLE_NATIVE: " ${ROARING_DISABLE_NATIVE} )
+MESSAGE( STATUS "ROARING_ARCH: " ${ROARING_ARCH} )
 MESSAGE( STATUS "ROARING_BUILD_STATIC: " ${ROARING_BUILD_STATIC} )
 MESSAGE( STATUS "ROARING_BUILD_LTO: " ${ROARING_BUILD_LTO} )
 MESSAGE( STATUS "ROARING_SANITIZE: " ${ROARING_SANITIZE} )

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ As with all ``cmake`` projects, you can specify the compilers you wish to use by
 
 
 
-If wish to build an x64 version while disabling AVX2 and BMI2 support at the expense of performance, you can do the following :
+If you wish to build an x64 version while disabling AVX2 and BMI2 support at the expense of performance, you can do the following :
 
 ```
 mkdir -p buildnoavx
@@ -407,6 +407,32 @@ do the following...
 mkdir -p buildnox64
 cd buildnoavx
 cmake -DROARING_DISABLE_X64=ON ..
+make
+```
+
+We tell the compiler to target the architecture of the build machine by using the `march=native` flag. This give the
+compiler the freedom to use instructions that your CPU support, but can be dangerous if you are going to use the built
+binaries on different machines. For example, you could get a `SIGILL` crash if you run the code on an older machine
+which does not have some of the instructions (e.g. `POPCOUNT`). There are two ways to deal with this:
+
+First, you can disable this feature altogether by specifying `-DROARING_DISABLE_NATIVE=OFF`:
+
+```
+mkdir -p buildnonative
+cd buildnoavx
+cmake -DROARING_DISABLE_NATIVE=ON ..
+make
+```
+
+Second, you can specify the architecture by specifying `-DROARING_ARCH=arch`. For example, if you have many servers
+but the oldest server is running the Intel `westmere` architecture, you can specify -`DROARING_ARCH=westmere`. You can
+find out the list of valid architecture values by typing `man gcc`. If `-DROARING_DISABLE_NATIVE=on` is specified, then
+this option has no effect.
+
+```
+mkdir -p build_westmere
+cd build_westmere
+cmake -DROARING_ARCH=westmere ..
 make
 ```
 

--- a/tools/cmake/FindOptions.cmake
+++ b/tools/cmake/FindOptions.cmake
@@ -14,8 +14,9 @@ endif()
 
 ## -march=native is not supported on some platforms
 if(NOT MSVC)
+
 if(NOT ROARING_DISABLE_NATIVE)
-set(OPT_FLAGS "-march=native")
+set(OPT_FLAGS "-march=${ROARING_ARCH}")
 endif()
 endif()
 


### PR DESCRIPTION
As outlined in https://github.com/RoaringBitmap/CRoaring/issues/176 ,
passing `march=native` can cause SIGILL when the build server is newer
than the server running the binary.

Currently, the only way around this issue is to use
`ROARING_DISABLE_NATIVE` and not use `march` at all.

This commit gives users additional control by adding a new CMake build
option to specify the architecture, e.g. `-DROARING_ARCH=westmere`.
If the existing `ROARING_DISABLE_NATIVE` flag is set to `OFF`, then
this new option has no effect.