### PR TITLE
Added aarch64 and armhf to travis workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,33 @@ language: c
 sudo: true
 compiler:
   - clang
+dist: xenial
+addons:
+  apt:
+    packages:
+      - gcc-5-aarch64-linux-gnu
+      - g++-5-aarch64-linux-gnu
+      - gcc-5-arm-linux-gnueabihf
+      - g++-5-arm-linux-gnueabihf
+      - gcc-5-multilib
+      - g++-5-multilib
+      - qemu-user-static
+      - binfmt-support
 
 branches:
   only:
     - master
 
-script:
-- ./amalgamation.sh  && clang -march=native -O3 -std=c11  -o amalgamation_demo amalgamation_demo.c  && ./amalgamation_demo && clang++ -march=native -O3 -std=c++11 -o amalgamation_demo amalgamation_demo.cpp  && ./amalgamation_demo &&  clang -march=native -mno-sse3 -O3 -std=c11  -o amalgamation_demo amalgamation_demo.c  && ./amalgamation_demo && clang++ -march=native -mno-sse3 -O3 -std=c++11 -o amalgamation_demo amalgamation_demo.cpp  && ./amalgamation_demo
-- mkdir -p buildsani && cd buildsani && cmake -DCMAKE_BUILD_TYPE=Debug -DROARING_SANITIZE=ON .. && make && make CTEST_OUTPUT_ON_FAILURE=1 test && cd .. && mkdir -p buildsaninox64 && cd buildsaninox64 && cmake -DCMAKE_BUILD_TYPE=Debug -DROARING_SANITIZE=ON  -DROARING_DISABLE_X64=ON  .. && make && make CTEST_OUTPUT_ON_FAILURE=1 test && cd .. && mkdir -p build && cd build && cmake .. && make && make CTEST_OUTPUT_ON_FAILURE=1 test && cd .. &&  mkdir -p buildnox64 && cd buildnox64 && cmake -DROARING_DISABLE_X64=ON .. && make && make CTEST_OUTPUT_ON_FAILURE=1 test && cd .. &&  mkdir -p debugbuild && cd debugbuild && cmake -DCMAKE_BUILD_TYPE=Debug .. && make && make CTEST_OUTPUT_ON_FAILURE=1 test && cd .. &&  mkdir -p debugbuildnox64 && cd debugbuildnox64 && cmake  -DCMAKE_BUILD_TYPE=Debug  -DROARING_DISABLE_X64=ON .. && make && make CTEST_OUTPUT_ON_FAILURE=1 test
+matrix:
+  include: # ordered by execution time, slowest first
+    - env: CONF=armhf
+    - env: CONF=aarch64
+    - env: CONF=sani
+    - env: CONF=saninox64
+    - env: CONF=debug
+    - env: CONF=debugnox64
+    - env: CONF=release
+    - env: CONF=releasenox64
+    - env: CONF=amalgamation
+script: tools/travis.sh $CONF
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ SET(ROARING_DISABLE_NATIVE ON) # ARM platforms may not like -march=native
 endif()
 
 option(ROARING_BUILD_STATIC "Build a static library" OFF) # turning it on disables the production of a dynamic library
+option(ROARING_LINK_STATIC "Link executables (tests, benchmarks) statically" OFF)
 option(ROARING_BUILD_LTO "Build library with Link Time Optimization" OFF)
 option(ROARING_SANITIZE "Sanitize addresses" OFF)
 option(ENABLE_ROARING_TESTS "If OFF, disable unit tests altogether" ON)
@@ -74,6 +75,7 @@ MESSAGE( STATUS "ROARING_DISABLE_AVX: " ${ROARING_DISABLE_AVX} ) # options in cm
 MESSAGE( STATUS "ROARING_DISABLE_NATIVE: " ${ROARING_DISABLE_NATIVE} )
 MESSAGE( STATUS "ROARING_ARCH: " ${ROARING_ARCH} )
 MESSAGE( STATUS "ROARING_BUILD_STATIC: " ${ROARING_BUILD_STATIC} )
