### PR TITLE
Add copyright and licensing information to amalgamated source code

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -16,6 +16,7 @@ ALLCFILES=$( ( [ -d $SCRIPTPATH/.git ] && ( type git >/dev/null 2>&1 ) &&  ( git
 
 # order matters
 ALLCHEADERS="
+$SCRIPTPATH/src/license-comment.h
 $SCRIPTPATH/include/roaring/roaring_version.h
 $SCRIPTPATH/include/roaring/portability.h
 $SCRIPTPATH/include/roaring/containers/perfparameters.h
@@ -82,7 +83,7 @@ echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${AMAL_C}"
     echo "#endif"
     echo ""
 
-    for h in ${ALLCFILES}; do
+    for h in "$SCRIPTPATH/src/license-comment.h" ${ALLCFILES}; do
         dofile $h
     done
 } >> "${AMAL_C}"
@@ -116,7 +117,7 @@ echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${AMAL_HH}"
 {
     echo "#include \"${AMAL_H}\""
 
-    for h in ${ALLCPPHEADERS}; do
+    for h in "$SCRIPTPATH/src/license-comment.h" ${ALLCPPHEADERS}; do
         dofile $h
     done
 } >> "${AMAL_HH}"

--- a/src/license-comment.h
+++ b/src/license-comment.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2016-2020 The CRoaring authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */


### PR DESCRIPTION
This hopefully makes it easier for projects that embed a copy of the
amalgamated source code to remain in compliance with section 4 of the
terms of the Apache license.