### PR TITLE
Drop inline function declaration in public api

### DIFF
--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -259,10 +259,7 @@ void roaring_bitmap_add_range_closed(roaring_bitmap_t *ra, uint32_t min, uint32_
 /**
  * Add all values in range [min, max)
  */
-inline void roaring_bitmap_add_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
-  if(max == min) return;
-  roaring_bitmap_add_range_closed(ra, (uint32_t)min, (uint32_t)(max - 1));
-}
+void roaring_bitmap_add_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max);
 
 /**
  * Remove value x
@@ -274,10 +271,7 @@ void roaring_bitmap_remove(roaring_bitmap_t *r, uint32_t x);
 void roaring_bitmap_remove_range_closed(roaring_bitmap_t *ra, uint32_t min, uint32_t max);
 
 /** Remove all values in range [min, max) */
-inline void roaring_bitmap_remove_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
-    if(max == min) return;
-    roaring_bitmap_remove_range_closed(ra, (uint32_t)min, (uint32_t)(max - 1));
-}
+void roaring_bitmap_remove_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max);
 
 /** Remove multiple values */
 void roaring_bitmap_remove_many(roaring_bitmap_t *r, size_t n_args,

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -227,6 +227,11 @@ void roaring_bitmap_add_range_closed(roaring_bitmap_t *ra, uint32_t min, uint32_
     }
 }
 
+void roaring_bitmap_add_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
+  if(max == min) return;
+  roaring_bitmap_add_range_closed(ra, (uint32_t)min, (uint32_t)(max - 1));
+}
+
 void roaring_bitmap_remove_range_closed(roaring_bitmap_t *ra, uint32_t min, uint32_t max) {
     if (min > max) {
         return;
@@ -264,8 +269,10 @@ void roaring_bitmap_remove_range_closed(roaring_bitmap_t *ra, uint32_t min, uint
     }
 }
 
-void roaring_bitmap_add_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max);
-void roaring_bitmap_remove_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max);
+void roaring_bitmap_remove_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
+    if(max == min) return;
+    roaring_bitmap_remove_range_closed(ra, (uint32_t)min, (uint32_t)(max - 1));
+}
 
 void roaring_bitmap_printf(const roaring_bitmap_t *ra) {
     printf("{");


### PR DESCRIPTION
Removes `inline` declaration in public API of `roaring_bitmap_add_range` and `roaring_bitmap_remove_range`. I was trying to make [croaring-rs](https://github.com/saulius/croaring-rs) work on Windows [as requested](https://github.com/saulius/croaring-rs/pull/42). These two functions seem to cause issues with MSVC linker: [see test output here](https://travis-ci.org/saulius/croaring-rs/builds/478230256). After I removed `inline` declaration it seems to build and work [just fine](https://travis-ci.org/saulius/croaring-rs/builds/478235806).

I understand the purpose of inlining here, but can we do without it? 

@lemire 