+MESSAGE( STATUS "ROARING_LINK_STATIC: " ${ROARING_LINK_STATIC} )
 MESSAGE( STATUS "ROARING_BUILD_LTO: " ${ROARING_BUILD_LTO} )
 MESSAGE( STATUS "ROARING_SANITIZE: " ${ROARING_SANITIZE} )
 MESSAGE( STATUS "CMAKE_C_COMPILER: " ${CMAKE_C_COMPILER} ) # important to know which compiler is used

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CRoaring [![Build Status](https://travis-ci.org/RoaringBitmap/CRoaring.png)](https://travis-ci.org/RoaringBitmap/CRoaring)   [![Build Status](https://img.shields.io/appveyor/ci/lemire/croaring.svg)](https://ci.appveyor.com/project/lemire/croaring)
+# CRoaring [![Build Status](https://travis-ci.org/RoaringBitmap/CRoaring.svg)](https://travis-ci.org/RoaringBitmap/CRoaring)   [![Build Status](https://img.shields.io/appveyor/ci/lemire/croaring.svg)](https://ci.appveyor.com/project/lemire/croaring)
 Portable Roaring bitmaps in C (and C++) with full support for your favorite compiler (GNU GCC, LLVM's clang, Visual Studio). Included in the [Awesome C](https://github.com/kozross/awesome-c) list of open source C software.
 
 # Introduction

--- a/tools/cmake/FindOptions.cmake
+++ b/tools/cmake/FindOptions.cmake
@@ -60,3 +60,11 @@ set(CMAKE_CXX_FLAGS "${CXXSTD_FLAGS} ${OPT_FLAGS} ${INCLUDE_FLAGS} ${WARNING_FLA
 if(MSVC)
 add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /wd4005 /wd4996 /wd4267 /wd4244  /wd4113 /nologo")
 endif()
+
+if(ROARING_LINK_STATIC)
+  if(NOT MSVC)
+    set(CMAKE_EXE_LINKER_FLAGS "-static")
+  else()
+    MESSAGE(WARNING "Option ROARING_LINK_STATIC is not supported with MSVC and was ignored")
+  endif()
+endif()

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <configuration>"
+  exit 1
+fi
+conf="$1"
+
+cd $(dirname $(readlink -f "$0"))/..
+
+case "$conf" in
+  amalgamation)
+    ./amalgamation.sh
+    clang -march=native -O3 -std=c11  -o amalgamation_demo amalgamation_demo.c
+    ./amalgamation_demo
+    clang++ -march=native -O3 -std=c++11 -o amalgamation_demo amalgamation_demo.cpp
+    ./amalgamation_demo
+    clang -march=native -mno-sse3 -O3 -std=c11  -o amalgamation_demo amalgamation_demo.c
+    ./amalgamation_demo
+    clang++ -march=native -mno-sse3 -O3 -std=c++11 -o amalgamation_demo amalgamation_demo.cpp
+    ./amalgamation_demo
+    ;;
+
+  sani)
+    rm -Rf build${conf}
+    mkdir build${conf}
+    cd build${conf}
+    cmake -DCMAKE_BUILD_TYPE=Debug -DROARING_SANITIZE=ON ..
+    make
+    make CTEST_OUTPUT_ON_FAILURE=1 test
+    ;;
+
+  saninox64)
+    rm -Rf build${conf}
+    mkdir build${conf}
+    cd build${conf}
+    cmake -DCMAKE_BUILD_TYPE=Debug -DROARING_SANITIZE=ON -DROARING_DISABLE_X64=ON ..
+    make
+    make CTEST_OUTPUT_ON_FAILURE=1 test
+    ;;
+
+  release)
+    rm -Rf build${conf}
+    mkdir build${conf}
+    cd build${conf}
+    cmake ..
+    make
+    make CTEST_OUTPUT_ON_FAILURE=1 test
+    ;;
+
+  releasenox64)
+    rm -Rf build${conf}
+    mkdir build${conf}
+    cd build${conf}
+    cmake -DROARING_DISABLE_X64=ON ..
+    make
+    make CTEST_OUTPUT_ON_FAILURE=1 test
+    ;;
+
+  debug)
+    rm -Rf build${conf}
+    mkdir build${conf}
+    cd build${conf}
+    cmake -DCMAKE_BUILD_TYPE=Debug ..
+    make
+    make CTEST_OUTPUT_ON_FAILURE=1 test
+    ;;
+
+  debugnox64)
+    rm -Rf build${conf}
+    mkdir build${conf}
+    cd build${conf}
+    cmake  -DCMAKE_BUILD_TYPE=Debug  -DROARING_DISABLE_X64=ON ..
+    make
+    make CTEST_OUTPUT_ON_FAILURE=1 test
+    ;;
+
+  armhf)
+    rm -Rf build${conf}
+    mkdir build${conf}
+    cd build${conf}
+    cmake \
+      -DCMAKE_C_COMPILER='arm-linux-gnueabihf-gcc-5' \
+      -DCMAKE_CXX_COMPILER='arm-linux-gnueabihf-g++-5' \
+      -DROARING_BUILD_STATIC=yes \
+      -DROARING_LINK_STATIC=yes \
+      -DROARING_DISABLE_NATIVE=no \
+      -DROARING_ARCH='armv7-a' \
+      ..
+    make
+    # Travis kills job because it doesn't get any output from
+    # realdata_unit in 10 minutes.
+    # Print test output to avoid this.
+    make ARGS="-V" test
+    ;;
+
+  aarch64)
+    rm -Rf build${conf}
+    mkdir build${conf}
+    cd build${conf}
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release  \
+      -DCMAKE_C_COMPILER='aarch64-linux-gnu-gcc-5' \
+      -DCMAKE_CXX_COMPILER='aarch64-linux-gnu-g++-5' \
+      -DROARING_BUILD_STATIC=yes \
+      -DROARING_LINK_STATIC=yes \
+      -DROARING_DISABLE_NATIVE=no \
+      -DROARING_ARCH='armv8-a' \
+      ..
+    make
+    make CTEST_OUTPUT_ON_FAILURE=1 test
+    ;;
+
+  *)
+    echo "Unknown configuration: '$conf'"
+    exit 1
+    ;;
+esac
+
+


### PR DESCRIPTION
* Reworked travis workflow so that now different
  configurations are tested simultaneously
* Added additional travis jobs to build and test
  roaring bitmap for aarch64 and armhf.
  Unit tests are run by using qemu.
* Introduced new ROARING_LINK_STATIC flag to produce
  statically linked binaries (tests and benchmarks)