### PR TITLE
Generate and install pkg-config metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ find_package(CTargets)
 find_package(Options)
 find_package(LTO)
 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/roaring.pc.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/roaring.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/roaring.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 ## C header files get installed to /usr/local/include/roaring typically
 
 

--- a/roaring.pc.in
+++ b/roaring.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: roaring
+Description: Roaring bitmap implementation in C
+Version: @ROARING_LIB_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lroaring


### PR DESCRIPTION
This provides a way for dependent projects with non-CMake build
systems to locate libroaring. Multiple build systems can read these
files, either directly (like Meson) or via the pkg-config or pkgconf
tools (like Autotools).