### PR TITLE
Add namespace to generated amalgamation_demo.cpp

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -131,13 +131,13 @@ cat <<< '
 #include "roaring.hh"
 #include "roaring.c"
 int main() {
-  Roaring r1;
+  roaring::Roaring r1;
   for (uint32_t i = 100; i < 1000; i++) {
     r1.add(i);
   }
   std::cout << "cardinality = " << r1.cardinality() << std::endl;
 
-  Roaring64Map r2;
+  roaring::Roaring64Map r2;
   for (uint64_t i = 18000000000000000100ull; i < 18000000000000001000ull; i++) {
     r2.add(i);
   }

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -25,7 +25,9 @@ class Roaring64MapSetBitForwardIterator;
 class Roaring64MapSetBitBiDirectionalIterator;
 
 class Roaring64Map {
-   public:
+  typedef api::roaring_bitmap_t roaring_bitmap_t;
+
+  public:
     /**
      * Create an empty bitmap
      */
@@ -998,7 +1000,7 @@ class Roaring64MapSetBitForwardIterator {
 	const std::map<uint32_t, Roaring>& p;
     std::map<uint32_t, Roaring>::const_iterator map_iter;
     std::map<uint32_t, Roaring>::const_iterator map_end;
-    roaring_uint32_iterator_t i;
+    api::roaring_uint32_iterator_t i;
 };
 
 class Roaring64MapSetBitBiDirectionalIterator final :public Roaring64MapSetBitForwardIterator {


### PR DESCRIPTION
Users of the C++ class must now use Roaring from namespace `roaring`
The file `amalgamation_demo.cpp` is generated by a shell script, and
the script wasn't modified to use this namespacing.

This also exposed that the 64-bit class was dependent on the api::
namespace inclusion from the unit test.  When that namespace is not
included, it needs to qualify the `roaring_bitmap_t` and iterator
datatypes.