### PR TITLE
Resolve signed/unsigned comparison warning

### DIFF
--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -676,7 +676,7 @@ static inline void run_container_remove_range(run_container_t *run, uint32_t min
     int32_t last = rle16_find_run(run->runs, run->n_runs, max);
 
     if (first >= 0 && min > run->runs[first].value &&
-        max < run->runs[first].value + run->runs[first].length) {
+        max < ((uint32_t)run->runs[first].value + (uint32_t)run->runs[first].length)) {
         // split this run into two adjacent runs
 
         // right subinterval


### PR DESCRIPTION
It appears in this code that under msvc, the sum of two uint16_t's is being promoted to a signed value. This change makes the promotionof each value explicitly to uint32_t to match the type of the comparison. Also, parentheses added to promote readability.