### PR TITLE
Add C++ Namespaces (retry to trigger Appveyor)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 option(ROARING_BUILD_STATIC "Build a static library" OFF) # turning it on disables the production of a dynamic library
 option(ROARING_LINK_STATIC "Link executables (tests, benchmarks) statically" OFF)
 option(ROARING_BUILD_LTO "Build library with Link Time Optimization" OFF)
+option(ROARING_BUILD_C_AS_CPP "Build library C files using C++ compilation" OFF)
 option(ROARING_SANITIZE "Sanitize addresses" OFF)
 option(ENABLE_ROARING_TESTS "If OFF, disable unit tests altogether" ON)
 

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -6,11 +6,14 @@ A C++ header for Roaring Bitmaps.
 
 #include <stdarg.h>
 
-#include <roaring/roaring.h>
 #include <algorithm>
 #include <new>
 #include <stdexcept>
 #include <string>
+
+#include <roaring/roaring.h>
+
+namespace roaring {
 
 class RoaringSetBitForwardIterator;
 
@@ -731,5 +734,7 @@ inline RoaringSetBitForwardIterator &Roaring::end() const {
     static RoaringSetBitForwardIterator e(*this, true);
     return e;
 }
+
+}  // namespace roaring
 
 #endif /* INCLUDE_ROARING_HH_ */

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -23,28 +23,28 @@ class Roaring {
      * Create an empty bitmap
      */
     Roaring() {
-        ra_init(&roaring.high_low_container);
+        internal::ra_init(&roaring.high_low_container);
     }
 
     /**
      * Construct a bitmap from a list of integer values.
      */
     Roaring(size_t n, const uint32_t *data) : Roaring() {
-        roaring_bitmap_add_many(&roaring, n, data);
+        api::roaring_bitmap_add_many(&roaring, n, data);
     }
 
     /**
      * Copy constructor
      */
     Roaring(const Roaring &r) {
-        bool is_ok =
-            ra_copy(&r.roaring.high_low_container, &roaring.high_low_container,
+        bool is_ok = internal::ra_copy(
+            &r.roaring.high_low_container, &roaring.high_low_container,
                     roaring_bitmap_get_copy_on_write(&r.roaring));
         if (!is_ok) {
             throw std::runtime_error("failed memory alloc in constructor");
         }
-        roaring_bitmap_set_copy_on_write(&roaring,
-            roaring_bitmap_get_copy_on_write(&r.roaring));
+        api::roaring_bitmap_set_copy_on_write(&roaring,
+            api::roaring_bitmap_get_copy_on_write(&r.roaring));
     }
 
     /**
@@ -53,7 +53,7 @@ class Roaring {
      */
     Roaring(Roaring &&r) noexcept {
         roaring = std::move(r.roaring);
-        ra_init(&r.roaring.high_low_container);
+        internal::ra_init(&r.roaring.high_low_container);
     }
 
     /**
@@ -87,21 +87,21 @@ class Roaring {
      * Add value x
      *
      */
-    void add(uint32_t x) { roaring_bitmap_add(&roaring, x); }
+    void add(uint32_t x) { api::roaring_bitmap_add(&roaring, x); }
 
     /**
      * Add value x
      * Returns true if a new value was added, false if the value was already existing.
      */
     bool addChecked(uint32_t x) { 
-        return roaring_bitmap_add_checked(&roaring, x);
+        return api::roaring_bitmap_add_checked(&roaring, x);
     }
 
     /**
     * add if all values from x (included) to y (excluded)
     */
     void addRange(const uint64_t x, const uint64_t y)  {
-        return roaring_bitmap_add_range(&roaring, x, y);
+        return api::roaring_bitmap_add_range(&roaring, x, y);
     }
 
     /**
@@ -109,68 +109,68 @@ class Roaring {
      *
      */
     void addMany(size_t n_args, const uint32_t *vals) {
-        roaring_bitmap_add_many(&roaring, n_args, vals);
+        api::roaring_bitmap_add_many(&roaring, n_args, vals);
     }
 
     /**
      * Remove value x
      *
      */
-    void remove(uint32_t x) { roaring_bitmap_remove(&roaring, x); }
+    void remove(uint32_t x) { api::roaring_bitmap_remove(&roaring, x); }
 
     /**
      * Remove value x
      * Returns true if a new value was removed, false if the value was not existing.
      */
     bool removeChecked(uint32_t x) {
-        return roaring_bitmap_remove_checked(&roaring, x);
+        return api::roaring_bitmap_remove_checked(&roaring, x);
     }
 
     /**
      * Return the largest value (if not empty)
      *
      */
-    uint32_t maximum() const { return roaring_bitmap_maximum(&roaring); }
+    uint32_t maximum() const { return api::roaring_bitmap_maximum(&roaring); }
 
     /**
     * Return the smallest value (if not empty)
     *
     */
-    uint32_t minimum() const { return roaring_bitmap_minimum(&roaring); }
+    uint32_t minimum() const { return api::roaring_bitmap_minimum(&roaring); }
 
     /**
      * Check if value x is present
      */
     bool contains(uint32_t x) const {
-        return roaring_bitmap_contains(&roaring, x);
+        return api::roaring_bitmap_contains(&roaring, x);
     }
 
     /**
     * Check if all values from x (included) to y (excluded) are present
     */
     bool containsRange(const uint64_t x, const uint64_t y) const {
-        return roaring_bitmap_contains_range(&roaring, x, y);
+        return api::roaring_bitmap_contains_range(&roaring, x, y);
     }
 
     /**
      * Destructor
      */
-    ~Roaring() { ra_clear(&roaring.high_low_container); }
+    ~Roaring() { internal::ra_clear(&roaring.high_low_container); }
 
     /**
      * Copies the content of the provided bitmap, and
      * discard the current content.
      */
     Roaring &operator=(const Roaring &r) {
-        ra_clear(&roaring.high_low_container);
-        bool is_ok =
-            ra_copy(&r.roaring.high_low_container, &roaring.high_low_container,
+        internal::ra_clear(&roaring.high_low_container);
+        bool is_ok = internal::ra_copy(
+            &r.roaring.high_low_container, &roaring.high_low_container,
                     roaring_bitmap_get_copy_on_write(&r.roaring));
         if (!is_ok) {
             throw std::runtime_error("failed memory alloc in assignment");
         }
-        roaring_bitmap_set_copy_on_write(&roaring,
-            roaring_bitmap_get_copy_on_write(&r.roaring));
+        api::roaring_bitmap_set_copy_on_write(&roaring,
+            api::roaring_bitmap_get_copy_on_write(&r.roaring));
         return *this;
     }
 
@@ -179,9 +179,9 @@ class Roaring {
      * discard the current content.
      */
     Roaring &operator=(Roaring &&r) noexcept {
-        ra_clear(&roaring.high_low_container);
+        internal::ra_clear(&roaring.high_low_container);
         roaring = std::move(r.roaring);
-        ra_init(&r.roaring.high_low_container);
+        internal::ra_init(&r.roaring.high_low_container);
         return *this;
     }
 
@@ -192,7 +192,7 @@ class Roaring {
      * modified.
      */
     Roaring &operator&=(const Roaring &r) {
-        roaring_bitmap_and_inplace(&roaring, &r.roaring);
+        api::roaring_bitmap_and_inplace(&roaring, &r.roaring);
         return *this;
     }
 
@@ -203,7 +203,7 @@ class Roaring {
      * modified.
      */
     Roaring &operator-=(const Roaring &r) {
-        roaring_bitmap_andnot_inplace(&roaring, &r.roaring);
+        api::roaring_bitmap_andnot_inplace(&roaring, &r.roaring);
         return *this;
     }
 
@@ -215,7 +215,7 @@ class Roaring {
      * See also the fastunion function to aggregate many bitmaps more quickly.
      */
     Roaring &operator|=(const Roaring &r) {
-        roaring_bitmap_or_inplace(&roaring, &r.roaring);
+        api::roaring_bitmap_or_inplace(&roaring, &r.roaring);
         return *this;
     }
 
@@ -226,7 +226,7 @@ class Roaring {
      * modified.
      */
     Roaring &operator^=(const Roaring &r) {
-        roaring_bitmap_xor_inplace(&roaring, &r.roaring);
+        api::roaring_bitmap_xor_inplace(&roaring, &r.roaring);
         return *this;
     }
 
@@ -239,26 +239,26 @@ class Roaring {
      * Get the cardinality of the bitmap (number of elements).
      */
     uint64_t cardinality() const {
-        return roaring_bitmap_get_cardinality(&roaring);
+        return api::roaring_bitmap_get_cardinality(&roaring);
     }
 
     /**
     * Returns true if the bitmap is empty (cardinality is zero).
     */
-    bool isEmpty() const { return roaring_bitmap_is_empty(&roaring); }
+    bool isEmpty() const { return api::roaring_bitmap_is_empty(&roaring); }
 
     /**
     * Returns true if the bitmap is subset of the other.
     */
     bool isSubset(const Roaring &r) const {
-        return roaring_bitmap_is_subset(&roaring, &r.roaring);
+        return api::roaring_bitmap_is_subset(&roaring, &r.roaring);
     }
 
     /**
     * Returns true if the bitmap is strict subset of the other.
     */
     bool isStrictSubset(const Roaring &r) const {
-        return roaring_bitmap_is_strict_subset(&roaring, &r.roaring);
+        return api::roaring_bitmap_is_strict_subset(&roaring, &r.roaring);
     }
 
     /**
@@ -268,21 +268,21 @@ class Roaring {
      * (e.g., ans = new uint32[mybitmap.cardinality()];)
      */
     void toUint32Array(uint32_t *ans) const {
-        roaring_bitmap_to_uint32_array(&roaring, ans);
+        api::roaring_bitmap_to_uint32_array(&roaring, ans);
     }
     /**
      * to int array with pagination
      * 
      */
     void rangeUint32Array(uint32_t *ans, size_t offset, size_t limit) const {
-        roaring_bitmap_range_uint32_array(&roaring, offset, limit, ans);
+        api::roaring_bitmap_range_uint32_array(&roaring, offset, limit, ans);
     }
 
     /**
      * Return true if the two bitmaps contain the same elements.
      */
     bool operator==(const Roaring &r) const {
-        return roaring_bitmap_equals(&roaring, &r.roaring);
+        return api::roaring_bitmap_equals(&roaring, &r.roaring);
     }
 
     /**
@@ -290,7 +290,7 @@ class Roaring {
      * areas outside the range are passed through unchanged.
      */
     void flip(uint64_t range_start, uint64_t range_end) {
-        roaring_bitmap_flip_inplace(&roaring, range_start, range_end);
+        api::roaring_bitmap_flip_inplace(&roaring, range_start, range_end);
     }
 
     /**
@@ -298,7 +298,7 @@ class Roaring {
      *  return whether a change was applied
      */
     bool removeRunCompression() {
-        return roaring_bitmap_remove_run_compression(&roaring);
+        return api::roaring_bitmap_remove_run_compression(&roaring);
     }
 
     /** convert array and bitmap containers to run containers when it is more
@@ -307,13 +307,13 @@ class Roaring {
      * true if the result has at least one run container.
      * Additional savings might be possible by calling shrinkToFit().
      */
-    bool runOptimize() { return roaring_bitmap_run_optimize(&roaring); }
+    bool runOptimize() { return api::roaring_bitmap_run_optimize(&roaring); }
 
     /**
      * If needed, reallocate memory to shrink the memory usage. Returns
      * the number of bytes saved.
     */
-    size_t shrinkToFit() { return roaring_bitmap_shrink_to_fit(&roaring); }
+    size_t shrinkToFit() { return api::roaring_bitmap_shrink_to_fit(&roaring); }
 
     /**
      * Iterate over the bitmap elements. The function iterator is called once for
@@ -324,7 +324,7 @@ class Roaring {
      * should stop), and takes (uint32_t,void*) as inputs.
      */
     void iterate(roaring_iterator iterator, void *ptr) const {
-        roaring_iterate(&roaring, iterator, ptr);
+        api::roaring_iterate(&roaring, iterator, ptr);
     }
 
     /**
@@ -335,7 +335,7 @@ class Roaring {
      *   Otherwise, it returns false.
      */
     bool select(uint32_t rnk, uint32_t *element) const {
-        return roaring_bitmap_select(&roaring, rnk, element);
+        return api::roaring_bitmap_select(&roaring, rnk, element);
     }
 
     /**
@@ -343,7 +343,7 @@ class Roaring {
      *
      */
     uint64_t and_cardinality(const Roaring &r) const {
-        return roaring_bitmap_and_cardinality(&roaring, &r.roaring);
+        return api::roaring_bitmap_and_cardinality(&roaring, &r.roaring);
     }
 
     /**
@@ -351,7 +351,7 @@ class Roaring {
      *
      */
     bool intersect(const Roaring &r) const {
-    	 return roaring_bitmap_intersect(&roaring, &r.roaring);
+    	 return api::roaring_bitmap_intersect(&roaring, &r.roaring);
     }
 
     /**
@@ -363,7 +363,7 @@ class Roaring {
      *
      */
     double jaccard_index(const Roaring &r) const {
-        return roaring_bitmap_jaccard_index(&roaring, &r.roaring);
+        return api::roaring_bitmap_jaccard_index(&roaring, &r.roaring);
     }
 
     /**
@@ -371,7 +371,7 @@ class Roaring {
      *
      */
     uint64_t or_cardinality(const Roaring &r) const {
-        return roaring_bitmap_or_cardinality(&roaring, &r.roaring);
+        return api::roaring_bitmap_or_cardinality(&roaring, &r.roaring);
     }
 
     /**
@@ -379,7 +379,7 @@ class Roaring {
      *
      */
     uint64_t andnot_cardinality(const Roaring &r) const {
-        return roaring_bitmap_andnot_cardinality(&roaring, &r.roaring);
+        return api::roaring_bitmap_andnot_cardinality(&roaring, &r.roaring);
     }
 
     /**
@@ -388,7 +388,7 @@ class Roaring {
      *
      */
     uint64_t xor_cardinality(const Roaring &r) const {
-        return roaring_bitmap_xor_cardinality(&roaring, &r.roaring);
+        return api::roaring_bitmap_xor_cardinality(&roaring, &r.roaring);
     }
 
     /**
@@ -399,7 +399,9 @@ class Roaring {
     * 1 when ranking the smallest value, but the select function returns the
     * smallest value when using index 0.
     */
-    uint64_t rank(uint32_t x) const { return roaring_bitmap_rank(&roaring, x); }
+    uint64_t rank(uint32_t x) const {
+        return api::roaring_bitmap_rank(&roaring, x);
+    }
 
     /**
     * write a bitmap to a char buffer. This is meant to be compatible with
@@ -443,9 +445,9 @@ class Roaring {
     */
     size_t write(char *buf, bool portable = true) const {
         if (portable)
-            return roaring_bitmap_portable_serialize(&roaring, buf);
+            return api::roaring_bitmap_portable_serialize(&roaring, buf);
         else
-            return roaring_bitmap_serialize(&roaring, buf);
+            return api::roaring_bitmap_serialize(&roaring, buf);
     }
 
     /**
@@ -460,7 +462,9 @@ class Roaring {
      * many, many bytes could be read. See also readSafe.
      */
     static Roaring read(const char *buf, bool portable = true) {
-        roaring_bitmap_t * r = portable ? roaring_bitmap_portable_deserialize(buf) : roaring_bitmap_deserialize(buf);
+        roaring_bitmap_t * r = portable
+            ? api::roaring_bitmap_portable_deserialize(buf)
+            : api::roaring_bitmap_deserialize(buf);
         if (r == NULL) {
             throw std::runtime_error("failed alloc while reading");
         }
@@ -472,7 +476,8 @@ class Roaring {
      *
      */
     static Roaring readSafe(const char *buf, size_t maxbytes) {
-        roaring_bitmap_t * r = roaring_bitmap_portable_deserialize_safe(buf,maxbytes);
+        roaring_bitmap_t * r =
+                api::roaring_bitmap_portable_deserialize_safe(buf,maxbytes);
         if (r == NULL) {
             throw std::runtime_error("failed alloc while reading");
         }
@@ -489,9 +494,9 @@ class Roaring {
      */
     size_t getSizeInBytes(bool portable = true) const {
         if (portable)
-            return roaring_bitmap_portable_size_in_bytes(&roaring);
+            return api::roaring_bitmap_portable_size_in_bytes(&roaring);
         else
-            return roaring_bitmap_size_in_bytes(&roaring);
+            return api::roaring_bitmap_size_in_bytes(&roaring);
     }
 
     /**
@@ -499,7 +504,7 @@ class Roaring {
      * The current bitmap and the provided bitmap are unchanged.
      */
     Roaring operator&(const Roaring &o) const {
-        roaring_bitmap_t *r = roaring_bitmap_and(&roaring, &o.roaring);
+        roaring_bitmap_t *r = api::roaring_bitmap_and(&roaring, &o.roaring);
         if (r == NULL) {
             throw std::runtime_error("failed materalization in and");
         }
@@ -511,7 +516,7 @@ class Roaring {
      * The current bitmap and the provided bitmap are unchanged.
      */
     Roaring operator-(const Roaring &o) const {
-        roaring_bitmap_t *r = roaring_bitmap_andnot(&roaring, &o.roaring);
+        roaring_bitmap_t *r = api::roaring_bitmap_andnot(&roaring, &o.roaring);
         if (r == NULL) {
             throw std::runtime_error("failed materalization in andnot");
         }
@@ -523,7 +528,7 @@ class Roaring {
      * The current bitmap and the provided bitmap are unchanged.
      */
     Roaring operator|(const Roaring &o) const {
-        roaring_bitmap_t *r = roaring_bitmap_or(&roaring, &o.roaring);
+        roaring_bitmap_t *r = api::roaring_bitmap_or(&roaring, &o.roaring);
         if (r == NULL) {
             throw std::runtime_error("failed materalization in or");
         }
@@ -535,7 +540,7 @@ class Roaring {
      * The current bitmap and the provided bitmap are unchanged.
      */
     Roaring operator^(const Roaring &o) const {
-        roaring_bitmap_t *r = roaring_bitmap_xor(&roaring, &o.roaring);
+        roaring_bitmap_t *r = api::roaring_bitmap_xor(&roaring, &o.roaring);
         if (r == NULL) {
             throw std::runtime_error("failed materalization in xor");
         }
@@ -546,13 +551,13 @@ class Roaring {
      * Whether or not we apply copy and write.
      */
     void setCopyOnWrite(bool val) {
-        roaring_bitmap_set_copy_on_write(&roaring, val);
+        api::roaring_bitmap_set_copy_on_write(&roaring, val);
     }
 
     /**
      * Print the content of the bitmap
      */
-    void printf() const { roaring_bitmap_printf(&roaring); }
+    void printf() const { api::roaring_bitmap_printf(&roaring); }
 
     /**
      * Print the content of the bitmap into a string
@@ -583,7 +588,7 @@ class Roaring {
      * Whether or not copy and write is active.
      */
     bool getCopyOnWrite() const {
-        return roaring_bitmap_get_copy_on_write(&roaring);
+        return api::roaring_bitmap_get_copy_on_write(&roaring);
     }
 
     /**
@@ -598,7 +603,7 @@ class Roaring {
         }
         for (size_t k = 0; k < n; ++k) x[k] = &inputs[k]->roaring;
 
-        roaring_bitmap_t *c_ans = roaring_bitmap_or_many(n, x);
+        roaring_bitmap_t *c_ans = api::roaring_bitmap_or_many(n, x);
         if (c_ans == NULL) {
             free(x);
             throw std::runtime_error("failed memory alloc in fastunion");
@@ -678,28 +683,28 @@ class RoaringSetBitForwardIterator final {
     * Move the iterator to the first value >= val.
     */
     void equalorlarger(uint32_t val) {
-      roaring_move_uint32_iterator_equalorlarger(&i,val);
+        api::roaring_move_uint32_iterator_equalorlarger(&i,val);
     }
 
     type_of_iterator &operator++() {  // ++i, must returned inc. value
-        roaring_advance_uint32_iterator(&i);
+        api::roaring_advance_uint32_iterator(&i);
         return *this;
     }
 
     type_of_iterator operator++(int) {  // i++, must return orig. value
         RoaringSetBitForwardIterator orig(*this);
-        roaring_advance_uint32_iterator(&i);
+        api::roaring_advance_uint32_iterator(&i);
         return orig;
     }
 
     type_of_iterator& operator--() { // prefix --
-        roaring_previous_uint32_iterator(&i);
+        api::roaring_previous_uint32_iterator(&i);
         return *this;
     }
 
     type_of_iterator operator--(int) { // postfix --
         RoaringSetBitForwardIterator orig(*this);
-        roaring_previous_uint32_iterator(&i);
+        api::roaring_previous_uint32_iterator(&i);
         return orig;
     }
 
@@ -719,7 +724,7 @@ class RoaringSetBitForwardIterator final {
             i.has_value = false;
             i.current_value = UINT32_MAX;
         } else {
-            roaring_init_iterator(&parent.roaring, &i);
+            api::roaring_init_iterator(&parent.roaring, &i);
         }
     }
 

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -17,6 +17,9 @@ A C++ header for 64-bit Roaring Bitmaps, implemented by way of a map of many
 #include <utility>
 
 #include "roaring.hh"
+using roaring::Roaring;
+
+namespace roaring {
 
 class Roaring64MapSetBitForwardIterator;
 class Roaring64MapSetBitBiDirectionalIterator;
@@ -1053,5 +1056,7 @@ inline Roaring64MapSetBitForwardIterator Roaring64Map::begin() const {
 inline Roaring64MapSetBitForwardIterator Roaring64Map::end() const {
     return Roaring64MapSetBitForwardIterator(*this, true);
 }
+
+}  // namespace roaring
 
 #endif /* INCLUDE_ROARING_64_MAP_HH_ */

--- a/include/roaring/array_util.h
+++ b/include/roaring/array_util.h
@@ -6,6 +6,10 @@
 
 #include <roaring/portability.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  *  Good old binary search.
  *  Assumes that array is sorted, has logarithmic complexity.
@@ -232,5 +236,9 @@ size_t fast_union_uint16(const uint16_t *set_1, size_t size_1, const uint16_t *s
 
 
 bool memequals(const void *s1, const void *s2, size_t n);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/roaring/array_util.h
+++ b/include/roaring/array_util.h
@@ -7,7 +7,7 @@
 #include <roaring/portability.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /*
@@ -238,7 +238,7 @@ size_t fast_union_uint16(const uint16_t *set_1, size_t size_1, const uint16_t *s
 bool memequals(const void *s1, const void *s2, size_t n);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif

--- a/include/roaring/array_util.h
+++ b/include/roaring/array_util.h
@@ -7,7 +7,7 @@
 #include <roaring/portability.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /*
@@ -238,7 +238,7 @@ size_t fast_union_uint16(const uint16_t *set_1, size_t size_1, const uint16_t *s
 bool memequals(const void *s1, const void *s2, size_t n);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif

--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -6,6 +6,10 @@
 #include <roaring/portability.h>
 #include <roaring/utilasm.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Set all bits in indexes [begin,end) to true.
  */
@@ -534,5 +538,9 @@ AVXPOPCNTFNC(andnot, _mm256_andnot_si256)
  */
 
 #endif  // USEAVX
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -7,7 +7,7 @@
 #include <roaring/utilasm.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /*
@@ -540,7 +540,7 @@ AVXPOPCNTFNC(andnot, _mm256_andnot_si256)
 #endif  // USEAVX
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal
 #endif
 
 #endif

--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -7,7 +7,7 @@
 #include <roaring/utilasm.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /*
@@ -540,7 +540,7 @@ AVXPOPCNTFNC(andnot, _mm256_andnot_si256)
 #endif  // USEAVX
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif

--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -13,6 +13,10 @@
 #include <roaring/portability.h>
 #include <roaring/roaring_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Containers with DEFAULT_MAX_SIZE or less integers should be arrays */
 enum { DEFAULT_MAX_SIZE = 4096 };
 
@@ -443,5 +447,9 @@ static inline void array_container_remove_range(array_container_t *array,
       array->cardinality -= count;
   }
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_ARRAY_H_ */

--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -14,7 +14,7 @@
 #include <roaring/roaring_types.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /* Containers with DEFAULT_MAX_SIZE or less integers should be arrays */
@@ -449,7 +449,7 @@ static inline void array_container_remove_range(array_container_t *array,
 }
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_ARRAY_H_ */

--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -15,6 +15,12 @@
 
 #ifdef __cplusplus
 extern "C" { namespace roaring {
+
+// Note: in pure C++ code, you should avoid putting `using` in header files 
+using api::roaring_iterator;
+using api::roaring_iterator64;
+
+namespace internal {
 #endif
 
 /* Containers with DEFAULT_MAX_SIZE or less integers should be arrays */
@@ -449,7 +455,7 @@ static inline void array_container_remove_range(array_container_t *array,
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } } // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_ARRAY_H_ */

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -12,6 +12,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef USEAVX
 #define ALIGN_AVX __attribute__((aligned(sizeof(__m256i))))
 #else
@@ -477,4 +481,9 @@ int bitset_container_rank(const bitset_container_t *container, uint16_t x);
 
 /* Returns the index of the first value equal or larger than x, or -1 */
 int bitset_container_index_equalorlarger(const bitset_container_t *container, uint16_t x);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* INCLUDE_CONTAINERS_BITSET_H_ */

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -13,7 +13,7 @@
 #include <stdint.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 #ifdef USEAVX
@@ -483,7 +483,7 @@ int bitset_container_rank(const bitset_container_t *container, uint16_t x);
 int bitset_container_index_equalorlarger(const bitset_container_t *container, uint16_t x);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_BITSET_H_ */

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -14,6 +14,12 @@
 
 #ifdef __cplusplus
 extern "C" { namespace roaring {
+
+// Note: in pure C++ code, you should avoid putting `using` in header files 
+using api::roaring_iterator;
+using api::roaring_iterator64;
+
+namespace internal {
 #endif
 
 #ifdef USEAVX
@@ -483,7 +489,7 @@ int bitset_container_rank(const bitset_container_t *container, uint16_t x);
 int bitset_container_index_equalorlarger(const bitset_container_t *container, uint16_t x);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_BITSET_H_ */

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -18,6 +18,10 @@
 #include <roaring/containers/run.h>
 #include <roaring/bitset_util.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // would enum be possible or better?
 
 /**
@@ -71,7 +75,7 @@ void *shared_container_extract_copy(shared_container_t *container,
                                     uint8_t *typecode);
 
 /* access to container underneath */
-inline const void *container_unwrap_shared(
+static inline const void *container_unwrap_shared(
     const void *candidate_shared_container, uint8_t *type) {
     if (*type == SHARED_CONTAINER_TYPE_CODE) {
         *type =
@@ -85,7 +89,7 @@ inline const void *container_unwrap_shared(
 
 
 /* access to container underneath */
-inline void *container_mutable_unwrap_shared(
+static inline void *container_mutable_unwrap_shared(
     void *candidate_shared_container, uint8_t *type) {
     if (*type == SHARED_CONTAINER_TYPE_CODE) {
         *type =
@@ -543,7 +547,7 @@ static inline void *container_remove(void *container, uint16_t val,
 /**
  * Check whether a value is in a container, requires a  typecode
  */
-inline bool container_contains(const void *container, uint16_t val,
+static inline bool container_contains(const void *container, uint16_t val,
                                uint8_t typecode) {
     container = container_unwrap_shared(container, &typecode);
     switch (typecode) {
@@ -2353,5 +2357,9 @@ static inline void *container_remove_range(void *container, uint8_t type,
             __builtin_unreachable();
      }
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -19,7 +19,7 @@
 #include <roaring/bitset_util.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 // would enum be possible or better?
@@ -2359,7 +2359,7 @@ static inline void *container_remove_range(void *container, uint8_t type,
 }
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -19,7 +19,7 @@
 #include <roaring/bitset_util.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 // would enum be possible or better?
@@ -2359,7 +2359,7 @@ static inline void *container_remove_range(void *container, uint8_t type,
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif

--- a/include/roaring/containers/convert.h
+++ b/include/roaring/containers/convert.h
@@ -11,7 +11,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /* Convert an array into a bitset. The input container is not freed or modified.
@@ -61,7 +61,7 @@ void *container_from_run_range(const run_container_t *run,
                                                     uint32_t min, uint32_t max, uint8_t *typecode_after);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_CONVERT_H_ */

--- a/include/roaring/containers/convert.h
+++ b/include/roaring/containers/convert.h
@@ -11,7 +11,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /* Convert an array into a bitset. The input container is not freed or modified.
@@ -61,7 +61,7 @@ void *container_from_run_range(const run_container_t *run,
                                                     uint32_t min, uint32_t max, uint8_t *typecode_after);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_CONVERT_H_ */

--- a/include/roaring/containers/convert.h
+++ b/include/roaring/containers/convert.h
@@ -10,6 +10,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Convert an array into a bitset. The input container is not freed or modified.
  */
 bitset_container_t *bitset_container_from_array(const array_container_t *arr);
@@ -55,5 +59,9 @@ void *convert_run_to_efficient_container_and_free(run_container_t *c,
  */
 void *container_from_run_range(const run_container_t *run,
                                                     uint32_t min, uint32_t max, uint8_t *typecode_after);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_CONVERT_H_ */

--- a/include/roaring/containers/mixed_andnot.h
+++ b/include/roaring/containers/mixed_andnot.h
@@ -8,6 +8,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Compute the andnot of src_1 and src_2 and write the result to
  * dst, a valid array container that could be the same as dst.*/
 void array_bitset_container_andnot(const array_container_t *src_1,
@@ -157,4 +161,9 @@ bool bitset_bitset_container_andnot(const bitset_container_t *src_1,
 bool bitset_bitset_container_iandnot(bitset_container_t *src_1,
                                      const bitset_container_t *src_2,
                                      void **dst);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/include/roaring/containers/mixed_andnot.h
+++ b/include/roaring/containers/mixed_andnot.h
@@ -9,7 +9,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /* Compute the andnot of src_1 and src_2 and write the result to
@@ -163,7 +163,7 @@ bool bitset_bitset_container_iandnot(bitset_container_t *src_1,
                                      void **dst);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif

--- a/include/roaring/containers/mixed_andnot.h
+++ b/include/roaring/containers/mixed_andnot.h
@@ -9,7 +9,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /* Compute the andnot of src_1 and src_2 and write the result to
@@ -163,7 +163,7 @@ bool bitset_bitset_container_iandnot(bitset_container_t *src_1,
                                      void **dst);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif

--- a/include/roaring/containers/mixed_equal.h
+++ b/include/roaring/containers/mixed_equal.h
@@ -10,6 +10,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Return true if the two containers have the same content.
  */
@@ -26,5 +30,9 @@ bool run_container_equals_array(const run_container_t* container1,
  */
 bool run_container_equals_bitset(const run_container_t* container1,
                                  const bitset_container_t* container2);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CONTAINERS_MIXED_EQUAL_H_ */

--- a/include/roaring/containers/mixed_equal.h
+++ b/include/roaring/containers/mixed_equal.h
@@ -11,7 +11,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /**
@@ -32,7 +32,7 @@ bool run_container_equals_bitset(const run_container_t* container1,
                                  const bitset_container_t* container2);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif /* CONTAINERS_MIXED_EQUAL_H_ */

--- a/include/roaring/containers/mixed_equal.h
+++ b/include/roaring/containers/mixed_equal.h
@@ -11,7 +11,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /**
@@ -32,7 +32,7 @@ bool run_container_equals_bitset(const run_container_t* container1,
                                  const bitset_container_t* container2);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif /* CONTAINERS_MIXED_EQUAL_H_ */

--- a/include/roaring/containers/mixed_intersection.h
+++ b/include/roaring/containers/mixed_intersection.h
@@ -15,6 +15,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Compute the intersection of src_1 and src_2 and write the result to
  * dst. It is allowed for dst to be equal to src_1. We assume that dst is a
  * valid container. */
@@ -87,5 +91,9 @@ bool run_bitset_container_intersect(const run_container_t *src_1,
  */
 bool bitset_bitset_container_intersection_inplace(
     bitset_container_t *src_1, const bitset_container_t *src_2, void **dst);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_INTERSECTION_H_ */

--- a/include/roaring/containers/mixed_intersection.h
+++ b/include/roaring/containers/mixed_intersection.h
@@ -16,7 +16,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /* Compute the intersection of src_1 and src_2 and write the result to
@@ -93,7 +93,7 @@ bool bitset_bitset_container_intersection_inplace(
     bitset_container_t *src_1, const bitset_container_t *src_2, void **dst);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_INTERSECTION_H_ */

--- a/include/roaring/containers/mixed_intersection.h
+++ b/include/roaring/containers/mixed_intersection.h
@@ -16,7 +16,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /* Compute the intersection of src_1 and src_2 and write the result to
@@ -93,7 +93,7 @@ bool bitset_bitset_container_intersection_inplace(
     bitset_container_t *src_1, const bitset_container_t *src_2, void **dst);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_INTERSECTION_H_ */

--- a/include/roaring/containers/mixed_negation.h
+++ b/include/roaring/containers/mixed_negation.h
@@ -10,6 +10,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Negation across the entire range of the container.
  * Compute the  negation of src  and write the result
  * to *dst. The complement of a
@@ -119,5 +123,9 @@ int run_container_negation_range(const run_container_t *src,
 int run_container_negation_range_inplace(run_container_t *src,
                                          const int range_start,
                                          const int range_end, void **dst);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_NEGATION_H_ */

--- a/include/roaring/containers/mixed_negation.h
+++ b/include/roaring/containers/mixed_negation.h
@@ -11,7 +11,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /* Negation across the entire range of the container.
@@ -125,7 +125,7 @@ int run_container_negation_range_inplace(run_container_t *src,
                                          const int range_end, void **dst);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_NEGATION_H_ */

--- a/include/roaring/containers/mixed_negation.h
+++ b/include/roaring/containers/mixed_negation.h
@@ -11,7 +11,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /* Negation across the entire range of the container.
@@ -125,7 +125,7 @@ int run_container_negation_range_inplace(run_container_t *src,
                                          const int range_end, void **dst);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_NEGATION_H_ */

--- a/include/roaring/containers/mixed_subset.h
+++ b/include/roaring/containers/mixed_subset.h
@@ -10,6 +10,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Return true if container1 is a subset of container2.
  */
@@ -39,5 +43,9 @@ bool run_container_is_subset_bitset(const run_container_t* container1,
 */
 bool bitset_container_is_subset_run(const bitset_container_t* container1,
                                     const run_container_t* container2);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CONTAINERS_MIXED_SUBSET_H_ */

--- a/include/roaring/containers/mixed_subset.h
+++ b/include/roaring/containers/mixed_subset.h
@@ -11,7 +11,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /**
@@ -45,7 +45,7 @@ bool bitset_container_is_subset_run(const bitset_container_t* container1,
                                     const run_container_t* container2);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif /* CONTAINERS_MIXED_SUBSET_H_ */

--- a/include/roaring/containers/mixed_subset.h
+++ b/include/roaring/containers/mixed_subset.h
@@ -11,7 +11,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /**
@@ -45,7 +45,7 @@ bool bitset_container_is_subset_run(const bitset_container_t* container1,
                                     const run_container_t* container2);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif /* CONTAINERS_MIXED_SUBSET_H_ */

--- a/include/roaring/containers/mixed_union.h
+++ b/include/roaring/containers/mixed_union.h
@@ -15,6 +15,10 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Compute the union of src_1 and src_2 and write the result to
  * dst. It is allowed for src_2 to be dst.   */
 void array_bitset_container_union(const array_container_t *src_1,
@@ -98,5 +102,9 @@ void run_bitset_container_union(const run_container_t *src_1,
 void run_bitset_container_lazy_union(const run_container_t *src_1,
                                      const bitset_container_t *src_2,
                                      bitset_container_t *dst);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_UNION_H_ */

--- a/include/roaring/containers/mixed_union.h
+++ b/include/roaring/containers/mixed_union.h
@@ -16,7 +16,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /* Compute the union of src_1 and src_2 and write the result to
@@ -104,7 +104,7 @@ void run_bitset_container_lazy_union(const run_container_t *src_1,
                                      bitset_container_t *dst);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_UNION_H_ */

--- a/include/roaring/containers/mixed_union.h
+++ b/include/roaring/containers/mixed_union.h
@@ -16,7 +16,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /* Compute the union of src_1 and src_2 and write the result to
@@ -104,7 +104,7 @@ void run_bitset_container_lazy_union(const run_container_t *src_1,
                                      bitset_container_t *dst);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_MIXED_UNION_H_ */

--- a/include/roaring/containers/mixed_xor.h
+++ b/include/roaring/containers/mixed_xor.h
@@ -23,6 +23,10 @@
 
 //#include "containers.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Compute the xor of src_1 and src_2 and write the result to
  * dst (which has no container initially).
  * Result is true iff dst is a bitset  */
@@ -151,4 +155,9 @@ bool array_array_container_ixor(array_container_t *src_1,
 
 int run_run_container_ixor(run_container_t *src_1, const run_container_t *src_2,
                            void **dst);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/include/roaring/containers/mixed_xor.h
+++ b/include/roaring/containers/mixed_xor.h
@@ -24,7 +24,7 @@
 //#include "containers.h"
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /* Compute the xor of src_1 and src_2 and write the result to
@@ -157,7 +157,7 @@ int run_run_container_ixor(run_container_t *src_1, const run_container_t *src_2,
                            void **dst);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif

--- a/include/roaring/containers/mixed_xor.h
+++ b/include/roaring/containers/mixed_xor.h
@@ -24,7 +24,7 @@
 //#include "containers.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /* Compute the xor of src_1 and src_2 and write the result to
@@ -157,7 +157,7 @@ int run_run_container_ixor(run_container_t *src_1, const run_container_t *src_2,
                            void **dst);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif

--- a/include/roaring/containers/perfparameters.h
+++ b/include/roaring/containers/perfparameters.h
@@ -3,6 +3,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
 During lazy computations, we can transform array containers into bitset
 containers as
@@ -32,6 +36,10 @@ enum { ARRAY_DEFAULT_INIT_SIZE = 0 };
 /* automatically attempt to convert a bitset to a full run */
 #ifndef OR_BITSET_CONVERSION_TO_FULL
 #define OR_BITSET_CONVERSION_TO_FULL true
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/include/roaring/containers/perfparameters.h
+++ b/include/roaring/containers/perfparameters.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /**
@@ -39,7 +39,7 @@ enum { ARRAY_DEFAULT_INIT_SIZE = 0 };
 #endif
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif

--- a/include/roaring/containers/perfparameters.h
+++ b/include/roaring/containers/perfparameters.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /**
@@ -39,7 +39,7 @@ enum { ARRAY_DEFAULT_INIT_SIZE = 0 };
 #endif
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -17,7 +17,7 @@
 #include <roaring/array_util.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 /* struct rle16_s - run length pair
@@ -717,7 +717,7 @@ static inline void run_container_remove_range(run_container_t *run, uint32_t min
 }
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_RUN_H_ */

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -18,6 +18,12 @@
 
 #ifdef __cplusplus
 extern "C" { namespace roaring {
+
+// Note: in pure C++ code, you should avoid putting `using` in header files 
+using api::roaring_iterator;
+using api::roaring_iterator64;
+
+namespace internal {
 #endif
 
 /* struct rle16_s - run length pair
@@ -717,7 +723,7 @@ static inline void run_container_remove_range(run_container_t *run, uint32_t min
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif /* INCLUDE_CONTAINERS_RUN_H_ */

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -16,6 +16,10 @@
 #include <roaring/roaring_types.h>
 #include <roaring/array_util.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* struct rle16_s - run length pair
  *
  * @value:  start position of the run
@@ -30,6 +34,14 @@ struct rle16_s {
 };
 
 typedef struct rle16_s rle16_t;
+
+#ifdef __cplusplus
+    #define MAKE_RLE16(val,len) \
+        {(uint16_t)(val), (uint16_t)(len)}  // no tagged structs until c++20
+#else
+    #define MAKE_RLE16(val,len) \
+        (rle16_t){.value = (uint16_t)(val), .length = (uint16_t)(len)}
+#endif
 
 /* struct run_container_s - run container bitmap
  *
@@ -383,10 +395,7 @@ static inline void run_container_append_value(run_container_t *run,
                                               rle16_t *previousrl) {
     const uint32_t previousend = previousrl->value + previousrl->length;
     if (val > previousend + 1) {  // we add a new one
-        //*previousrl = (rle16_t){.value = val, .length = 0};// requires C99
-        previousrl->value = val;
-        previousrl->length = 0;
-
+        *previousrl = MAKE_RLE16(val, 0);
         run->runs[run->n_runs] = *previousrl;
         run->n_runs++;
     } else if (val == previousend + 1) {  // we merge
@@ -401,11 +410,7 @@ static inline void run_container_append_value(run_container_t *run,
  */
 static inline rle16_t run_container_append_value_first(run_container_t *run,
                                                        uint16_t val) {
-    // rle16_t newrle = (rle16_t){.value = val, .length = 0};// requires C99
-    rle16_t newrle;
-    newrle.value = val;
-    newrle.length = 0;
-
+    rle16_t newrle = MAKE_RLE16(val, 0);
     run->runs[run->n_runs] = newrle;
     run->n_runs++;
     return newrle;
@@ -711,5 +716,8 @@ static inline void run_container_remove_range(run_container_t *run, uint32_t min
     }
 }
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_CONTAINERS_RUN_H_ */

--- a/include/roaring/misc/configreport.h
+++ b/include/roaring/misc/configreport.h
@@ -12,6 +12,10 @@
 
 #include <roaring/portability.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 #ifdef IS_X64
 // useful for basic info (0)
 static inline void native_cpuid(unsigned int *eax, unsigned int *ebx,
@@ -174,6 +178,10 @@ static inline void tellmeall() {
 #endif
 }
 
+#endif
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif /* INCLUDE_MISC_CONFIGREPORT_H_ */

--- a/include/roaring/misc/configreport.h
+++ b/include/roaring/misc/configreport.h
@@ -13,7 +13,7 @@
 #include <roaring/portability.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace misc {
 #endif
 
 #ifdef IS_X64
@@ -181,7 +181,7 @@ static inline void tellmeall() {
 #endif
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace misc {
 #endif
 
 #endif /* INCLUDE_MISC_CONFIGREPORT_H_ */

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -28,7 +28,7 @@
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" {  // portability definitions are in global scope, not a namespace
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__) && !defined(_WIN64) && !defined(ROARING_ACK_32BIT)
@@ -247,7 +247,7 @@ static inline int hamming(uint64_t x) {
 #endif
 
 #ifdef __cplusplus
-}
+}  // extern "C" {
 #endif
 
 #endif /* INCLUDE_PORTABILITY_H_ */

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -27,6 +27,9 @@
 #include <malloc.h>  // this should never be needed but there are some reports that it is needed.
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #if defined(_MSC_VER) && !defined(__clang__) && !defined(_WIN64) && !defined(ROARING_ACK_32BIT)
 #pragma message( \
@@ -241,6 +244,10 @@ static inline int hamming(uint64_t x) {
 
 #ifndef UINT32_C
 #define UINT32_C(c) (c##UL)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* INCLUDE_PORTABILITY_H_ */

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -4,14 +4,15 @@ An implementation of Roaring Bitmaps in C.
 
 #ifndef ROARING_H
 #define ROARING_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <roaring/roaring_array.h>
 #include <roaring/roaring_types.h>
 #include <roaring/roaring_version.h>
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct roaring_bitmap_s {
     roaring_array_t high_low_container;
@@ -48,10 +49,10 @@ roaring_bitmap_t *roaring_bitmap_of_ptr(size_t n_args, const uint32_t *vals);
  * then ensure that you do so for all of your bitmaps since
  * interactions between bitmaps with and without COW is unsafe.
  */
-inline bool roaring_bitmap_get_copy_on_write(const roaring_bitmap_t* r) {
+static inline bool roaring_bitmap_get_copy_on_write(const roaring_bitmap_t* r) {
     return r->high_low_container.flags & ROARING_FLAG_COW;
 }
-inline void roaring_bitmap_set_copy_on_write(roaring_bitmap_t* r, bool cow) {
+static inline void roaring_bitmap_set_copy_on_write(roaring_bitmap_t* r, bool cow) {
     if (cow) {
         r->high_low_container.flags |= ROARING_FLAG_COW;
     } else {
@@ -271,7 +272,7 @@ void roaring_bitmap_add_range_closed(roaring_bitmap_t *ra, uint32_t min, uint32_
 /**
  * Add all values in range [min, max)
  */
-inline void roaring_bitmap_add_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
+static inline void roaring_bitmap_add_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
   if(max == min) return;
   roaring_bitmap_add_range_closed(ra, (uint32_t)min, (uint32_t)(max - 1));
 }
@@ -286,7 +287,7 @@ void roaring_bitmap_remove(roaring_bitmap_t *r, uint32_t x);
 void roaring_bitmap_remove_range_closed(roaring_bitmap_t *ra, uint32_t min, uint32_t max);
 
 /** Remove all values in range [min, max) */
-inline void roaring_bitmap_remove_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
+static inline void roaring_bitmap_remove_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
     if(max == min) return;
     roaring_bitmap_remove_range_closed(ra, (uint32_t)min, (uint32_t)(max - 1));
 }
@@ -304,7 +305,7 @@ bool roaring_bitmap_remove_checked(roaring_bitmap_t *r, uint32_t x);
 /**
  * Check if value x is present
  */
-inline bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val) {
+static inline bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val) {
     const uint16_t hb = val >> 16;
     /*
      * the next function call involves a binary search and lots of branching.

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -11,7 +11,7 @@ An implementation of Roaring Bitmaps in C.
 #include <stdbool.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 typedef struct roaring_bitmap_s {
@@ -774,7 +774,7 @@ void roaring_free_uint32_iterator(roaring_uint32_iterator_t *it);
 uint32_t roaring_read_uint32_iterator(roaring_uint32_iterator_t *it, uint32_t* buf, uint32_t count);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -12,6 +12,14 @@ An implementation of Roaring Bitmaps in C.
 
 #ifdef __cplusplus
 extern "C" { namespace roaring {
+    
+// These definitions are needed for inlining.
+// Note: in pure C++ code, you should avoid putting `using` in header files 
+using internal::ra_get_index;
+using internal::ra_get_container_at_index;
+using internal::container_contains;
+
+namespace api {
 #endif
 
 typedef struct roaring_bitmap_s {
@@ -774,7 +782,7 @@ void roaring_free_uint32_iterator(roaring_uint32_iterator_t *it);
 uint32_t roaring_read_uint32_iterator(roaring_uint32_iterator_t *it, uint32_t* buf, uint32_t count);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace api {
 #endif
 
 #endif

--- a/include/roaring/roaring_array.h
+++ b/include/roaring/roaring_array.h
@@ -1,14 +1,15 @@
 #ifndef INCLUDE_ROARING_ARRAY_H
 #define INCLUDE_ROARING_ARRAY_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <assert.h>
 #include <roaring/array_util.h>
 #include <roaring/containers/containers.h>
 #include <stdbool.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define MAX_CONTAINERS 65536
 

--- a/include/roaring/roaring_array.h
+++ b/include/roaring/roaring_array.h
@@ -9,6 +9,8 @@
 
 #ifdef __cplusplus
 extern "C" { namespace roaring {
+
+namespace api {
 #endif
 
 #define MAX_CONTAINERS 65536
@@ -18,13 +20,6 @@ extern "C" { namespace roaring {
 
 #define ROARING_FLAG_COW UINT8_C(0x1)
 #define ROARING_FLAG_FROZEN UINT8_C(0x2)
-
-enum {
-    SERIAL_COOKIE_NO_RUNCONTAINER = 12346,
-    SERIAL_COOKIE = 12347,
-    FROZEN_COOKIE = 13766,
-    NO_OFFSET_THRESHOLD = 4
-};
 
 /**
  * Roaring arrays are array-based key-value pairs having containers as values
@@ -44,6 +39,22 @@ typedef struct roaring_array_s {
     uint8_t *typecodes;
     uint8_t flags;
 } roaring_array_t;
+
+#ifdef __cplusplus
+}  // namespace api
+
+// Note: in pure C++ code, you should avoid putting `using` in header files
+using api::roaring_array_t;
+
+namespace internal {
+#endif
+
+enum {
+    SERIAL_COOKIE_NO_RUNCONTAINER = 12346,
+    SERIAL_COOKIE = 12347,
+    FROZEN_COOKIE = 13766,
+    NO_OFFSET_THRESHOLD = 4
+};
 
 /**
  * Create a new roaring array
@@ -309,6 +320,7 @@ void ra_copy_range(roaring_array_t *ra, uint32_t begin, uint32_t end,
 void ra_shift_tail(roaring_array_t *ra, int32_t count, int32_t distance);
 
 #ifdef __cplusplus
+}  // namespace internal
 } }  // extern "C" { namespace roaring {
 #endif
 

--- a/include/roaring/roaring_array.h
+++ b/include/roaring/roaring_array.h
@@ -8,7 +8,7 @@
 #include <stdint.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 #define MAX_CONTAINERS 65536
@@ -309,7 +309,7 @@ void ra_copy_range(roaring_array_t *ra, uint32_t begin, uint32_t end,
 void ra_shift_tail(roaring_array_t *ra, int32_t count, int32_t distance);
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif

--- a/include/roaring/roaring_types.h
+++ b/include/roaring/roaring_types.h
@@ -5,6 +5,10 @@
 #ifndef ROARING_TYPES_H
 #define ROARING_TYPES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef bool (*roaring_iterator)(uint32_t value, void *param);
 typedef bool (*roaring_iterator64)(uint64_t value, void *param);
 
@@ -44,5 +48,9 @@ typedef struct roaring_statistics_s {
 
     // and n_values_arrays, n_values_rle, n_values_bitmap
 } roaring_statistics_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ROARING_TYPES_H */

--- a/include/roaring/roaring_types.h
+++ b/include/roaring/roaring_types.h
@@ -6,7 +6,7 @@
 #define ROARING_TYPES_H
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace api {
 #endif
 
 typedef bool (*roaring_iterator)(uint32_t value, void *param);
@@ -50,7 +50,7 @@ typedef struct roaring_statistics_s {
 } roaring_statistics_t;
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace api {
 #endif
 
 #endif /* ROARING_TYPES_H */

--- a/include/roaring/roaring_types.h
+++ b/include/roaring/roaring_types.h
@@ -6,7 +6,7 @@
 #define ROARING_TYPES_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 typedef bool (*roaring_iterator)(uint32_t value, void *param);
@@ -50,7 +50,7 @@ typedef struct roaring_statistics_s {
 } roaring_statistics_t;
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif /* ROARING_TYPES_H */

--- a/include/roaring/utilasm.h
+++ b/include/roaring/utilasm.h
@@ -8,6 +8,10 @@
 
 #include <roaring/portability.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(USE_BMI) & defined(ROARING_INLINE_ASM)
 #define ASMBITMANIPOPTIMIZATION  // optimization flag
 
@@ -66,4 +70,9 @@
         )
 
 #endif  // USE_BMI
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* INCLUDE_UTILASM_H_ */

--- a/include/roaring/utilasm.h
+++ b/include/roaring/utilasm.h
@@ -9,7 +9,7 @@
 #include <roaring/portability.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { namespace roaring {
 #endif
 
 #if defined(USE_BMI) & defined(ROARING_INLINE_ASM)
@@ -72,7 +72,7 @@ extern "C" {
 #endif  // USE_BMI
 
 #ifdef __cplusplus
-}
+} }  // extern "C" { namespace roaring {
 #endif
 
 #endif  /* INCLUDE_UTILASM_H_ */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,10 @@ set(ROARING_SRC
     roaring_priority_queue.c
     roaring_array.c)
 
+if(ROARING_BUILD_C_AS_CPP)  # more checks and tools, e.g. <type_traits> analysis 
+  SET_SOURCE_FILES_PROPERTIES(${ROARING_SRC} PROPERTIES LANGUAGE CXX)
+endif()
+
 add_library(${ROARING_LIB_NAME} ${ROARING_LIB_TYPE} ${ROARING_SRC})
 target_include_directories(${ROARING_LIB_NAME}
   PUBLIC

--- a/src/array_util.c
+++ b/src/array_util.c
@@ -10,7 +10,7 @@
 #include <roaring/utilasm.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 extern inline int32_t binarySearch(const uint16_t *array, int32_t lenarray,
@@ -1961,5 +1961,5 @@ bool memequals(const void *s1, const void *s2, size_t n) {
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/array_util.c
+++ b/src/array_util.c
@@ -8,6 +8,11 @@
 #include <roaring/array_util.h>
 #include <roaring/portability.h>
 #include <roaring/utilasm.h>
+
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 extern inline int32_t binarySearch(const uint16_t *array, int32_t lenarray,
                                    uint16_t ikey);
 
@@ -1954,3 +1959,7 @@ bool memequals(const void *s1, const void *s2, size_t n) {
     return memcmp(s1, s2, n) == 0;
 #endif
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/bitset_util.c
+++ b/src/bitset_util.c
@@ -7,7 +7,7 @@
 #include <roaring/bitset_util.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 #ifdef IS_X64
@@ -931,5 +931,5 @@ void bitset_flip_list(void *bitset, const uint16_t *list, uint64_t length) {
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/bitset_util.c
+++ b/src/bitset_util.c
@@ -6,6 +6,10 @@
 
 #include <roaring/bitset_util.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 #ifdef IS_X64
 static uint8_t lengthTable[256] = {
     0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4,
@@ -925,3 +929,7 @@ void bitset_flip_list(void *bitset, const uint16_t *list, uint64_t length) {
         list++;
     }
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 extern inline uint16_t array_container_minimum(const array_container_t *arr);
@@ -444,5 +444,5 @@ bool array_container_iterate64(const array_container_t *cont, uint32_t base,
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -8,6 +8,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 extern inline uint16_t array_container_minimum(const array_container_t *arr);
 extern inline uint16_t array_container_maximum(const array_container_t *arr);
 extern inline int array_container_index_equalorlarger(const array_container_t *arr, uint16_t x);
@@ -438,3 +442,7 @@ bool array_container_iterate64(const array_container_t *cont, uint32_t base,
             return false;
     return true;
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -15,6 +15,10 @@
 #include <roaring/portability.h>
 #include <roaring/utilasm.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 extern inline int bitset_container_cardinality(const bitset_container_t *bitset);
 extern inline bool bitset_container_nonzero_cardinality(bitset_container_t *bitset);
 extern inline void bitset_container_set(bitset_container_t *bitset, uint16_t pos);
@@ -683,3 +687,7 @@ int bitset_container_index_equalorlarger(const bitset_container_t *container, ui
   }
   return k * 64 + __builtin_ctzll(word);
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -16,7 +16,7 @@
 #include <roaring/utilasm.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 extern inline int bitset_container_cardinality(const bitset_container_t *bitset);
@@ -689,5 +689,5 @@ int bitset_container_index_equalorlarger(const bitset_container_t *container, ui
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -2,7 +2,7 @@
 #include <roaring/containers/containers.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 extern inline const void *container_unwrap_shared(
@@ -213,5 +213,5 @@ extern inline void *container_andnot(const void *c1, uint8_t type1, const void *
                               uint8_t type2, uint8_t *result_type);
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -1,6 +1,10 @@
 
 #include <roaring/containers/containers.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 extern inline const void *container_unwrap_shared(
     const void *candidate_shared_container, uint8_t *type);
 extern inline void *container_mutable_unwrap_shared(
@@ -207,3 +211,7 @@ extern inline void *container_lazy_ixor(void *c1, uint8_t type1, const void *c2,
 
 extern inline void *container_andnot(const void *c1, uint8_t type1, const void *c2,
                               uint8_t type2, uint8_t *result_type);
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -92,8 +92,6 @@ extern inline void *container_add(void *container, uint16_t val, uint8_t typecod
 extern inline bool container_contains(const void *container, uint16_t val,
                                       uint8_t typecode);
 
-extern inline void *container_clone(const void *container, uint8_t typecode);
-
 extern inline void *container_and(const void *c1, uint8_t type1, const void *c2,
                            uint8_t type2, uint8_t *result_type);
 

--- a/src/containers/convert.c
+++ b/src/containers/convert.c
@@ -5,6 +5,10 @@
 #include <roaring/containers/convert.h>
 #include <roaring/containers/perfparameters.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 // file contains grubby stuff that must know impl. details of all container
 // types.
 bitset_container_t *bitset_container_from_array(const array_container_t *a) {
@@ -317,3 +321,7 @@ void *container_from_run_range(const run_container_t *run,
     }
     return bitset;
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/convert.c
+++ b/src/containers/convert.c
@@ -6,7 +6,7 @@
 #include <roaring/containers/perfparameters.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 // file contains grubby stuff that must know impl. details of all container
@@ -323,5 +323,5 @@ void *container_from_run_range(const run_container_t *run,
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -290,8 +290,7 @@ int run_array_container_andnot(const run_container_t *src_1,
             if (end <= xstart) {
                 // output the first run
                 answer->runs[answer->n_runs++] =
-                    (rle16_t){.value = (uint16_t)start,
-                              .length = (uint16_t)(end - start - 1)};
+                    MAKE_RLE16(start, end - start - 1);
                 rlepos++;
                 if (rlepos < src_1->n_runs) {
                     start = src_1->runs[rlepos].value;
@@ -306,8 +305,7 @@ int run_array_container_andnot(const run_container_t *src_1,
             } else {
                 if (start < xstart) {
                     answer->runs[answer->n_runs++] =
-                        (rle16_t){.value = (uint16_t)start,
-                                  .length = (uint16_t)(xstart - start - 1)};
+                        MAKE_RLE16(start, xstart - start - 1);
                 }
                 if (xstart + 1 < end) {
                     start = xstart + 1;
@@ -321,9 +319,7 @@ int run_array_container_andnot(const run_container_t *src_1,
             }
         }
         if (rlepos < src_1->n_runs) {
-            answer->runs[answer->n_runs++] =
-                (rle16_t){.value = (uint16_t)start,
-                          .length = (uint16_t)(end - start - 1)};
+            answer->runs[answer->n_runs++] = MAKE_RLE16(start, end - start - 1);
             rlepos++;
             if (rlepos < src_1->n_runs) {
                 memcpy(answer->runs + answer->n_runs, src_1->runs + rlepos,

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -14,7 +14,7 @@
 #include <roaring/containers/perfparameters.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /* Compute the andnot of src_1 and src_2 and write the result to
@@ -507,5 +507,5 @@ bool bitset_bitset_container_iandnot(bitset_container_t *src_1,
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -13,6 +13,10 @@
 #include <roaring/containers/mixed_andnot.h>
 #include <roaring/containers/perfparameters.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 /* Compute the andnot of src_1 and src_2 and write the result to
  * dst, a valid array container that could be the same as dst.*/
 void array_bitset_container_andnot(const array_container_t *src_1,
@@ -501,3 +505,7 @@ bool bitset_bitset_container_iandnot(bitset_container_t *src_1,
         return true;
     }
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/mixed_equal.c
+++ b/src/containers/mixed_equal.c
@@ -1,5 +1,9 @@
 #include <roaring/containers/mixed_equal.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 bool array_container_equal_bitset(const array_container_t* container1,
                                   const bitset_container_t* container2) {
     if (container2->cardinality != BITSET_UNKNOWN_CARDINALITY) {
@@ -75,3 +79,7 @@ bool run_container_equals_bitset(const run_container_t* container1,
 
     return true;
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/mixed_equal.c
+++ b/src/containers/mixed_equal.c
@@ -1,7 +1,7 @@
 #include <roaring/containers/mixed_equal.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 bool array_container_equal_bitset(const array_container_t* container1,
@@ -81,5 +81,5 @@ bool run_container_equals_bitset(const run_container_t* container1,
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/containers/mixed_intersection.c
+++ b/src/containers/mixed_intersection.c
@@ -8,6 +8,10 @@
 #include <roaring/containers/convert.h>
 #include <roaring/containers/mixed_intersection.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 /* Compute the intersection of src_1 and src_2 and write the result to
  * dst.  */
 void array_bitset_container_intersection(const array_container_t *src_1,
@@ -342,3 +346,7 @@ bool bitset_bitset_container_intersection_inplace(
     }
     return false;  // not a bitset
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/mixed_intersection.c
+++ b/src/containers/mixed_intersection.c
@@ -9,7 +9,7 @@
 #include <roaring/containers/mixed_intersection.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /* Compute the intersection of src_1 and src_2 and write the result to
@@ -348,5 +348,5 @@ bool bitset_bitset_container_intersection_inplace(
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/containers/mixed_negation.c
+++ b/src/containers/mixed_negation.c
@@ -311,7 +311,7 @@ int run_container_negation_range_inplace(run_container_t *src,
     }
 
     // as with Java implementation, use locals to give self a buffer of depth 1
-    rle16_t buffered = (rle16_t){.value = (uint16_t)0, .length = (uint16_t)0};
+    rle16_t buffered = MAKE_RLE16(0, 0);
     rle16_t next = buffered;
     if (k < my_nbr_runs) buffered = src->runs[k];
 

--- a/src/containers/mixed_negation.c
+++ b/src/containers/mixed_negation.c
@@ -14,7 +14,7 @@
 #include <roaring/containers/run.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 // TODO: make simplified and optimized negation code across
@@ -337,5 +337,5 @@ int run_container_negation_range_inplace(run_container_t *src,
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/containers/mixed_negation.c
+++ b/src/containers/mixed_negation.c
@@ -13,6 +13,10 @@
 #include <roaring/containers/mixed_negation.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 // TODO: make simplified and optimized negation code across
 // the full range.
 
@@ -331,3 +335,7 @@ int run_container_negation_range_inplace(run_container_t *src,
 
     return return_typecode;
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/mixed_subset.c
+++ b/src/containers/mixed_subset.c
@@ -1,6 +1,10 @@
 #include <roaring/array_util.h>
 #include <roaring/containers/mixed_subset.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 bool array_container_is_subset_bitset(const array_container_t* container1,
                                       const bitset_container_t* container2) {
     if (container2->cardinality != BITSET_UNKNOWN_CARDINALITY) {
@@ -131,3 +135,7 @@ bool bitset_container_is_subset_run(const bitset_container_t* container1,
     }
     return true;
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/mixed_subset.c
+++ b/src/containers/mixed_subset.c
@@ -2,7 +2,7 @@
 #include <roaring/containers/mixed_subset.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 bool array_container_is_subset_bitset(const array_container_t* container1,
@@ -137,5 +137,5 @@ bool bitset_container_is_subset_run(const bitset_container_t* container1,
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/containers/mixed_union.c
+++ b/src/containers/mixed_union.c
@@ -12,7 +12,7 @@
 #include <roaring/containers/perfparameters.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /* Compute the union of src_1 and src_2 and write the result to
@@ -291,5 +291,5 @@ bool array_array_container_lazy_inplace_union(array_container_t *src_1,
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/containers/mixed_union.c
+++ b/src/containers/mixed_union.c
@@ -11,6 +11,10 @@
 #include <roaring/containers/mixed_union.h>
 #include <roaring/containers/perfparameters.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 /* Compute the union of src_1 and src_2 and write the result to
  * dst.  */
 void array_bitset_container_union(const array_container_t *src_1,
@@ -285,3 +289,7 @@ bool array_array_container_lazy_inplace_union(array_container_t *src_1,
     }
     return returnval;
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -12,7 +12,7 @@
 #include <roaring/containers/perfparameters.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 /* Compute the xor of src_1 and src_2 and write the result to
@@ -349,5 +349,5 @@ int run_run_container_ixor(run_container_t *src_1, const run_container_t *src_2,
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -11,6 +11,10 @@
 #include <roaring/containers/mixed_xor.h>
 #include <roaring/containers/perfparameters.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 /* Compute the xor of src_1 and src_2 and write the result to
  * dst (which has no container initially).
  * Result is true iff dst is a bitset  */
@@ -343,3 +347,7 @@ int run_run_container_ixor(run_container_t *src_1, const run_container_t *src_2,
     run_container_free(src_1);
     return ans;
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -4,6 +4,10 @@
 #include <roaring/containers/run.h>
 #include <roaring/portability.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 extern inline uint16_t run_container_minimum(const run_container_t *run);
 extern inline uint16_t run_container_maximum(const run_container_t *run);
 extern inline int32_t interleavedBinarySearch(const rle16_t *array,
@@ -763,3 +767,7 @@ int run_container_rank(const run_container_t *container, uint16_t x) {
     }
     return sum;
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -522,9 +522,7 @@ void run_container_andnot(const run_container_t *src_1,
     while ((rlepos1 < src_1->n_runs) && (rlepos2 < src_2->n_runs)) {
         if (end <= start2) {
             // output the first run
-            dst->runs[dst->n_runs++] =
-                (rle16_t){.value = (uint16_t)start,
-                          .length = (uint16_t)(end - start - 1)};
+            dst->runs[dst->n_runs++] = MAKE_RLE16(start, end - start - 1);
             rlepos1++;
             if (rlepos1 < src_1->n_runs) {
                 start = src_1->runs[rlepos1].value;
@@ -540,8 +538,7 @@ void run_container_andnot(const run_container_t *src_1,
         } else {
             if (start < start2) {
                 dst->runs[dst->n_runs++] =
-                    (rle16_t){.value = (uint16_t)start,
-                              .length = (uint16_t)(start2 - start - 1)};
+                    MAKE_RLE16(start, start2 - start - 1);
             }
             if (end2 < end) {
                 start = end2;
@@ -555,8 +552,7 @@ void run_container_andnot(const run_container_t *src_1,
         }
     }
     if (rlepos1 < src_1->n_runs) {
-        dst->runs[dst->n_runs++] = (rle16_t){
-            .value = (uint16_t)start, .length = (uint16_t)(end - start - 1)};
+        dst->runs[dst->n_runs++] = MAKE_RLE16(start, end - start - 1);
         rlepos1++;
         if (rlepos1 < src_1->n_runs) {
             memcpy(dst->runs + dst->n_runs, src_1->runs + rlepos1,
@@ -702,7 +698,7 @@ void run_container_smart_append_exclusive(run_container_t *src,
 
     if (!src->n_runs ||
         (start > (old_end = last_run->value + last_run->length + 1))) {
-        *appended_last_run = (rle16_t){.value = start, .length = length};
+        *appended_last_run = MAKE_RLE16(start, length);
         src->n_runs++;
         return;
     }
@@ -716,12 +712,10 @@ void run_container_smart_append_exclusive(run_container_t *src,
     if (start == last_run->value) {
         // wipe out previous
         if (new_end < old_end) {
-            *last_run = (rle16_t){.value = (uint16_t)new_end,
-                                  .length = (uint16_t)(old_end - new_end - 1)};
+            *last_run = MAKE_RLE16(new_end, old_end - new_end - 1);
             return;
         } else if (new_end > old_end) {
-            *last_run = (rle16_t){.value = (uint16_t)old_end,
-                                  .length = (uint16_t)(new_end - old_end - 1)};
+            *last_run = MAKE_RLE16(old_end, new_end - old_end - 1);
             return;
         } else {
             src->n_runs--;
@@ -730,14 +724,10 @@ void run_container_smart_append_exclusive(run_container_t *src,
     }
     last_run->length = start - last_run->value - 1;
     if (new_end < old_end) {
-        *appended_last_run =
-            (rle16_t){.value = (uint16_t)new_end,
-                      .length = (uint16_t)(old_end - new_end - 1)};
+        *appended_last_run = MAKE_RLE16(new_end, old_end - new_end - 1);
         src->n_runs++;
     } else if (new_end > old_end) {
-        *appended_last_run =
-            (rle16_t){.value = (uint16_t)old_end,
-                      .length = (uint16_t)(new_end - old_end - 1)};
+        *appended_last_run = MAKE_RLE16(old_end, new_end - old_end - 1);
         src->n_runs++;
     }
 }

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -5,7 +5,7 @@
 #include <roaring/portability.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 extern inline uint16_t run_container_minimum(const run_container_t *run);
@@ -769,5 +769,5 @@ int run_container_rank(const run_container_t *container, uint16_t x) {
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2566,7 +2566,7 @@ bool roaring_bitmap_intersect(const roaring_bitmap_t *x1,
             pos2 = ra_advance_until(& x2->high_low_container, s1, pos2);
         }
     }
-    return answer;
+    return answer != 0;
 }
 
 

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -9,6 +9,10 @@
 #include <string.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 extern inline bool roaring_bitmap_contains(const roaring_bitmap_t *r,
                                            uint32_t val);
 extern inline bool roaring_bitmap_get_copy_on_write(const roaring_bitmap_t* r);
@@ -2958,3 +2962,7 @@ roaring_bitmap_frozen_view(const char *buf, size_t length) {
 
     return rb;
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -10,7 +10,9 @@
 #include <inttypes.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+using namespace ::roaring::internal;
+
+extern "C" { namespace roaring { namespace api {
 #endif
 
 extern inline bool roaring_bitmap_contains(const roaring_bitmap_t *r,
@@ -2964,5 +2966,5 @@ roaring_bitmap_frozen_view(const char *buf, size_t length) {
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring {
 #endif

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -9,6 +9,10 @@
 #include <roaring/containers/containers.h>
 #include <roaring/roaring_array.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 // Convention: [0,ra->size) all elements are initialized
 //  [ra->size, ra->allocation_size) is junk and contains nothing needing freeing
 
@@ -898,3 +902,7 @@ bool ra_portable_deserialize(roaring_array_t *answer, const char *buf, const siz
     }
     return true;
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -10,7 +10,7 @@
 #include <roaring/roaring_array.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+extern "C" { namespace roaring { namespace internal {
 #endif
 
 // Convention: [0,ra->size) all elements are initialized
@@ -904,5 +904,5 @@ bool ra_portable_deserialize(roaring_array_t *answer, const char *buf, const siz
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/src/roaring_priority_queue.c
+++ b/src/roaring_priority_queue.c
@@ -1,7 +1,9 @@
 #include <roaring/roaring.h>
 
 #ifdef __cplusplus
-extern "C" { namespace roaring {
+using namespace ::roaring::internal;
+
+extern "C" { namespace roaring { namespace api {
 #endif
 
 struct roaring_pq_element_s {
@@ -245,5 +247,5 @@ roaring_bitmap_t *roaring_bitmap_or_many_heap(uint32_t number,
 }
 
 #ifdef __cplusplus
-} }  // extern "C" { namespace roaring {
+} } }  // extern "C" { namespace roaring { namespace api {
 #endif

--- a/src/roaring_priority_queue.c
+++ b/src/roaring_priority_queue.c
@@ -1,5 +1,9 @@
 #include <roaring/roaring.h>
 
+#ifdef __cplusplus
+extern "C" { namespace roaring {
+#endif
+
 struct roaring_pq_element_s {
     uint64_t size;
     bool is_temporary;
@@ -239,3 +243,7 @@ roaring_bitmap_t *roaring_bitmap_or_many_heap(uint32_t number,
     pq_free(pq);
     return answer;
 }
+
+#ifdef __cplusplus
+} }  // extern "C" { namespace roaring {
+#endif

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -4,14 +4,17 @@
 
 #include <type_traits>
 #include <assert.h>
-#include <roaring/roaring.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <iostream>
+
+#include <roaring/roaring.h>
 #include "roaring.hh"
 #include "roaring64map.hh"
+using namespace roaring;
+
 extern "C" {
 #include "test.h"
 }

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -10,14 +10,18 @@
 #include <time.h>
 #include <iostream>
 
-#include <roaring/roaring.h>
-#include "roaring.hh"
-#include "roaring64map.hh"
-using namespace roaring;
-
 extern "C" {
 #include "test.h"
 }
+
+#include <roaring/roaring.h>
+using namespace roaring::api;  // access to pure C exported API for testing
+
+#include "roaring.hh"
+using roaring::Roaring;  // the C++ wrapper class
+
+#include "roaring64map.hh"
+using roaring::Roaring64Map;  // C++ class extended for 64-bit numbers
 
 
 static_assert(std::is_nothrow_move_constructible<Roaring>::value,

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -1597,7 +1597,7 @@ static int run_negation_range_tests(int k, int h, int start_offset, int r_start,
             // run_container_append does not dynamically increase its
             // array
             run_container_append_first(
-                RI, (rle16_t){.value = offsetx, .length = actual_runlen - 1});
+                RI, MAKE_RLE16(offsetx, actual_runlen - 1));
             card += actual_runlen;
             if (++runlen == k) runlen = h;  // wrap after k-1 back to h.
         }
@@ -1678,7 +1678,7 @@ static int run_negation_range_tests_simpler(int k, int h, int start_offset,
                 actual_runlen = (1 << 16) - offsetx;
 
             run_container_append_first(
-                RI, (rle16_t){.value = offsetx, .length = actual_runlen - 1});
+                RI, MAKE_RLE16(offsetx, actual_runlen));
             card += actual_runlen;
             if (++runlen == k) runlen = h;
         }


### PR DESCRIPTION
> This PR includes two steps in a namespacing process; an initial step which put
> everything under the namespace `roaring` and a second one that breaks it
> out in a more granular way

A typical C++ client would want to use the C++ interface definitions
and have nothing else in the global namespace.  This would suggest
that `using namespace roaring;` would not bring in C APIs, but only
C++ classes and utilities.

As it would be nice for testing or other purposes to have a way to get
access to the same APIs a C client (should have), this puts those under
the namespace `roaring::api`.

Everything that doesn't fit into these categories is put under the
namespace `roaring::internal`...with the exception of the contents
of configreport.h which are put under `roaring::misc`.

This tries to follow the C++ best practice of not putting `using`
statements in header files, where possible.  But since it needs to
compile as C there have to be a few exceptions.