### PR TITLE
Inplace andnot/xor/lazy_xor Shared container leak

### DIFF
--- a/src/roaring.c
+++ b/src/roaring.c
@@ -985,9 +985,16 @@ void roaring_bitmap_xor_inplace(roaring_bitmap_t *x1,
             // require making a copy and then doing the computation in place which is likely 
             // less efficient than avoiding in place entirely and always generating a new 
             // container.
-            void *c = (container_type_1 == SHARED_CONTAINER_TYPE_CODE) ?
-              container_xor(c1, container_type_1, c2, container_type_2, &container_result_type)
-              : container_ixor(c1, container_type_1, c2, container_type_2, &container_result_type);
+            void *c;
+            if (container_type_1 == SHARED_CONTAINER_TYPE_CODE) {
+                c = container_xor(c1, container_type_1,  // doesn't free c1
+                        c2, container_type_2, &container_result_type);
+                shared_container_free((shared_container_t *)c1);  // so release
+            }
+            else {
+                c = container_ixor(c1, container_type_1, c2, container_type_2,
+                                   &container_result_type);
+            }
 
             if (container_nonzero_cardinality(c, container_result_type)) {
                 ra_set_container_at_index(&x1->high_low_container, pos1, c,
@@ -1135,10 +1142,16 @@ void roaring_bitmap_andnot_inplace(roaring_bitmap_t *x1,
             // require making a copy and then doing the computation in place which is likely 
             // less efficient than avoiding in place entirely and always generating a new 
             // container.
-            void *c = (container_type_1 == SHARED_CONTAINER_TYPE_CODE) ?
-              container_andnot(c1, container_type_1, c2, container_type_2, &container_result_type)
-              : container_iandnot(c1, container_type_1, c2, container_type_2, &container_result_type);
-
+            void *c;
+            if (container_type_1 == SHARED_CONTAINER_TYPE_CODE) {
+                c = container_andnot(c1, container_type_1,  // doesn't free c1
+                            c2, container_type_2, &container_result_type);
+                shared_container_free((shared_container_t *)c1);  // so release
+            }
+            else { 
+                c = container_iandnot(c1, container_type_1, c2,
+                                container_type_2, &container_result_type);
+            }
             if (container_nonzero_cardinality(c, container_result_type)) {
                 ra_replace_key_and_container_at_index(&x1->high_low_container,
                                                       intersection_size++, s1,
@@ -2403,9 +2416,16 @@ void roaring_bitmap_lazy_xor_inplace(roaring_bitmap_t *x1,
             // require making a copy and then doing the computation in place which is likely 
             // less efficient than avoiding in place entirely and always generating a new 
             // container.
-            void *c = (container_type_1 == SHARED_CONTAINER_TYPE_CODE) ?
-              container_lazy_xor(c1, container_type_1, c2, container_type_2, &container_result_type)
-              : container_lazy_ixor(c1, container_type_1, c2, container_type_2, &container_result_type);
+            void *c;
+            if (container_type_1 == SHARED_CONTAINER_TYPE_CODE) {
+                c = container_lazy_xor(c1, container_type_1,  // doesn't free c1
+                                c2, container_type_2, &container_result_type);
+                shared_container_free((shared_container_t *)c1);  // so release
+            }
+            else {
+                c = container_lazy_ixor(c1, container_type_1, c2,
+                                    container_type_2, &container_result_type);
+            }
             if (container_nonzero_cardinality(c, container_result_type)) {
                 ra_set_container_at_index(&x1->high_low_container, pos1, c,
                                           container_result_type);


### PR DESCRIPTION
Address sanitizer was reporting memory leaks when running the
`toplevel_unit` tests.  The leaks originated in the inplace
andnot/xor/lazy_xor code, and are connected to the choice to
not perform an inplace operation when a container is shared...
but to call into the non-modifying forms.

The and/or operations have code which checks if the resulting
container from an operation does not match the input and frees
the input container, like:

    if (c != c1) {  // in this instance a new container was
                    // created, and we need to free the old one
         container_free(c1, typecode1);
    }

There is no such code for andnot/xor/lazy_xor.  Instead the
inplace branches seem to do their own freeing of replaced
containers.  But the non-inplace branch does not account for the
needed drop of a refcount on the shared container that is being
replaced.

This adds a call to `shared_container_free()` on those branches,
which appears to stop the leaks in `toplevel_unit`.