### PR TITLE
Software implementation of popcnt

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -140,6 +140,7 @@ static inline int __builtin_clzll(unsigned long long input_num) {
 }
 
 /* result might be undefined when input_num is zero */
+#ifdef USESSE4
 static inline int __builtin_popcountll(unsigned long long input_num) {
 #ifdef _WIN64  // highly recommended!!!
     return (int)__popcnt64(input_num);
@@ -148,6 +149,20 @@ static inline int __builtin_popcountll(unsigned long long input_num) {
                  __popcnt((uint32_t)(input_num >> 32)));
 #endif
 }
+#else
+/* avoids use of popcnt which is unsupported on old processors */
+static inline int __builtin_popcountll(unsigned long long input_num) {
+	const uint64_t m1 = 0x5555555555555555; //binary: 0101...
+	const uint64_t m2 = 0x3333333333333333; //binary: 00110011..
+	const uint64_t m4 = 0x0f0f0f0f0f0f0f0f; //binary:  4 zeros,  4 ones ...
+	const uint64_t h01 = 0x0101010101010101; //the sum of 256 to the power of 0,1,2,3...
+
+	x -= (x >> 1) & m1;             //put count of each 2 bits into those 2 bits
+	x = (x & m2) + ((x >> 2) & m2); //put count of each 4 bits into those 4 bits 
+	x = (x + (x >> 4)) & m4;        //put count of each 8 bits into those 8 bits 
+	return (x * h01) >> 56;			//returns left 8 bits of x + (x<<8) + (x<<16) + (x<<24) + ... 
+}
+#endif
 
 static inline void __builtin_unreachable() { __assume(0); }
 #endif

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -141,26 +141,28 @@ static inline int __builtin_clzll(unsigned long long input_num) {
 
 /* result might be undefined when input_num is zero */
 #ifdef USESSE4
+/* POPCNT support was added to processors around the release of SSE4.2 */
+/* USESSE4 flag guarantees POPCNT support */
 static inline int __builtin_popcountll(unsigned long long input_num) {
 #ifdef _WIN64  // highly recommended!!!
-    return (int)__popcnt64(input_num);
+	return (int)__popcnt64(input_num);
 #else  // if we must support 32-bit Windows
-    return (int)(__popcnt((uint32_t)input_num) +
-                 __popcnt((uint32_t)(input_num >> 32)));
+	return (int)(__popcnt((uint32_t)input_num) +
+		__popcnt((uint32_t)(input_num >> 32)));
 #endif
 }
 #else
-/* avoids use of popcnt which is unsupported on old processors */
+/* software implementation avoids POPCNT */
 static inline int __builtin_popcountll(unsigned long long input_num) {
 	const uint64_t m1 = 0x5555555555555555; //binary: 0101...
 	const uint64_t m2 = 0x3333333333333333; //binary: 00110011..
 	const uint64_t m4 = 0x0f0f0f0f0f0f0f0f; //binary:  4 zeros,  4 ones ...
 	const uint64_t h01 = 0x0101010101010101; //the sum of 256 to the power of 0,1,2,3...
 
-	x -= (x >> 1) & m1;             //put count of each 2 bits into those 2 bits
-	x = (x & m2) + ((x >> 2) & m2); //put count of each 4 bits into those 4 bits 
-	x = (x + (x >> 4)) & m4;        //put count of each 8 bits into those 8 bits 
-	return (x * h01) >> 56;			//returns left 8 bits of x + (x<<8) + (x<<16) + (x<<24) + ... 
+	input_num -= (input_num >> 1) & m1;
+	input_num = (input_num & m2) + ((input_num >> 2) & m2);
+	input_num = (input_num + (input_num >> 4)) & m4;
+	return (input_num * h01) >> 56;
 }
 #endif
 


### PR DESCRIPTION
POPCNT support was not available on processors until around the time of SSE4.2 instructions. CRoaring flag for SSE4 guarantees POPCNT support. This patch uses that flag to guard against attempted usage
of the popcnt instruction on builds where we have not enabled that level of processor support. A software implentation is provided that should provide good all around performance.