### PR TITLE
Implement backward iterator

### DIFF
--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -691,6 +691,17 @@ class RoaringSetBitForwardIterator final {
         return orig;
     }
 
+    type_of_iterator& operator--() { // prefix --
+        roaring_previous_uint32_iterator(&i);
+        return *this;
+    }
+
+    type_of_iterator operator--(int) { // postfix --
+        RoaringSetBitForwardIterator orig(*this);
+        roaring_previous_uint32_iterator(&i);
+        return orig;
+    }
+
     bool operator==(const RoaringSetBitForwardIterator &o) const {
         return i.current_value == *o && i.has_value == o.i.has_value;
     }

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -623,8 +623,6 @@ typedef struct roaring_uint32_iterator_s {
     int32_t in_container_index;  // for bitset and array container, this is out
                                  // index
     int32_t run_index;           // for run container, this points  at the run
-    uint32_t in_run_index;  // within a run, this is our index (points at the
-                            // end of the current run)
 
     uint32_t current_value;
     bool has_value;
@@ -642,19 +640,26 @@ typedef struct roaring_uint32_iterator_s {
 
 /**
 * Initialize an iterator object that can be used to iterate through the
-* values.  If there is a  value, then it->has_value is true.
-* The first value is in it->current_value. The iterator traverses the values
-* in increasing order.
+* values. If there is a  value, then this iterator points to the first value
+* and it->has_value is true. The value is in it->current_value.
 */
 void roaring_init_iterator(const roaring_bitmap_t *ra,
                            roaring_uint32_iterator_t *newit);
 
 /**
+* Initialize an iterator object that can be used to iterate through the
+* values. If there is a value, then this iterator points to the last value
+* and it->has_value is true. The value is in it->current_value.
+*/
+void roaring_init_iterator_last(const roaring_bitmap_t *ra,
+                                roaring_uint32_iterator_t *newit);
+
+/**
 * Create an iterator object that can be used to iterate through the
 * values. Caller is responsible for calling roaring_free_iterator.
-* The iterator is initialized. If there is a  value, then it->has_value is true.
-* The first value is in it->current_value. The iterator traverses the values
-* in increasing order.
+* The iterator is initialized. If there is a  value, then this iterator
+* points to the first value and it->has_value is true.
+* The value is in it->current_value.
 *
 * This function calls roaring_init_iterator.
 */
@@ -666,6 +671,13 @@ roaring_uint32_iterator_t *roaring_create_iterator(const roaring_bitmap_t *ra);
 * orders. For convenience, returns it->has_value.
 */
 bool roaring_advance_uint32_iterator(roaring_uint32_iterator_t *it);
+
+/**
+* Decrement the iterator. If there is a new value, then it->has_value is true.
+* The new value is in it->current_value. Values are traversed in decreasing
+* orders. For convenience, returns it->has_value.
+*/
+bool roaring_previous_uint32_iterator(roaring_uint32_iterator_t *it);
 
 /**
 * Move the iterator to the first value >= val. If there is a such a value, then it->has_value is true.


### PR DESCRIPTION
Noteable changes:
- `in_run_index` removed from the `roaring_uint32_iterator_t` which
  breaks abi compatability. Just use the iterator's current value to
  and `run_index` figure out if it should advance or not

- added invariant to `roaring_uint32_iterator_t`: the `container_index`
  can be -1 in addition to `>= parent->high_low_container.size`.
  Previously when the `container_index >= parent->high_low_container_size`
  this represented that the iterator pointed past the end of the
  container. This is still true, however -1 now indicates that the
  iterator points before any of the values in container

- add `roaring_previous_uint32_iterator` method, which moves the
  iterator backwards

- add `roaring_init_iterator_last` method, which initializes the
  iterator to point to the last element in the bitmap

- add prefix and postfix `operator--` to c++ api