### PR TITLE
Cast uint16_t key to uint32_t in select

### DIFF
--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2518,7 +2518,7 @@ bool roaring_bitmap_select(const roaring_bitmap_t *bm, uint32_t rank,
 
     if (valid) {
         key = bm->high_low_container.keys[i - 1];
-        *element |= (key << 16);
+        *element |= (((uint32_t)key) << 16);  // w/o cast, key promotes signed
         return true;
     } else
         return false;


### PR DESCRIPTION
roaring_bitmap_select() has a `uint16_t` key, which gets shifted:

    *element |= (key << 16);

For this operation, key is promoted to a signed int.  If the value
is large (e.g. 65535) then this particular left shift of 16 could
shift a 1 into the sign bit, which is undefined behavior:

https://stackoverflow.com/q/55066827/why-cant-you-shift-a-uint16-t

Change is to cast the key to `uint32_t` before shifting.