### PR TITLE
Global scope API in roaring.h, but not roaring.hh

### DIFF
--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -11,7 +11,9 @@ A C++ header for Roaring Bitmaps.
 #include <stdexcept>
 #include <string>
 
+#define ROARING_API_NOT_IN_GLOBAL_NAMESPACE  // see remarks in roaring.h
 #include <roaring/roaring.h>
+#undef ROARING_API_NOT_IN_GLOBAL_NAMESPACE
 
 namespace roaring {
 

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -785,4 +785,22 @@ uint32_t roaring_read_uint32_iterator(roaring_uint32_iterator_t *it, uint32_t* b
 } } }  // extern "C" { namespace roaring { namespace api {
 #endif
 
+#endif  /* ROARING_H */
+
+#ifdef __cplusplus
+    /**
+     * Best practices for C++ headers is to avoid polluting global scope.
+     * But for C compatibility when just `roaring.h` is included building as
+     * C++, default to global access for the C public API.
+     *
+     * BUT when `roaring.hh` is included instead, it sets this flag.  That way
+     * explicit namespacing must be used to get the C functions.
+     *
+     * This is outside the include guard so that if you include BOTH headers, 
+     * the order won't matter; you still get the global definitions.
+     */
+    #if !defined(ROARING_API_NOT_IN_GLOBAL_NAMESPACE)
+        using namespace ::roaring::api;
+    #endif
 #endif
+

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -14,8 +14,7 @@ extern "C" {
 #include "test.h"
 }
 
-#include <roaring/roaring.h>
-using namespace roaring::api;  // access to pure C exported API for testing
+#include <roaring/roaring.h>  // access to pure C exported API for testing
 
 #include "roaring.hh"
 using roaring::Roaring;  // the C++ wrapper class


### PR DESCRIPTION
This tweak makes the inclusion of roaring.H under a C++ build pull
the definitions for the C API into global scope.  But an inclusion
of roaring.HH will suppress that `using` statement.

As a result, you can get C compatible semantics when superficially
building a codebase using a C++ compiler.  But purposeful use of
the C++ header will require explicit `using` of the C API.

This strategy resembles the compatibility headers like `stdio.h`
which act like their C counterparts by adding the std:: namespaced
definitions, e.g. of `<cstdio>`, to global scope.

https://stackoverflow.com/q/10460250/cstdio-stdio-h-namespace