### PR TITLE
Have C++ defaults behave like stl defaults

### DIFF
--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -38,16 +38,6 @@ class Roaring64Map {
     Roaring64Map(size_t n, const uint64_t *data) { addMany(n, data); }
 
     /**
-     * Copy constructor
-     */
-    Roaring64Map(const Roaring64Map &r) = default;
-
-    /**
-     * Move constructor
-     */
-    Roaring64Map(Roaring64Map &&r) = default;
-
-    /**
      * Construct a 64-bit map from a 32-bit one
      */
     Roaring64Map(const Roaring &r) { emplaceOrInsert(0, r); }
@@ -187,31 +177,6 @@ class Roaring64Map {
         return roarings.count(highBytes(x)) == 0
                    ? false
                    : roarings.at(highBytes(x)).contains(lowBytes(x));
-    }
-
-    /**
-     * Destructor
-     */
-    ~Roaring64Map() = default;
-
-    /**
-     * Copies the content of the provided bitmap, and
-     * discards the current content.
-     */
-    Roaring64Map &operator=(const Roaring64Map &r) {
-        roarings = r.roarings;
-        copyOnWrite = r.copyOnWrite;
-        return *this;
-    }
-
-    /**
-     * Moves the content of the provided bitmap, and
-     * discards the current content.
-     */
-    Roaring64Map &operator=(Roaring64Map &&r) {
-        roarings = std::move(r.roarings);
-        copyOnWrite = r.copyOnWrite;
-        return *this;
     }
 
     /**
@@ -969,11 +934,6 @@ class Roaring64MapSetBitForwardIterator final {
             }
         }
     }
-
-    ~Roaring64MapSetBitForwardIterator() = default;
-
-    Roaring64MapSetBitForwardIterator(
-        const Roaring64MapSetBitForwardIterator &o) = default;
 
    private:
     std::map<uint32_t, Roaring>::const_iterator map_iter;

--- a/include/roaring/roaring_array.h
+++ b/include/roaring/roaring_array.h
@@ -51,9 +51,9 @@ roaring_array_t *ra_create(void);
 bool ra_init_with_capacity(roaring_array_t *new_ra, uint32_t cap);
 
 /**
- * Initialize with default capacity
+ * Initialize with zero capacity
  */
-bool ra_init(roaring_array_t *t);
+void ra_init(roaring_array_t *t);
 
 /**
  * Copies this roaring array, we assume that dest is not initialized

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -58,11 +58,7 @@ roaring_bitmap_t *roaring_bitmap_create() {
     if (!ans) {
         return NULL;
     }
-    bool is_ok = ra_init(&ans->high_low_container);
-    if (!is_ok) {
-        free(ans);
-        return NULL;
-    }
+    ra_init(&ans->high_low_container);
     ans->copy_on_write = false;
     return ans;
 }

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -2,6 +2,7 @@
 * The purpose of this test is to check that we can call CRoaring from C++
 */
 
+#include <type_traits>
 #include <assert.h>
 #include <roaring/roaring.h>
 #include <stdio.h>
@@ -15,6 +16,9 @@ extern "C" {
 #include "test.h"
 }
 
+
+static_assert(std::is_nothrow_move_constructible<Roaring>::value,
+        "Expected Roaring to be no except move constructable");
 
 bool roaring_iterator_sumall(uint32_t value, void *param) {
     *(uint32_t *)param += value;


### PR DESCRIPTION
- Change `bool ra_init()` to `void ra_init()`, initializes array to have
  zero capacity. Does not `malloc` and cannot fail. ABI breaking change

- Have `Roaring` ctor use new `ra_init()`

- Make `Roaring` move ctor and move assignment `noexcept`. This is important
  for performance when holding them in stl containers (avoids copying)

- Delete dtor, copy ctor, move ctor, copy assignment operator and move
  assignment operator for `RoaringSetBitForwardIterator` and `Roaring64Map`
  since these objects don't manage any lifetimes manually. The compiler
  provides these by _default_ to us

- Add `static_assert`s that C++ classes are `noexcept` moveable in cpp
  unit test file