### PR TITLE
Make C files build w/C++ compiler, cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 option(ROARING_BUILD_STATIC "Build a static library" OFF) # turning it on disables the production of a dynamic library
 option(ROARING_LINK_STATIC "Link executables (tests, benchmarks) statically" OFF)
 option(ROARING_BUILD_LTO "Build library with Link Time Optimization" OFF)
+option(ROARING_BUILD_C_AS_CPP "Build library C files using C++ compilation" OFF)
 option(ROARING_SANITIZE "Sanitize addresses" OFF)
 option(ENABLE_ROARING_TESTS "If OFF, disable unit tests altogether" ON)
 

--- a/include/roaring/array_util.h
+++ b/include/roaring/array_util.h
@@ -6,6 +6,10 @@
 
 #include <roaring/portability.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  *  Good old binary search.
  *  Assumes that array is sorted, has logarithmic complexity.
@@ -232,5 +236,9 @@ size_t fast_union_uint16(const uint16_t *set_1, size_t size_1, const uint16_t *s
 
 
 bool memequals(const void *s1, const void *s2, size_t n);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -6,6 +6,10 @@
 #include <roaring/portability.h>
 #include <roaring/utilasm.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Set all bits in indexes [begin,end) to true.
  */
@@ -534,5 +538,9 @@ AVXPOPCNTFNC(andnot, _mm256_andnot_si256)
  */
 
 #endif  // USEAVX
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -13,6 +13,10 @@
 #include <roaring/portability.h>
 #include <roaring/roaring_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Containers with DEFAULT_MAX_SIZE or less integers should be arrays */
 enum { DEFAULT_MAX_SIZE = 4096 };
 
@@ -443,5 +447,9 @@ static inline void array_container_remove_range(array_container_t *array,
       array->cardinality -= count;
   }
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_ARRAY_H_ */

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -12,6 +12,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef USEAVX
 #define ALIGN_AVX __attribute__((aligned(sizeof(__m256i))))
 #else
@@ -477,4 +481,9 @@ int bitset_container_rank(const bitset_container_t *container, uint16_t x);
 
 /* Returns the index of the first value equal or larger than x, or -1 */
 int bitset_container_index_equalorlarger(const bitset_container_t *container, uint16_t x);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* INCLUDE_CONTAINERS_BITSET_H_ */

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -18,6 +18,10 @@
 #include <roaring/containers/run.h>
 #include <roaring/bitset_util.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // would enum be possible or better?
 
 /**
@@ -71,7 +75,7 @@ void *shared_container_extract_copy(shared_container_t *container,
                                     uint8_t *typecode);
 
 /* access to container underneath */
-inline const void *container_unwrap_shared(
+static inline const void *container_unwrap_shared(
     const void *candidate_shared_container, uint8_t *type) {
     if (*type == SHARED_CONTAINER_TYPE_CODE) {
         *type =
@@ -85,7 +89,7 @@ inline const void *container_unwrap_shared(
 
 
 /* access to container underneath */
-inline void *container_mutable_unwrap_shared(
+static inline void *container_mutable_unwrap_shared(
     void *candidate_shared_container, uint8_t *type) {
     if (*type == SHARED_CONTAINER_TYPE_CODE) {
         *type =
@@ -543,7 +547,7 @@ static inline void *container_remove(void *container, uint16_t val,
 /**
  * Check whether a value is in a container, requires a  typecode
  */
-inline bool container_contains(const void *container, uint16_t val,
+static inline bool container_contains(const void *container, uint16_t val,
                                uint8_t typecode) {
     container = container_unwrap_shared(container, &typecode);
     switch (typecode) {
@@ -2353,5 +2357,9 @@ static inline void *container_remove_range(void *container, uint8_t type,
             __builtin_unreachable();
      }
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/roaring/containers/convert.h
+++ b/include/roaring/containers/convert.h
@@ -10,6 +10,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Convert an array into a bitset. The input container is not freed or modified.
  */
 bitset_container_t *bitset_container_from_array(const array_container_t *arr);
@@ -55,5 +59,9 @@ void *convert_run_to_efficient_container_and_free(run_container_t *c,
  */
 void *container_from_run_range(const run_container_t *run,
                                                     uint32_t min, uint32_t max, uint8_t *typecode_after);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_CONVERT_H_ */

--- a/include/roaring/containers/mixed_andnot.h
+++ b/include/roaring/containers/mixed_andnot.h
@@ -8,6 +8,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Compute the andnot of src_1 and src_2 and write the result to
  * dst, a valid array container that could be the same as dst.*/
 void array_bitset_container_andnot(const array_container_t *src_1,
@@ -157,4 +161,9 @@ bool bitset_bitset_container_andnot(const bitset_container_t *src_1,
 bool bitset_bitset_container_iandnot(bitset_container_t *src_1,
                                      const bitset_container_t *src_2,
                                      void **dst);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/include/roaring/containers/mixed_equal.h
+++ b/include/roaring/containers/mixed_equal.h
@@ -10,6 +10,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Return true if the two containers have the same content.
  */
@@ -26,5 +30,9 @@ bool run_container_equals_array(const run_container_t* container1,
  */
 bool run_container_equals_bitset(const run_container_t* container1,
                                  const bitset_container_t* container2);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CONTAINERS_MIXED_EQUAL_H_ */

--- a/include/roaring/containers/mixed_intersection.h
+++ b/include/roaring/containers/mixed_intersection.h
@@ -15,6 +15,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Compute the intersection of src_1 and src_2 and write the result to
  * dst. It is allowed for dst to be equal to src_1. We assume that dst is a
  * valid container. */
@@ -87,5 +91,9 @@ bool run_bitset_container_intersect(const run_container_t *src_1,
  */
 bool bitset_bitset_container_intersection_inplace(
     bitset_container_t *src_1, const bitset_container_t *src_2, void **dst);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_INTERSECTION_H_ */

--- a/include/roaring/containers/mixed_negation.h
+++ b/include/roaring/containers/mixed_negation.h
@@ -10,6 +10,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Negation across the entire range of the container.
  * Compute the  negation of src  and write the result
  * to *dst. The complement of a
@@ -119,5 +123,9 @@ int run_container_negation_range(const run_container_t *src,
 int run_container_negation_range_inplace(run_container_t *src,
                                          const int range_start,
                                          const int range_end, void **dst);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_NEGATION_H_ */

--- a/include/roaring/containers/mixed_subset.h
+++ b/include/roaring/containers/mixed_subset.h
@@ -10,6 +10,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Return true if container1 is a subset of container2.
  */
@@ -39,5 +43,9 @@ bool run_container_is_subset_bitset(const run_container_t* container1,
 */
 bool bitset_container_is_subset_run(const bitset_container_t* container1,
                                     const run_container_t* container2);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CONTAINERS_MIXED_SUBSET_H_ */

--- a/include/roaring/containers/mixed_union.h
+++ b/include/roaring/containers/mixed_union.h
@@ -15,6 +15,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Compute the union of src_1 and src_2 and write the result to
  * dst. It is allowed for src_2 to be dst.   */
 void array_bitset_container_union(const array_container_t *src_1,
@@ -98,5 +102,9 @@ void run_bitset_container_union(const run_container_t *src_1,
 void run_bitset_container_lazy_union(const run_container_t *src_1,
                                      const bitset_container_t *src_2,
                                      bitset_container_t *dst);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_UNION_H_ */

--- a/include/roaring/containers/mixed_xor.h
+++ b/include/roaring/containers/mixed_xor.h
@@ -23,6 +23,10 @@
 
 //#include "containers.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Compute the xor of src_1 and src_2 and write the result to
  * dst (which has no container initially).
  * Result is true iff dst is a bitset  */
@@ -151,4 +155,9 @@ bool array_array_container_ixor(array_container_t *src_1,
 
 int run_run_container_ixor(run_container_t *src_1, const run_container_t *src_2,
                            void **dst);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/include/roaring/containers/perfparameters.h
+++ b/include/roaring/containers/perfparameters.h
@@ -3,6 +3,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
 During lazy computations, we can transform array containers into bitset
 containers as
@@ -32,6 +36,10 @@ enum { ARRAY_DEFAULT_INIT_SIZE = 0 };
 /* automatically attempt to convert a bitset to a full run */
 #ifndef OR_BITSET_CONVERSION_TO_FULL
 #define OR_BITSET_CONVERSION_TO_FULL true
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -16,6 +16,10 @@
 #include <roaring/roaring_types.h>
 #include <roaring/array_util.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* struct rle16_s - run length pair
  *
  * @value:  start position of the run
@@ -30,6 +34,14 @@ struct rle16_s {
 };
 
 typedef struct rle16_s rle16_t;
+
+#ifdef __cplusplus
+    #define MAKE_RLE16(val,len) \
+        {(uint16_t)(val), (uint16_t)(len)}  // no tagged structs until c++20
+#else
+    #define MAKE_RLE16(val,len) \
+        (rle16_t){.value = (uint16_t)(val), .length = (uint16_t)(len)}
+#endif
 
 /* struct run_container_s - run container bitmap
  *
@@ -383,10 +395,7 @@ static inline void run_container_append_value(run_container_t *run,
                                               rle16_t *previousrl) {
     const uint32_t previousend = previousrl->value + previousrl->length;
     if (val > previousend + 1) {  // we add a new one
-        //*previousrl = (rle16_t){.value = val, .length = 0};// requires C99
-        previousrl->value = val;
-        previousrl->length = 0;
-
+        *previousrl = MAKE_RLE16(val, 0);
         run->runs[run->n_runs] = *previousrl;
         run->n_runs++;
     } else if (val == previousend + 1) {  // we merge
@@ -401,11 +410,7 @@ static inline void run_container_append_value(run_container_t *run,
  */
 static inline rle16_t run_container_append_value_first(run_container_t *run,
                                                        uint16_t val) {
-    // rle16_t newrle = (rle16_t){.value = val, .length = 0};// requires C99
-    rle16_t newrle;
-    newrle.value = val;
-    newrle.length = 0;
-
+    rle16_t newrle = MAKE_RLE16(val, 0);
     run->runs[run->n_runs] = newrle;
     run->n_runs++;
     return newrle;
@@ -711,5 +716,8 @@ static inline void run_container_remove_range(run_container_t *run, uint32_t min
     }
 }
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_RUN_H_ */

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -27,6 +27,9 @@
 #include <malloc.h>  // this should never be needed but there are some reports that it is needed.
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #if defined(_MSC_VER) && !defined(__clang__) && !defined(_WIN64) && !defined(ROARING_ACK_32BIT)
 #pragma message( \
@@ -241,6 +244,10 @@ static inline int hamming(uint64_t x) {
 
 #ifndef UINT32_C
 #define UINT32_C(c) (c##UL)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* INCLUDE_PORTABILITY_H_ */

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -4,14 +4,15 @@ An implementation of Roaring Bitmaps in C.
 
 #ifndef ROARING_H
 #define ROARING_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <roaring/roaring_array.h>
 #include <roaring/roaring_types.h>
 #include <roaring/roaring_version.h>
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct roaring_bitmap_s {
     roaring_array_t high_low_container;
@@ -48,10 +49,10 @@ roaring_bitmap_t *roaring_bitmap_of_ptr(size_t n_args, const uint32_t *vals);
  * then ensure that you do so for all of your bitmaps since
  * interactions between bitmaps with and without COW is unsafe.
  */
-inline bool roaring_bitmap_get_copy_on_write(const roaring_bitmap_t* r) {
+static inline bool roaring_bitmap_get_copy_on_write(const roaring_bitmap_t* r) {
     return r->high_low_container.flags & ROARING_FLAG_COW;
 }
-inline void roaring_bitmap_set_copy_on_write(roaring_bitmap_t* r, bool cow) {
+static inline void roaring_bitmap_set_copy_on_write(roaring_bitmap_t* r, bool cow) {
     if (cow) {
         r->high_low_container.flags |= ROARING_FLAG_COW;
     } else {
@@ -271,7 +272,7 @@ void roaring_bitmap_add_range_closed(roaring_bitmap_t *ra, uint32_t min, uint32_
 /**
  * Add all values in range [min, max)
  */
-inline void roaring_bitmap_add_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
+static inline void roaring_bitmap_add_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
   if(max == min) return;
   roaring_bitmap_add_range_closed(ra, (uint32_t)min, (uint32_t)(max - 1));
 }
@@ -286,7 +287,7 @@ void roaring_bitmap_remove(roaring_bitmap_t *r, uint32_t x);
 void roaring_bitmap_remove_range_closed(roaring_bitmap_t *ra, uint32_t min, uint32_t max);
 
 /** Remove all values in range [min, max) */
-inline void roaring_bitmap_remove_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
+static inline void roaring_bitmap_remove_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
     if(max == min) return;
     roaring_bitmap_remove_range_closed(ra, (uint32_t)min, (uint32_t)(max - 1));
 }
@@ -304,7 +305,7 @@ bool roaring_bitmap_remove_checked(roaring_bitmap_t *r, uint32_t x);
 /**
  * Check if value x is present
  */
-inline bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val) {
+static inline bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val) {
     const uint16_t hb = val >> 16;
     /*
      * the next function call involves a binary search and lots of branching.

--- a/include/roaring/roaring_array.h
+++ b/include/roaring/roaring_array.h
@@ -1,14 +1,15 @@
 #ifndef INCLUDE_ROARING_ARRAY_H
 #define INCLUDE_ROARING_ARRAY_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <assert.h>
 #include <roaring/array_util.h>
 #include <roaring/containers/containers.h>
 #include <stdbool.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define MAX_CONTAINERS 65536
 

--- a/include/roaring/roaring_types.h
+++ b/include/roaring/roaring_types.h
@@ -5,6 +5,10 @@
 #ifndef ROARING_TYPES_H
 #define ROARING_TYPES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef bool (*roaring_iterator)(uint32_t value, void *param);
 typedef bool (*roaring_iterator64)(uint64_t value, void *param);
 
@@ -44,5 +48,9 @@ typedef struct roaring_statistics_s {
 
     // and n_values_arrays, n_values_rle, n_values_bitmap
 } roaring_statistics_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ROARING_TYPES_H */

--- a/include/roaring/utilasm.h
+++ b/include/roaring/utilasm.h
@@ -8,6 +8,10 @@
 
 #include <roaring/portability.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(USE_BMI) & defined(ROARING_INLINE_ASM)
 #define ASMBITMANIPOPTIMIZATION  // optimization flag
 
@@ -66,4 +70,9 @@
         )
 
 #endif  // USE_BMI
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* INCLUDE_UTILASM_H_ */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,10 @@ set(ROARING_SRC
     roaring_priority_queue.c
     roaring_array.c)
 
+if(ROARING_BUILD_C_AS_CPP)  # more checks and tools, e.g. <type_traits> analysis 
+  SET_SOURCE_FILES_PROPERTIES(${ROARING_SRC} PROPERTIES LANGUAGE CXX)
+endif()
+
 add_library(${ROARING_LIB_NAME} ${ROARING_LIB_TYPE} ${ROARING_SRC})
 target_include_directories(${ROARING_LIB_NAME}
   PUBLIC

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -92,8 +92,6 @@ extern inline void *container_add(void *container, uint16_t val, uint8_t typecod
 extern inline bool container_contains(const void *container, uint16_t val,
                                       uint8_t typecode);
 
-extern inline void *container_clone(const void *container, uint8_t typecode);
-
 extern inline void *container_and(const void *c1, uint8_t type1, const void *c2,
                            uint8_t type2, uint8_t *result_type);
 

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -290,8 +290,7 @@ int run_array_container_andnot(const run_container_t *src_1,
             if (end <= xstart) {
                 // output the first run
                 answer->runs[answer->n_runs++] =
-                    (rle16_t){.value = (uint16_t)start,
-                              .length = (uint16_t)(end - start - 1)};
+                    MAKE_RLE16(start, end - start - 1);
                 rlepos++;
                 if (rlepos < src_1->n_runs) {
                     start = src_1->runs[rlepos].value;
@@ -306,8 +305,7 @@ int run_array_container_andnot(const run_container_t *src_1,
             } else {
                 if (start < xstart) {
                     answer->runs[answer->n_runs++] =
-                        (rle16_t){.value = (uint16_t)start,
-                                  .length = (uint16_t)(xstart - start - 1)};
+                        MAKE_RLE16(start, xstart - start - 1);
                 }
                 if (xstart + 1 < end) {
                     start = xstart + 1;
@@ -321,9 +319,7 @@ int run_array_container_andnot(const run_container_t *src_1,
             }
         }
         if (rlepos < src_1->n_runs) {
-            answer->runs[answer->n_runs++] =
-                (rle16_t){.value = (uint16_t)start,
-                          .length = (uint16_t)(end - start - 1)};
+            answer->runs[answer->n_runs++] = MAKE_RLE16(start, end - start - 1);
             rlepos++;
             if (rlepos < src_1->n_runs) {
                 memcpy(answer->runs + answer->n_runs, src_1->runs + rlepos,

--- a/src/containers/mixed_negation.c
+++ b/src/containers/mixed_negation.c
@@ -311,7 +311,7 @@ int run_container_negation_range_inplace(run_container_t *src,
     }
 
     // as with Java implementation, use locals to give self a buffer of depth 1
-    rle16_t buffered = (rle16_t){.value = (uint16_t)0, .length = (uint16_t)0};
+    rle16_t buffered = MAKE_RLE16(0, 0);
     rle16_t next = buffered;
     if (k < my_nbr_runs) buffered = src->runs[k];
 

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -522,9 +522,7 @@ void run_container_andnot(const run_container_t *src_1,
     while ((rlepos1 < src_1->n_runs) && (rlepos2 < src_2->n_runs)) {
         if (end <= start2) {
             // output the first run
-            dst->runs[dst->n_runs++] =
-                (rle16_t){.value = (uint16_t)start,
-                          .length = (uint16_t)(end - start - 1)};
+            dst->runs[dst->n_runs++] = MAKE_RLE16(start, end - start - 1);
             rlepos1++;
             if (rlepos1 < src_1->n_runs) {
                 start = src_1->runs[rlepos1].value;
@@ -540,8 +538,7 @@ void run_container_andnot(const run_container_t *src_1,
         } else {
             if (start < start2) {
                 dst->runs[dst->n_runs++] =
-                    (rle16_t){.value = (uint16_t)start,
-                              .length = (uint16_t)(start2 - start - 1)};
+                    MAKE_RLE16(start, start2 - start - 1);
             }
             if (end2 < end) {
                 start = end2;
@@ -555,8 +552,7 @@ void run_container_andnot(const run_container_t *src_1,
         }
     }
     if (rlepos1 < src_1->n_runs) {
-        dst->runs[dst->n_runs++] = (rle16_t){
-            .value = (uint16_t)start, .length = (uint16_t)(end - start - 1)};
+        dst->runs[dst->n_runs++] = MAKE_RLE16(start, end - start - 1);
         rlepos1++;
         if (rlepos1 < src_1->n_runs) {
             memcpy(dst->runs + dst->n_runs, src_1->runs + rlepos1,
@@ -702,7 +698,7 @@ void run_container_smart_append_exclusive(run_container_t *src,
 
     if (!src->n_runs ||
         (start > (old_end = last_run->value + last_run->length + 1))) {
-        *appended_last_run = (rle16_t){.value = start, .length = length};
+        *appended_last_run = MAKE_RLE16(start, length);
         src->n_runs++;
         return;
     }
@@ -716,12 +712,10 @@ void run_container_smart_append_exclusive(run_container_t *src,
     if (start == last_run->value) {
         // wipe out previous
         if (new_end < old_end) {
-            *last_run = (rle16_t){.value = (uint16_t)new_end,
-                                  .length = (uint16_t)(old_end - new_end - 1)};
+            *last_run = MAKE_RLE16(new_end, old_end - new_end - 1);
             return;
         } else if (new_end > old_end) {
-            *last_run = (rle16_t){.value = (uint16_t)old_end,
-                                  .length = (uint16_t)(new_end - old_end - 1)};
+            *last_run = MAKE_RLE16(old_end, new_end - old_end - 1);
             return;
         } else {
             src->n_runs--;
@@ -730,14 +724,10 @@ void run_container_smart_append_exclusive(run_container_t *src,
     }
     last_run->length = start - last_run->value - 1;
     if (new_end < old_end) {
-        *appended_last_run =
-            (rle16_t){.value = (uint16_t)new_end,
-                      .length = (uint16_t)(old_end - new_end - 1)};
+        *appended_last_run = MAKE_RLE16(new_end, old_end - new_end - 1);
         src->n_runs++;
     } else if (new_end > old_end) {
-        *appended_last_run =
-            (rle16_t){.value = (uint16_t)old_end,
-                      .length = (uint16_t)(new_end - old_end - 1)};
+        *appended_last_run = MAKE_RLE16(old_end, new_end - old_end - 1);
         src->n_runs++;
     }
 }

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2566,7 +2566,7 @@ bool roaring_bitmap_intersect(const roaring_bitmap_t *x1,
             pos2 = ra_advance_until(& x2->high_low_container, s1, pos2);
         }
     }
-    return answer;
+    return answer != 0;
 }
 
 

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -1597,7 +1597,7 @@ static int run_negation_range_tests(int k, int h, int start_offset, int r_start,
             // run_container_append does not dynamically increase its
             // array
             run_container_append_first(
-                RI, (rle16_t){.value = offsetx, .length = actual_runlen - 1});
+                RI, MAKE_RLE16(offsetx, actual_runlen - 1));
             card += actual_runlen;
             if (++runlen == k) runlen = h;  // wrap after k-1 back to h.
         }
@@ -1678,7 +1678,7 @@ static int run_negation_range_tests_simpler(int k, int h, int start_offset,
                 actual_runlen = (1 << 16) - offsetx;
 
             run_container_append_first(
-                RI, (rle16_t){.value = offsetx, .length = actual_runlen - 1});
+                RI, MAKE_RLE16(offsetx, actual_runlen));
             card += actual_runlen;
             if (++runlen == k) runlen = h;
         }


### PR DESCRIPTION
The Roaring sources *nearly* built with C++.  The only barriers were
some inconsistencies in `inline` vs `static inline`...and use of tagged
structure initialization for making `rle16_t` pairs.

This adds a MAKE_RLE16() macro that uses tags in C, but leaves them off
in C++.  Using the macro makes the callsites more readable, and
consistent.

`extern "C" {...}` brackets the *contents* of headers.  Cases where it
spanned inclusion of other headers (like `<assert.h>` or `<stdbool.h`)
are fixed.  Having all the headers compliant with extern "C" permits
things like C++ test code to be able to reach in at any level of
implementation (e.g. to do a comparison of the behavior of a low-level
container against standard C++ library types like `std::set`).

A new CMake option ROARING_BUILD_C_AS_CPP is added.  This instructs
it to treat the files in the library itself that end in `.c` as if
they were C++.  Being able to use a C++ compiler to build C codebases
is a useful test for catching certain errors--and it also offers a
rich set of static analysis capabilities (e.g. with `<type_traits>`)