### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,20 @@ matrix:
     - env: CONF=release
     - env: CONF=releasenox64
     - env: CONF=amalgamation
-script: tools/travis.sh $CONF
+    # power jobs added.
+    - env: CONF=armhf
+      arch: ppc64le
+    - env: CONF=aarch64
+      arch: ppc64le    
+    - env: CONF=debug
+      arch: ppc64le      
+    - env: CONF=debugnox64
+      arch: ppc64le    
+    - env: CONF=release
+      arch: ppc64le
+    - env: CONF=releasenox64
+      arch: ppc64le
+    - env: CONF=amalgamation
+      arch: ppc64le
+    script: tools/travis.sh $CONF
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: c
 sudo: true
 compiler:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

