### PR TITLE
Feature/suppress 32bit sux

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -28,7 +28,7 @@
 #endif
 
 
-#if defined(_MSC_VER) && !defined(__clang__) && !defined(_WIN64)
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(_WIN64) && !defined(ACKNOWLEDGE_32BIT)
 #pragma message( \
     "You appear to be attempting a 32-bit build under Visual Studio. We recommend a 64-bit build instead.")
 #endif

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -28,7 +28,7 @@
 #endif
 
 
-#if defined(_MSC_VER) && !defined(__clang__) && !defined(_WIN64) && !defined(ACKNOWLEDGE_32BIT)
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(_WIN64) && !defined(ROARING_ACK_32BIT)
 #pragma message( \
     "You appear to be attempting a 32-bit build under Visual Studio. We recommend a 64-bit build instead.")
 #endif


### PR DESCRIPTION
Recommendation for 64 bit builds over 32 bit ones is a good goal. However in certain circumstances, 64 bit simply isn't possible. Continued output of this message adds no value and actually pollutes
the output logs. This commit adds support for a preprocessor define that will suppress the message. Suppression of message requires definition of the symbol in the consumer.