### PR TITLE
Remove unreachable serialization code

### DIFF
--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -52,13 +52,6 @@ void array_container_free(array_container_t *array);
 /* Duplicate container */
 array_container_t *array_container_clone(const array_container_t *src);
 
-int32_t array_container_serialize(const array_container_t *container,
-                                  char *buf) WARN_UNUSED;
-
-uint32_t array_container_serialization_len(const array_container_t *container);
-
-void *array_container_deserialize(const char *buf, size_t buf_len);
-
 /* Get the cardinality of `array'. */
 static inline int array_container_cardinality(const array_container_t *array) {
     return array->cardinality;

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -45,13 +45,6 @@ void bitset_container_set_all(bitset_container_t *bitset);
 /* Duplicate bitset */
 bitset_container_t *bitset_container_clone(const bitset_container_t *src);
 
-int32_t bitset_container_serialize(const bitset_container_t *container,
-                                   char *buf) WARN_UNUSED;
-
-uint32_t bitset_container_serialization_len(void);
-
-void *bitset_container_deserialize(const char *buf, size_t buf_len);
-
 /* Set the bit in [begin,end). WARNING: as of April 2016, this method is slow
  * and
  * should not be used in performance-sensitive code. Ever.  */

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -158,6 +158,7 @@ static inline void *container_to_bitset(void *container, uint8_t typecode) {
 
 /**
  * Get the container name from the typecode
+ * (unused at time of writing)
  */
 static inline const char *get_container_name(uint8_t typecode) {
     switch (typecode) {
@@ -585,13 +586,6 @@ static inline bool container_contains_range(const void *container, uint32_t rang
             return false;
     }
 }
-
-int32_t container_serialize(const void *container, uint8_t typecode,
-                            char *buf) WARN_UNUSED;
-
-uint32_t container_serialization_len(const void *container, uint8_t typecode);
-
-void *container_deserialize(uint8_t typecode, const char *buf, size_t buf_len);
 
 /**
  * Returns true if the two containers have the same content. Note that

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -64,13 +64,6 @@ void run_container_free(run_container_t *run);
 /* Duplicate container */
 run_container_t *run_container_clone(const run_container_t *src);
 
-int32_t run_container_serialize(const run_container_t *container,
-                                char *buf) WARN_UNUSED;
-
-uint32_t run_container_serialization_len(const run_container_t *container);
-
-void *run_container_deserialize(const char *buf, size_t buf_len);
-
 /*
  * Effectively deletes the value at index index, repacking data.
  */

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -511,13 +511,6 @@ int bitset_container_number_of_runs(bitset_container_t *b) {
   return num_runs;
 }
 
-int32_t bitset_container_serialize(const bitset_container_t *container, char *buf) {
-  int32_t l = sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS;
-  memcpy(buf, container->array, l);
-  return(l);
-}
-
-
 
 int32_t bitset_container_write(const bitset_container_t *container,
                                   char *buf) {
@@ -531,32 +524,6 @@ int32_t bitset_container_read(int32_t cardinality, bitset_container_t *container
 	container->cardinality = cardinality;
 	memcpy(container->array, buf, BITSET_CONTAINER_SIZE_IN_WORDS * sizeof(uint64_t));
 	return bitset_container_size_in_bytes(container);
-}
-
-uint32_t bitset_container_serialization_len() {
-  return(sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
-}
-
-void* bitset_container_deserialize(const char *buf, size_t buf_len) {
-  bitset_container_t *ptr;
-  size_t l = sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS;
-
-  if(l != buf_len)
-    return(NULL);
-
-  if((ptr = (bitset_container_t *)malloc(sizeof(bitset_container_t))) != NULL) {
-    memcpy(ptr, buf, sizeof(bitset_container_t));
-    // sizeof(__m256i) == 32
-    ptr->array = (uint64_t *) roaring_bitmap_aligned_malloc(32, l);
-    if (! ptr->array) {
-        free(ptr);
-        return NULL;
-    }
-    memcpy(ptr->array, buf, l);
-    ptr->cardinality = bitset_container_compute_cardinality(ptr);
-  }
-
-  return((void*)ptr);
 }
 
 bool bitset_container_iterate(const bitset_container_t *cont, uint32_t base, roaring_iterator iterator, void *ptr) {

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -6,8 +6,6 @@ extern inline const void *container_unwrap_shared(
 extern inline void *container_mutable_unwrap_shared(
     void *candidate_shared_container, uint8_t *type);
 
-extern inline const char *get_container_name(uint8_t typecode);
-
 extern inline int container_get_cardinality(const void *container, uint8_t typecode);
 
 extern inline void *container_iand(void *c1, uint8_t type1, const void *c2,
@@ -78,63 +76,6 @@ void container_printf_as_uint32_array(const void *container, uint8_t typecode,
             return;
         default:
             __builtin_unreachable();
-    }
-}
-
-int32_t container_serialize(const void *container, uint8_t typecode,
-                            char *buf) {
-    container = container_unwrap_shared(container, &typecode);
-    switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
-            return (bitset_container_serialize((const bitset_container_t *)container,
-                                               buf));
-        case ARRAY_CONTAINER_TYPE_CODE:
-            return (
-                array_container_serialize((const array_container_t *)container, buf));
-        case RUN_CONTAINER_TYPE_CODE:
-            return (run_container_serialize((const run_container_t *)container, buf));
-        default:
-            assert(0);
-            __builtin_unreachable();
-            return (-1);
-    }
-}
-
-uint32_t container_serialization_len(const void *container, uint8_t typecode) {
-    container = container_unwrap_shared(container, &typecode);
-    switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
-            return bitset_container_serialization_len();
-        case ARRAY_CONTAINER_TYPE_CODE:
-            return array_container_serialization_len(
-                (const array_container_t *)container);
-        case RUN_CONTAINER_TYPE_CODE:
-            return run_container_serialization_len(
-                (const run_container_t *)container);
-        default:
-            assert(0);
-            __builtin_unreachable();
-            return (0);
-    }
-}
-
-void *container_deserialize(uint8_t typecode, const char *buf, size_t buf_len) {
-    switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
-            return (bitset_container_deserialize(buf, buf_len));
-        case ARRAY_CONTAINER_TYPE_CODE:
-            return (array_container_deserialize(buf, buf_len));
-        case RUN_CONTAINER_TYPE_CODE:
-            return (run_container_deserialize(buf, buf_len));
-        case SHARED_CONTAINER_TYPE_CODE:
-            printf("this should never happen.\n");
-            assert(0);
-            __builtin_unreachable();
-            return (NULL);
-        default:
-            assert(0);
-            __builtin_unreachable();
-            return (NULL);
     }
 }
 

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -463,25 +463,6 @@ void ra_shift_tail(roaring_array_t *ra, int32_t count, int32_t distance) {
 }
 
 
-size_t ra_size_in_bytes(roaring_array_t *ra) {
-    size_t cardinality = 0;
-    size_t tot_len =
-        1 /* initial byte type */ + 4 /* tot_len */ + sizeof(roaring_array_t) +
-        ra->size * (sizeof(uint16_t) + sizeof(void *) + sizeof(uint8_t));
-    for (int32_t i = 0; i < ra->size; i++) {
-        tot_len +=
-            (container_serialization_len(ra->containers[i], ra->typecodes[i]) +
-             sizeof(uint16_t));
-        cardinality +=
-            container_get_cardinality(ra->containers[i], ra->typecodes[i]);
-    }
-
-    if ((cardinality * sizeof(uint32_t) + sizeof(uint32_t)) < tot_len) {
-        return cardinality * sizeof(uint32_t) + 1 + sizeof(uint32_t);
-    }
-    return tot_len;
-}
-
 void ra_to_uint32_array(const roaring_array_t *ra, uint32_t *ans) {
     size_t ctr = 0;
     for (int32_t i = 0; i < ra->size; ++i) {


### PR DESCRIPTION
There is code present in the library for container serialization
that is not reachable through the API.  This code is tied to the
`container_serialize()` and `container_deserialize()` functions,
which dispatch to functions for each specific container.  The
active serialization code paths are based on _write() and _read()
dispatch functions.

The only current usage of these functions was in a test of the `run`
container serialization in toplevel_unit.c.  This commit changes
that test so that it still generates a lower-level run container,
but then injects it into a single-container roaring_bitmap_t.  Then
it uses the active serialize and deserialize functions on that
bitmap in the test--effectively making it test deployed API code.

With that change in place, the following routines can be removed
(or put under an #ifdef if they are for some future purpose).

* ra_size_in_bytes()
    * container_serialization_len()
        * bitset_container_serialization_len()
        * array_container_serialization_len()
        * run_container_serialization_len()
* container_serialize()
    * bitset_container_serialize()
    * array_container_serialize()
    * run_container_serialize()
* container_deserialize()
    * bitset_cotainer_deserialize()
    * array_container_deserialize()
    * run_container_deserialize()

This commit removes them to demonstrate no loss of functionality.