### PR TITLE
roaring_checked.hh differential check against std::set

### DIFF
--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -18,7 +18,9 @@ namespace roaring {
 class RoaringSetBitForwardIterator;
 
 class Roaring {
-   public:
+  typedef api::roaring_bitmap_t roaring_bitmap_t;  // class-local name alias
+
+  public:
     /**
      * Create an empty bitmap
      */
@@ -323,7 +325,7 @@ class Roaring {
      * (true means that the iteration should continue while false means that it
      * should stop), and takes (uint32_t,void*) as inputs.
      */
-    void iterate(roaring_iterator iterator, void *ptr) const {
+    void iterate(api::roaring_iterator iterator, void *ptr) const {
         api::roaring_iterate(&roaring, iterator, ptr);
     }
 
@@ -728,7 +730,7 @@ class RoaringSetBitForwardIterator final {
         }
     }
 
-    roaring_uint32_iterator_t i;
+    api::roaring_uint32_iterator_t i;
 };
 
 inline RoaringSetBitForwardIterator Roaring::begin() const {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 
 add_cpp_test(cpp_unit)
+add_cpp_test(cpp_random_unit)
 add_c_test(array_container_unit)
 add_c_test(bitset_container_unit)
 add_c_test(mixed_container_unit)

--- a/tests/cpp_random_unit.cpp
+++ b/tests/cpp_random_unit.cpp
@@ -1,0 +1,295 @@
+//
+// cpp_random_unit.cpp
+//
+// The `roaring_checked.hh` variation of the C++ wrapper for roaring bitmaps
+// keeps a C++ `std::set` in sync with changes made using the object's methods.
+// That class has the same name (Roaring) and is in namespace `doublecheck`.
+//
+// This test generates bitsets with randomized content and runs through the
+// various operations with them.
+//
+// The doublecheck code validates the results of API calls, and checks for
+// coherence whenever a `Roaring` class is destructed.  Checking for coherence
+// can also be done explicitly with `does_std_set_match_roaring()`.
+//
+// Note: This could be used as the basis for more rigorous "Fuzz Testing" in
+// the future, which would be able to integrate further coverage information
+// to make sure code paths were being exercised comprehensively:
+//
+// https://www.llvm.org/docs/LibFuzzer.html
+//
+
+#include <type_traits>
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <iostream>
+
+#include <vector>
+
+#include "roaring_checked.hh"
+using doublechecked::Roaring;  // so `Roaring` means `doublecheck::Roaring` 
+
+extern "C" {
+#include "test.h"
+}
+
+
+// The tests can run as long as one wants.  Ideally, the sanitizer options
+// for `address` and `undefined behavior` should be enabled (see the CMake
+// option ROARING_SANITIZE).
+//
+const unsigned long NUM_STEPS = 1000;
+
+// A batch of bitsets is kept live and recycled as they are operated on against
+// each other.  This is how many are kept around at one time.
+//
+const int NUM_ROARS = 30;
+
+// If we generated data fully at random in the uint32_t space, then sets would
+// be unlikely to intersect very often.  Use a rolling focal point to kind of
+// distribute the values near enough to each other to be likely to interfere.
+//
+uint32_t gravity;
+
+
+Roaring make_random_bitset() {
+    Roaring r;
+    int num_ops = rand() % 100;
+    for (int i = 0; i < num_ops; ++i) {
+        switch (rand() % 4) {
+          case 0:
+            r.add(gravity);
+            break;
+
+          case 1: {
+            uint32_t start = gravity + (rand() % 50) - 25;
+            r.addRange(start, start + rand() % 100);
+            break; }
+
+          case 2: {
+            uint32_t start = gravity + (rand() % 50) - 25;
+            r.flip(start, rand() % 50);
+            break; }
+
+          case 3: {  // tests remove(), select(), rank()
+            uint32_t card = r.cardinality();
+            if (card != 0) {
+                uint32_t rnk = rand() % card;
+                uint32_t element;
+                assert_true(r.select(rnk, &element));
+                assert_int_equal(rnk + 1, r.rank(element));
+                r.remove(rnk);
+            }
+            break; }
+
+          default:
+            assert_true(false);
+        }
+        gravity += (rand() % 200) - 100;
+    }
+    assert_true(r.does_std_set_match_roaring());
+    return r;
+}
+
+
+void sanity_check_doublechecking(void **) {
+    Roaring r;
+    while (r.isEmpty())
+        r = make_random_bitset();
+
+    // Pick a random element out of the guaranteed non-empty bitset
+    //
+    uint32_t rnk = rand() % r.cardinality();
+    uint32_t element;
+    assert_true(r.select(rnk, &element));
+
+    // Deliberately get check (the std::set) out of sync to ensure match fails
+    //
+    r.check.erase(element);
+    assert_false(r.does_std_set_match_roaring());
+
+    // Put the std::set back in sync so the destructor doesn't assert
+    //
+    r.check.insert(element);
+    assert_true(r.does_std_set_match_roaring());
+}
+
+
+void random_doublecheck_test(void **) {
+    //
+    // Make a group of bitsets to choose from when performing operations.
+    //
+    std::vector<Roaring> roars;
+    for (int i = 0; i < NUM_ROARS; ++i)
+        roars.insert(roars.end(), make_random_bitset());
+
+    for (unsigned long step = 0; step < NUM_STEPS; ++step) {
+        //
+        // Each step modifies the chosen `out` bitset...possibly just
+        // overwriting it completely.
+        //
+        Roaring &out = roars[rand() % NUM_ROARS];
+
+        // The left and right bitsets may be used as inputs for operations.
+        // They can be a reference to the same object as out, or can be
+        // references to each other (which is good to test those conditions).
+        //
+        const Roaring &left = roars[rand() % NUM_ROARS];
+        const Roaring &right = roars[rand() % NUM_ROARS];
+
+      #ifdef ROARING_CPP_RANDOM_PRINT_STATUS
+        printf(
+            "[%lu]: %lu %lu %lu\n",
+            step,
+            static_cast<unsigned long>(left.cardinality()),
+            static_cast<unsigned long>(right.cardinality()),
+            static_cast<unsigned long>(out.cardinality())
+        );
+      #endif
+
+        int op = rand() % 6;
+
+        // The "doublecheck" in the C++ wrapper for the non-inplace operations
+        // does a check against the inplace version (vs. rewrite the `std::set`
+        // code twice).  Hence the inplace and/andnot/or/xor get tested too.
+        //
+        switch (op) {
+          case 0: {  // AND
+            uint64_t card = left.and_cardinality(right);
+            assert_int_equal(card, right.and_cardinality(left));
+
+            out = left & right;
+
+            assert_int_equal(card, out.cardinality());
+            if (&out != &left)
+                assert_true(out.isSubset(left));
+            if (&out != &right)
+                assert_true(out.isSubset(right));
+            break; }
+
+          case 1: {  // ANDNOT
+            uint64_t card = left.andnot_cardinality(right);
+
+            out = left - right;
+
+            assert_int_equal(card, out.cardinality());
+            if ((&out != &left) && (&out != &right))
+                assert_int_equal(
+                    card, left.cardinality() - right.and_cardinality(left)
+                );
+            if (&out != &left)
+                assert_true(out.isSubset(left));
+            if (&out != &right)
+                assert_false(out.intersect(right));
+            break; }
+
+          case 2: {  // OR
+            uint64_t card = left.or_cardinality(right);
+            assert_int_equal(card, right.or_cardinality(left));
+
+            out = left | right;
+
+            assert_int_equal(card, out.cardinality());
+            if (&out != &left)
+                assert_true(left.isSubset(out));
+            if (&out != &right)
+                assert_true(right.isSubset(out));
+            break; }
+
+          case 3: {  // XOR
+            uint64_t card = left.xor_cardinality(right);
+            assert_true(card == right.xor_cardinality(left));
+
+            out = left ^ right;
+
+            assert_int_equal(card, out.cardinality());
+            if ((&out != &left) && (&out != &right)) {
+                assert_false(out.intersect(left & right));
+                assert_true(
+                    card == left.cardinality() + right.cardinality()
+                        - (2 * left.and_cardinality(right))
+                );
+            }
+            break; }
+
+          case 4: {  // FASTUNION
+            const Roaring *inputs[3] = { &out, &left, &right };
+            out = Roaring::fastunion(3, inputs);  // result checked internally
+            break; }
+
+          case 5: {  // FLIP
+            uint32_t card = out.cardinality();
+            if (card != 0) {  // pick gravity point inside set somewhere
+                uint32_t rnk = rand() % card;
+                uint32_t element;
+                assert_true(out.select(rnk, &element));
+                assert_int_equal(rnk + 1, out.rank(element));
+                gravity = element;
+            }
+            uint32_t start = gravity + (rand() % 50) - 25;
+            out.flip(start, rand() % 50);
+            break; }
+
+          default:
+            assert_true(false);
+        }
+
+        // Periodically apply a post-processing step to the out bitset
+        //
+        int post = rand() % 15;
+        switch (post) {
+          case 0:
+            out.removeRunCompression();
+            break;
+
+          case 1:
+            out.runOptimize();
+            break;
+
+          case 2:
+            out.shrinkToFit();
+            break;
+
+          default:
+            break;
+        }
+
+        // Explicitly ask if the `std::set` matches the roaring bitmap in out
+        //
+        assert_true(out.does_std_set_match_roaring());
+
+        // Do some arbitrary query operations.  No need to test the results, as
+        // the doublecheck code ensures the `std::set` matches internally.
+        //
+        out.isEmpty();
+        out.minimum();
+        out.maximum();
+        out.contains(rand());
+        out.containsRange(rand(), rand());
+        for (int i = -50; i < 50; ++i) {
+            out.contains(gravity + i);
+            out.containsRange(gravity + i, rand() % 25);
+        }
+
+        // When doing random intersections, the tendency is that sets will
+        // lose all their data points over time.  So empty sets are usually
+        // re-seeded with more data, but a few get through to test empty cases.
+        //
+        if (out.isEmpty() && (rand() % 10 != 0))
+            out = make_random_bitset();
+    }
+}
+
+
+int main() {
+    gravity = rand() % 10000;  // starting focal point
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(sanity_check_doublechecking),
+        cmocka_unit_test(random_doublecheck_test)};
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/roaring_checked.hh
+++ b/tests/roaring_checked.hh
@@ -1,0 +1,618 @@
+//
+// roaring_checked.hh
+//
+// PURPOSE:
+//
+// This file implements a class which maintains a `class Roaring` bitset in
+// sync with a C++ `std::set` of 32-bit integers.  It asserts if it ever
+// notices a difference between the result the roaring bitset gives and the
+// result that the set would give.
+//
+// The doublechecked class is a drop-in replacement for the plain C++ class.
+// Hence any codebase that uses that class could act as a test...if it wished.
+//
+// USAGE:
+//
+// The checked class has the same name (Roaring) in `namespace doublechecked`.
+// So switching between versions could be done easily with a command-line
+// `-D` setting for a #define, e.g.:
+//
+//     #ifdef ROARING_DOUBLECHECK_CPP
+//         #include "roaring_checked.hh"
+//         using doublechecked::Roaring;
+//     #else
+//         #include "roaring.hh"
+//     #endif
+//
+// NOTES:
+//
+// * The algorithms available in `<algorithm>` don't generally support in-place
+//   operations, and many (like `std::set_intersection`) weren't added until
+//   C++17.  For these two reasons, many are re-implemented here.
+//
+
+#ifndef INCLUDE_ROARING_CHECKED_HH_
+#define INCLUDE_ROARING_CHECKED_HH_
+
+#include <stdarg.h>
+
+#include <algorithm>
+#include <new>
+#include <stdexcept>
+#include <string>
+
+#include <set>  // sorted set, typically a red-black tree implementation
+#include <assert.h>
+
+#define ROARING_CPP_NAMESPACE unchecked  // can't be overridden if global
+#include "roaring.hh"  // contains Roaring unchecked class
+
+namespace doublechecked {  // put the checked class in its own namespace
+
+class Roaring {
+  public:  // members public to allow tests access to them
+    roaring::Roaring plain;  // ordinary Roaring bitset wrapper class
+    std::set<uint32_t> check;  // contents kept in sync with `plain`
+
+  public:
+    Roaring() : plain() {
+    }
+
+    Roaring(size_t n, const uint32_t *data) : plain (n, data) {
+        for (size_t i = 0; i < n; ++i)
+            check.insert(data[i]);
+    }
+
+    Roaring(const Roaring &r) {
+        plain = r.plain;
+        check = r.check;
+    }
+
+    Roaring(Roaring &&r) noexcept {
+        plain = std::move(r.plain);
+        check = std::move(r.check);
+    }
+
+    Roaring(roaring::api::roaring_bitmap_t *s) noexcept : plain (s) {
+        for (auto value : plain)
+            check.insert(value);
+    }
+
+    // This constructor is unique to doublecheck::Roaring(), for making a
+    // doublechecked version from an unchecked version.  Note that this alone
+    // is somewhat toothless for checking...e.g. running an operation and then
+    // accepting that all the values in it were correct doesn't do much.  So
+    // the results of such constructions should be validated another way.
+    //
+    Roaring(roaring::Roaring &&other_plain) {
+        plain = std::move(other_plain);
+        for (auto value : plain)
+            check.insert(value);
+    }
+
+    // Note: This does not call `::Roaring::bitmapOf()` because variadics can't
+    // forward their parameters.  But this is all the code does, so it's fine.
+    //
+    static Roaring bitmapOf(size_t n, ...) {
+        doublechecked::Roaring ans;
+        va_list vl;
+        va_start(vl, n);
+        for (size_t i = 0; i < n; i++) {
+            ans.add(va_arg(vl, uint32_t));
+        }
+        va_end(vl);
+        return ans;
+    }
+
+    void add(uint32_t x) {
+        plain.add(x);
+        check.insert(x);
+    }
+
+    bool addChecked(uint32_t x) {
+        bool ans = plain.addChecked(x);
+        bool was_in_set = check.insert(x).second;  // insert -> pair<iter,bool>
+        assert(ans == was_in_set);
+        (void)was_in_set;  // unused besides assert
+        return ans;
+    }
+
+    void addRange(const uint64_t x, const uint64_t y)  {
+        plain.addRange(x, y);
+        if (x != y) {  // repeat add_range_closed() cast and bounding logic
+            uint32_t min = static_cast<uint32_t>(x);
+            uint32_t max = static_cast<uint32_t>(y - 1);
+            if (min <= max) {
+                for (uint32_t val = max; val != min - 1; --val)
+                    check.insert(val);
+            }
+        }
+    }
+
+    void addMany(size_t n_args, const uint32_t *vals) {
+        plain.addMany(n_args, vals);
+        for (size_t i = 0; i < n_args; ++i)
+            check.insert(vals[i]);
+    }
+
+    void remove(uint32_t x) {
+        plain.remove(x);
+        check.erase(x);
+    }
+
+    bool removeChecked(uint32_t x) {
+        bool ans = plain.removeChecked(x);
+        size_t num_removed = check.erase(x);
+        assert(ans == (num_removed == 1));
+        (void)num_removed;  // unused besides assert
+        return ans;
+    }
+
+    uint32_t maximum() const {
+        uint32_t ans = plain.maximum();
+        assert(check.empty() ? ans == 0 : ans == *check.rbegin());
+        return ans;
+    }
+
+    uint32_t minimum() const {
+        uint32_t ans = plain.minimum();
+        assert(check.empty() ? ans == UINT32_MAX : ans == *check.begin());
+        return ans;
+    }
+
+    bool contains(uint32_t x) const {
+        bool ans = plain.contains(x);
+        assert(ans == (check.find(x) != check.end()));
+        return ans;
+    }
+
+    bool containsRange(const uint64_t x, const uint64_t y) const {
+        bool ans = plain.containsRange(x, y);
+ 
+        auto it = check.find(x);
+        if (x >= y)
+            assert(ans == true);  // roaring says true for this
+        else if (it == check.end())
+            assert(ans == false);  // start of range not in set
+        else {
+            uint64_t last = x;  // iterate up to y so long as values sequential
+            while (++it != check.end() && last + 1 == *it && *it < y)
+                last = *it;
+            assert(ans == (last == y - 1));
+        }
+
+        return ans;
+    }
+
+    // This method is exclusive to `doublechecked::Roaring`
+    //
+    bool does_std_set_match_roaring() const {
+        auto it_check = check.begin();
+        auto it_check_end = check.end();
+        auto it_plain = plain.begin();
+        auto it_plain_end = plain.end();
+
+        for (; it_check != it_check_end; ++it_check, ++it_plain) {
+            if (it_plain == it_plain_end)
+                return false;
+            if (*it_check != *it_plain)
+                return false;
+        }
+        return it_plain == plain.end();  // should have visited all values
+    }
+
+    ~Roaring() {
+        assert(does_std_set_match_roaring());  // always check on destructor
+    }
+
+    Roaring &operator=(const Roaring &r) {
+        plain = r.plain;
+        check = r.check;
+        return *this;
+    }
+
+    Roaring &operator=(Roaring &&r) noexcept {
+        plain = std::move(r.plain);
+        check = std::move(r.check);
+        return *this;
+    }
+
+    Roaring &operator&=(const Roaring &r) {
+        plain &= r.plain;
+
+        auto it = check.begin();
+        auto r_it = r.check.begin();
+        while (it != check.end() && r_it != r.check.end()) {
+            if (*it < *r_it) { it = check.erase(it); }
+            else if (*r_it < *it) { ++r_it; }
+            else { ++it; ++r_it; }  // overlapped
+        }
+        check.erase(it, check.end());  // erase rest of check not in r.check
+
+        return *this;
+    }
+
+    Roaring &operator-=(const Roaring &r) {
+        plain -= r.plain;
+
+        for (auto value : r.check)
+            check.erase(value);  // Note std::remove() is not for ordered sets
+    
+        return *this;
+    }
+
+    Roaring &operator|=(const Roaring &r) {
+        plain |= r.plain;
+
+        check.insert(r.check.begin(), r.check.end());  // won't add duplicates
+
+        return *this;
+    }
+
+    Roaring &operator^=(const Roaring &r) {
+        plain ^= r.plain;
+
+        auto it = check.begin();
+        auto it_end = check.end();
+        auto r_it = r.check.begin();
+        auto r_it_end = r.check.end();
+        if (it == it_end) { check = r.check; }  // this empty
+        else if (r_it == r_it_end) { }  // r empty
+        else if (*it > *r.check.rbegin() || *r_it > *check.rbegin()) {
+            check.insert(r.check.begin(), r.check.end());  // obvious disjoint
+        } else while (r_it != r_it_end) {  // may overlap
+            if (it == it_end) { check.insert(*r_it); ++r_it; }
+            else if (*it == *r_it) {  // remove overlapping value
+                it = check.erase(it);  // returns *following* iterator
+                ++r_it;
+            }
+            else if (*it < *r_it) { ++it; }  // keep value from this
+            else { check.insert(*r_it); ++r_it; }  // add value from r
+        }
+
+        return *this;
+    }
+
+    void swap(Roaring &r) {
+        std::swap(r.plain, plain);
+        std::swap(r.check, check);
+    }
+
+    uint64_t cardinality() const {
+        uint64_t ans = plain.cardinality();
+        assert(ans == check.size());
+        return ans;
+    }
+
+    bool isEmpty() const {
+        bool ans = plain.isEmpty();
+        assert(ans == check.empty());
+        return ans;
+    }
+
+    bool isSubset(const Roaring &r) const {  // is `this` subset of `r`?
+        bool ans = plain.isSubset(r.plain);
+        assert(ans == std::includes(
+            r.check.begin(), r.check.end(),  // containing range
+            check.begin(), check.end()  // range to test for containment
+        ));
+        return ans;
+    }
+
+    bool isStrictSubset(const Roaring &r) const {  // is `this` subset of `r`?
+        bool ans = plain.isStrictSubset(r.plain);
+        assert(ans == (std::includes(
+            r.check.begin(), r.check.end(),  // containing range
+            check.begin(), check.end()  // range to test for containment
+        ) && r.check.size() > check.size()));
+        return ans;
+    }
+
+    void toUint32Array(uint32_t *ans) const {
+        plain.toUint32Array(ans);
+        // TBD: doublecheck
+    }
+
+    void rangeUint32Array(uint32_t *ans, size_t offset, size_t limit) const {
+        plain.rangeUint32Array(ans, offset, limit);
+        // TBD: doublecheck
+    }
+
+    bool operator==(const Roaring &r) const {
+        bool ans = (plain == r.plain);
+        assert(ans == (check == r.check));
+        return ans;
+    }
+
+    void flip(uint64_t range_start, uint64_t range_end) {
+        plain.flip(range_start, range_end);
+  
+        if (range_start < range_end) {
+            if (range_end >= UINT64_C(0x100000000))
+                range_end = UINT64_C(0x100000000);
+            auto hint = check.lower_bound(range_start);  // *hint stays as >= i
+            auto it_end = check.end();
+            for (uint64_t i = range_start; i < range_end; ++i) {
+                if (hint == it_end || *hint > i)  // i not present, so add
+                    check.insert(hint, i);  // leave hint past i
+                else  // *hint == i, must adjust hint and erase
+                    hint = check.erase(hint);  // returns *following* iterator
+            }
+        }
+    }
+
+    bool removeRunCompression() {
+        return plain.removeRunCompression();
+    }
+
+    bool runOptimize() {
+        return plain.runOptimize();
+    }
+
+    size_t shrinkToFit() {
+        return plain.shrinkToFit();
+    }
+
+    void iterate(roaring::api::roaring_iterator iterator, void *ptr) const {
+        plain.iterate(iterator, ptr);
+        assert(does_std_set_match_roaring());  // checks equivalent iteration
+    }
+
+    bool select(uint32_t rnk, uint32_t *element) const {
+        bool ans = plain.select(rnk, element);
+
+        auto it = check.begin();
+        auto it_end = check.end();
+        for (uint32_t i = 0; it != it_end && i < rnk; ++i)
+            ++it;
+        assert(ans == (it != it_end) && (ans ? *it == *element : true));
+
+        return ans;
+    }
+
+    uint64_t and_cardinality(const Roaring &r) const {
+        uint64_t ans = plain.and_cardinality(r.plain);
+
+        auto it = check.begin();
+        auto it_end = check.end();
+        auto r_it = r.check.begin();
+        auto r_it_end = r.check.end();
+        if (it == it_end || r_it == r_it_end) {
+            assert(ans == 0);  // if either is empty then no intersection
+        } else if (*it > *r.check.rbegin() || *r_it > *check.rbegin()) {
+            assert(ans == 0);  // obvious disjoint
+        } else {  // may overlap
+            uint64_t count = 0;
+            while (it != it_end && r_it != r_it_end) {
+                if (*it == *r_it) { ++count; ++it; ++r_it; }  // count overlap
+                else if (*it < *r_it) { ++it; }
+                else { ++r_it; }
+            }
+            assert(ans == count);
+        }
+
+        return ans;
+    }
+
+    bool intersect(const Roaring &r) const {
+    	  bool ans = plain.intersect(r.plain);
+
+        auto it = check.begin();
+        auto it_end = check.end();
+        auto r_it = r.check.begin();
+        auto r_it_end = r.check.end();
+        if (it == it_end || r_it == r_it_end) {
+            assert(ans == false);  // if either are empty, no intersection
+        } else if (*it > *r.check.rbegin() || *r_it > *check.rbegin()) {
+            assert(ans == false);  // obvious disjoint
+        } else while (it != it_end && r_it != r_it_end) {  // may overlap
+            if (*it == *r_it) { assert(ans == true); goto done; }  // overlap
+            else if (*it < *r_it) { ++it; }
+            else { ++r_it; }
+        }
+        assert(ans == false);
+
+      done:  // (could use lambda vs goto, but debug step in lambdas is poor)
+         return ans;
+    }
+
+    double jaccard_index(const Roaring &r) const {
+        double ans = plain.jaccard_index(r.plain);
+        // TBD: doublecheck
+        return ans;
+    }
+
+    uint64_t or_cardinality(const Roaring &r) const {
+        uint64_t ans = plain.or_cardinality(r.plain);
+    
+        auto it = check.begin();
+        auto it_end = check.end();
+        auto r_it = r.check.begin();
+        auto r_it_end = r.check.end();
+        if (it == it_end) { assert(ans == r.check.size()); }  // this empty
+        else if (r_it == r_it_end) { assert(ans == check.size()); }  // r empty
+        else if (*it > *r.check.rbegin() || *r_it > *check.rbegin()) {
+            assert(ans == check.size() + r.check.size());  // obvious disjoint
+        } else {
+            uint64_t count = 0;
+            while (it != it_end || r_it != r_it_end) {
+                ++count;  // note matching case counts once but bumps both
+                if (it == it_end) { ++r_it; }
+                else if (r_it == r_it_end) { ++it; }
+                else if (*it == *r_it) { ++it; ++r_it; }  // matching case
+                else if (*it < *r_it) { ++it; }
+                else { ++r_it; }
+            }
+            assert(ans == count);
+        }
+
+        return ans;
+    }
+
+    uint64_t andnot_cardinality(const Roaring &r) const {
+        uint64_t ans = plain.andnot_cardinality(r.plain);
+
+        auto it = check.begin();
+        auto it_end = check.end();
+        auto r_it = r.check.begin();
+        auto r_it_end = r.check.end();
+        if (it == it_end) { assert(ans == 0); }  // this empty
+        else if (r_it == r_it_end) { assert(ans == check.size()); }  // r empty
+        else if (*it > *r.check.rbegin() || *r_it > *check.rbegin()) {
+            assert(ans == check.size());  // disjoint so nothing removed
+        } else {  // may overlap
+            uint64_t count = check.size();  // start with cardinality of this
+            while (it != it_end && r_it != r_it_end) {
+                if (*it == *r_it) { --count; ++it; ++r_it; }  // remove overlap
+                else if (*it < *r_it) { ++it; }
+                else { ++r_it; }
+            }
+            assert(ans == count);
+        }
+
+        return ans;
+    }
+
+    uint64_t xor_cardinality(const Roaring &r) const {
+        uint64_t ans = plain.xor_cardinality(r.plain);
+  
+        auto it = check.begin();
+        auto it_end = check.end();
+        auto r_it = r.check.begin();
+        auto r_it_end = r.check.end();
+        if (it == it_end) { assert(ans == r.check.size()); }  // this empty
+        else if (r_it == r_it_end) { assert(ans == check.size()); }  // r empty
+        else if (*it > *r.check.rbegin() || *r_it > *check.rbegin()) {
+            assert(ans == check.size() + r.check.size());  // obvious disjoint
+        } else {  // may overlap
+            uint64_t count = 0;
+            while (it != it_end || r_it != r_it_end) {
+                if (it == it_end) { ++count; ++r_it; }
+                else if (r_it == r_it_end) { ++count; ++it; }
+                else if (*it == *r_it) { ++it; ++r_it; }  // overlap uncounted
+                else if (*it < *r_it) { ++count; ++it; }
+                else { ++count; ++r_it; }
+            }
+            assert(ans == count);
+        }
+ 
+        return ans;
+    }
+
+    uint64_t rank(uint32_t x) const {
+        uint64_t ans = plain.rank(x);
+ 
+        uint64_t count = 0;
+        auto it = check.begin();
+        auto it_end = check.end();
+        for (; it != it_end && *it <= x; ++it)
+            ++count;
+        assert(ans == count);
+ 
+        return ans;
+    }
+
+    size_t write(char *buf, bool portable = true) const {
+        return plain.write(buf, portable);
+    }
+
+    static Roaring read(const char *buf, bool portable = true) {
+        auto plain = roaring::Roaring::read(buf, portable);
+        return Roaring(std::move(plain));
+    }
+
+    static Roaring readSafe(const char *buf, size_t maxbytes) {
+        auto plain = roaring::Roaring::readSafe(buf, maxbytes);
+        return Roaring(std::move(plain));
+    }
+
+    size_t getSizeInBytes(bool portable = true) const {
+        return plain.getSizeInBytes(portable);
+    }
+
+    Roaring operator&(const Roaring &o) const {
+        Roaring ans(plain & o.plain);
+    
+        Roaring inplace(*this);
+        assert(ans == (inplace &= o));  // validate against in-place version
+
+        return ans;
+    }
+
+    Roaring operator-(const Roaring &o) const {
+        Roaring ans(plain - o.plain);
+
+        Roaring inplace(*this);
+        assert(ans == (inplace -= o));  // validate against in-place version
+
+        return ans;
+    }
+
+    Roaring operator|(const Roaring &o) const {
+        Roaring ans(plain | o.plain);
+
+        Roaring inplace(*this);
+        assert(ans == (inplace |= o));  // validate against in-place version
+
+        return ans;
+    }
+
+    Roaring operator^(const Roaring &o) const {
+        Roaring ans(plain ^ o.plain);
+
+        Roaring inplace(*this);
+        assert(ans == (inplace ^= o));  // validate against in-place version
+
+        return ans;
+    }
+
+    void setCopyOnWrite(bool val) {
+        plain.setCopyOnWrite(val);
+    }
+
+    void printf() const {
+        plain.printf();
+    }
+
+    std::string toString() const {
+        return plain.toString();
+    }
+
+    bool getCopyOnWrite() const {
+        return plain.getCopyOnWrite();
+    }
+
+    static Roaring fastunion(size_t n, const Roaring **inputs) {
+        auto plain_inputs = new const roaring::Roaring*[n];
+        for (size_t i = 0; i < n; ++i)
+            plain_inputs[i] = &inputs[i]->plain;
+        Roaring ans(roaring::Roaring::fastunion(n, plain_inputs));
+        delete[] plain_inputs;
+
+        if (n == 0)
+            assert(ans.cardinality() == 0);
+        else {
+            Roaring temp = *inputs[0];
+            for (size_t i = 1; i < n; ++i)
+                temp |= *inputs[i];
+            assert(temp == ans);
+        }
+
+        return ans;
+    }
+
+    typedef roaring::RoaringSetBitForwardIterator const_iterator;
+
+    const_iterator begin() const {
+        return roaring::RoaringSetBitForwardIterator(plain);
+    }
+
+    const_iterator &end() const {
+        static roaring::RoaringSetBitForwardIterator e(plain, true);
+        return e;
+    }
+};
+
+}  // end `namespace doublechecked`
+
+#endif  // INCLUDE_ROARING_CHECKED_HH_


### PR DESCRIPTION
Adds code to the Roaring C++ class under #ifdef ROARING_DOUBLECHECK_CPP
which maintains a parallel state to the roaring bitmap in a `std::set`.
This code is stripped out via amalgamation.sh for a release roaring.hh

Having the code in the main class means that any codebase that uses the
C++ object can leverage the tests, so this isn't exercising a distinct
object which was created solely for testing.  It also increases the
likelihood of attention to the checks during code maintenance.

Since std::set stays sorted, the algorithms are not terribly difficult
to have written using iterators.  Though it may not be worth it vs.
using higher level facilities like `set_intersection()` that would
create temporary objects.

The corresponding std::set algorithms are implemented for the inplace
forms of the API only.  The non-inplace operators are then validated
against the inplace forms, to avoid writing the C++ code twice.

Included is a starting concept for a fuzzing unit test that uses the
ROARING_DOUBLECHECK_CPP setting.  This is how #247 was found.

The topic of fuzz testing has previously been mentioned in #122.