### PR TITLE
rename aligned_malloc, aligned_free

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -185,7 +185,7 @@ extern int posix_memalign(void **__memptr, size_t __alignment, size_t __size);
 #endif  //__cplusplus // C++ does not have a well defined signature
 
 // portable version of  posix_memalign
-static inline void *aligned_malloc(size_t alignment, size_t size) {
+static inline void *roaring_bitmap_aligned_malloc(size_t alignment, size_t size) {
     void *p;
 #ifdef _MSC_VER
     p = _aligned_malloc(size, alignment);
@@ -199,7 +199,7 @@ static inline void *aligned_malloc(size_t alignment, size_t size) {
     return p;
 }
 
-static inline void aligned_free(void *memblock) {
+static inline void roaring_bitmap_aligned_free(void *memblock) {
 #ifdef _MSC_VER
     _aligned_free(memblock);
 #elif defined(__MINGW32__) || defined(__MINGW64__)

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -49,7 +49,7 @@ bitset_container_t *bitset_container_create(void) {
         return NULL;
     }
     // sizeof(__m256i) == 32
-    bitset->array = (uint64_t *)aligned_malloc(
+    bitset->array = (uint64_t *)roaring_bitmap_aligned_malloc(
         32, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
     if (!bitset->array) {
         free(bitset);
@@ -98,7 +98,7 @@ void bitset_container_add_from_range(bitset_container_t *bitset, uint32_t min,
 /* Free memory. */
 void bitset_container_free(bitset_container_t *bitset) {
     if(bitset->array != NULL) {// Jon Strabala reports that some tools complain otherwise
-      aligned_free(bitset->array);
+      roaring_bitmap_aligned_free(bitset->array);
       bitset->array = NULL; // pedantic
     }
     free(bitset);
@@ -113,7 +113,7 @@ bitset_container_t *bitset_container_clone(const bitset_container_t *src) {
         return NULL;
     }
     // sizeof(__m256i) == 32
-    bitset->array = (uint64_t *)aligned_malloc(
+    bitset->array = (uint64_t *)roaring_bitmap_aligned_malloc(
         32, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
     if (!bitset->array) {
         free(bitset);
@@ -547,7 +547,7 @@ void* bitset_container_deserialize(const char *buf, size_t buf_len) {
   if((ptr = (bitset_container_t *)malloc(sizeof(bitset_container_t))) != NULL) {
     memcpy(ptr, buf, sizeof(bitset_container_t));
     // sizeof(__m256i) == 32
-    ptr->array = (uint64_t *) aligned_malloc(32, l);
+    ptr->array = (uint64_t *) roaring_bitmap_aligned_malloc(32, l);
     if (! ptr->array) {
         free(ptr);
         return NULL;

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -3955,7 +3955,7 @@ void test_range_cardinality() {
 
 void frozen_serialization_compare(roaring_bitmap_t *r1) {
     size_t num_bytes = roaring_bitmap_frozen_size_in_bytes(r1);
-    char *buf = aligned_malloc(32, num_bytes);
+    char *buf = roaring_bitmap_aligned_malloc(32, num_bytes);
     roaring_bitmap_frozen_serialize(r1, buf);
 
     const roaring_bitmap_t *r2 =
@@ -3966,7 +3966,7 @@ void frozen_serialization_compare(roaring_bitmap_t *r1) {
 
     roaring_bitmap_free(r1);
     roaring_bitmap_free(r2);
-    aligned_free(buf);
+    roaring_bitmap_aligned_free(buf);
 }
 
 void test_frozen_serialization() {


### PR DESCRIPTION
[#211] I verified that this solution works for my very specific name collision with another library. `make && make test` passes as well.