### PR TITLE
hide containers.h/roaring_array.h from public api

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -5,23 +5,31 @@
 ########################################################################
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
+timestamp=$(date)  # capture to label files with their generation time
+
 echo "We are about to amalgamate all CRoaring files into one source file. "
 echo "See https://www.sqlite.org/amalgamation.html and https://en.wikipedia.org/wiki/Single_Compilation_Unit for rationale. "
 
 AMAL_H="roaring.h"
 AMAL_C="roaring.c"
 
-# order does not matter
-ALLCFILES=$( ( [ -d $SCRIPTPATH/.git ] && ( type git >/dev/null 2>&1 ) &&  ( git ls-files $SCRIPTPATH/src/*.c $SCRIPTPATH/src/**/*c ) ) ||  ( find $SCRIPTPATH/src -name '*.c' ) )
-
 # order matters
-ALLCHEADERS="
-$SCRIPTPATH/src/license-comment.h
+ALL_PUBLIC_H="
 $SCRIPTPATH/include/roaring/roaring_version.h
+$SCRIPTPATH/include/roaring/roaring_types.h
+$SCRIPTPATH/include/roaring/roaring.h
+"
+
+# order does not matter
+ALL_PRIVATE_C=$( ( [ -d $SCRIPTPATH/.git ] && ( type git >/dev/null 2>&1 ) &&  ( git ls-files $SCRIPTPATH/src/*.c $SCRIPTPATH/src/**/*c ) ) ||  ( find $SCRIPTPATH/src -name '*.c' ) )
+
+# these private header files are embedded at the head of the amalgamated C file
+# the amalgamated public header file must be #include'd before the private ones
+# order matters
+ALL_PRIVATE_H="
 $SCRIPTPATH/include/roaring/portability.h
 $SCRIPTPATH/include/roaring/containers/perfparameters.h
 $SCRIPTPATH/include/roaring/array_util.h
-$SCRIPTPATH/include/roaring/roaring_types.h
 $SCRIPTPATH/include/roaring/utilasm.h
 $SCRIPTPATH/include/roaring/bitset_util.h
 $SCRIPTPATH/include/roaring/containers/array.h
@@ -38,20 +46,32 @@ $SCRIPTPATH/include/roaring/containers/mixed_xor.h
 $SCRIPTPATH/include/roaring/containers/containers.h
 $SCRIPTPATH/include/roaring/roaring_array.h
 $SCRIPTPATH/include/roaring/misc/configreport.h
-$SCRIPTPATH/include/roaring/roaring.h
 "
 
-for i in ${ALLCHEADERS} ${ALLCFILES}; do
+for i in ${ALL_PUBLIC_H} ${ALL_PRIVATE_C} ${ALL_PUBLIC_H}; do
     test -e $i && continue
     echo "FATAL: source file [$i] not found."
     exit 127
 done
 
+function echo_timestamp()
+{
+    echo "// !!! DO NOT EDIT - THIS IS AN AUTO-GENERATED FILE !!!"
+    echo "// Created by amalgamation.sh on ${timestamp}"
+    echo ""  # newline
+}
+
+function echo_license()
+{
+    cat $SCRIPTPATH/src/license-comment.h
+    echo ""  # newline
+}
 
 function stripinc()
 {
     sed -e '/# *include *"/d' -e '/# *include *<roaring\//d'
 }
+
 function dofile()
 {
     RELFILE=${1#"$SCRIPTPATH/"}
@@ -61,19 +81,22 @@ function dofile()
     echo "/* end file $RELFILE */"
 }
 
-timestamp=$(date)
 echo "Creating ${AMAL_H}..."
-echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${AMAL_H}"
 {
-    for h in ${ALLCHEADERS}; do
+    echo_timestamp
+    echo_license
+
+    for h in ${ALL_PUBLIC_H}; do
         dofile $h
     done
-} >> "${AMAL_H}"
+} > "${AMAL_H}"
 
 
 echo "Creating ${AMAL_C}..."
-echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${AMAL_C}"
 {
+    echo_timestamp
+    echo_license
+  
     echo "#include \"${AMAL_H}\""
 
     echo ""
@@ -83,18 +106,20 @@ echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${AMAL_C}"
     echo "#endif"
     echo ""
 
-    for h in "$SCRIPTPATH/src/license-comment.h" ${ALLCFILES}; do
+    echo "#include \"roaring.h\"  /* include public API definitions */"
+
+    for h in ${ALL_PRIVATE_H} ${ALL_PRIVATE_C}; do
         dofile $h
     done
-} >> "${AMAL_C}"
-
-
+} > "${AMAL_C}"
 
 
 DEMOC="amalgamation_demo.c"
 echo "Creating ${DEMOC}..."
-echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${DEMOC}"
-cat <<< '
+{
+    echo_timestamp
+
+    cat <<< '
 #include <stdio.h>
 #include "roaring.c"
 int main() {
@@ -104,7 +129,8 @@ int main() {
   roaring_bitmap_free(r1);
   return 0;
 }
-' >>  "${DEMOC}"
+'
+} > "${DEMOC}"
 
 
 echo "Done with C amalgamation. Proceeding with C++ wrap."
@@ -112,21 +138,37 @@ echo "Done with C amalgamation. Proceeding with C++ wrap."
 AMAL_HH="roaring.hh"
 
 echo "Creating ${AMAL_HH}..."
-ALLCPPHEADERS="$SCRIPTPATH/cpp/roaring.hh $SCRIPTPATH/cpp/roaring64map.hh"
-echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${AMAL_HH}"
+ALL_PUBLIC_HH="$SCRIPTPATH/cpp/roaring.hh $SCRIPTPATH/cpp/roaring64map.hh"
 {
-    echo "#include \"${AMAL_H}\""
+    echo_timestamp
+    echo_license
 
-    for h in "$SCRIPTPATH/src/license-comment.h" ${ALLCPPHEADERS}; do
-        dofile $h
+    # using the C++ roaring:: namespace does not make the C API available by
+    # default.  One must either `#include "roaring.h"` manually or use the
+    # `roaring::api::` namespace.  The protection against putting the API in
+    # global scope is one via a #define surrounding the include, but that
+    # inclusion is stripped out so we repeat it here.
+    #
+    # !!! This would be better if it found the inclusion of roaring.h and
+    # replaced it with the amalgamated file.
+    #
+    echo "#define ROARING_API_NOT_IN_GLOBAL_NAMESPACE  // see remarks in roaring.h"
+    echo "#include \"${AMAL_H}\""
+    echo "#undef ROARING_API_NOT_IN_GLOBAL_NAMESPACE"
+
+    for hh in ${ALL_PUBLIC_HH}; do
+        dofile $hh
     done
-} >> "${AMAL_HH}"
+} > "${AMAL_HH}"
 
 
 DEMOCPP="amalgamation_demo.cpp"
 echo "Creating ${DEMOCPP}..."
-echo "/* auto-generated on ${timestamp}. Do not edit! */" > "${DEMOCPP}"
-cat <<< '
+{
+    echo_timestamp
+    echo_license
+
+    cat <<< '
 #include <iostream>
 #include "roaring.hh"
 #include "roaring.c"
@@ -144,7 +186,8 @@ int main() {
   std::cout << "cardinality = " << r2.cardinality() << std::endl;
   return 0;
 }
-' >>  "${DEMOCPP}"
+'
+} >  "${DEMOCPP}"
 echo "Done with C++."
 
 echo "Done with all files generation. "

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -26,10 +26,11 @@ class Roaring {
 
   public:
     /**
-     * Create an empty bitmap
+     * Create an empty bitmap in the existing memory for the class.
+     * The bitmap will be in the "clear" state with no auxiliary allocations.
      */
     Roaring() {
-        internal::ra_init(&roaring.high_low_container);
+        api::roaring_bitmap_init_cleared(&roaring);
     }
 
     /**
@@ -42,11 +43,8 @@ class Roaring {
     /**
      * Copy constructor
      */
-    Roaring(const Roaring &r) {
-        bool is_ok = internal::ra_copy(
-            &r.roaring.high_low_container, &roaring.high_low_container,
-                    roaring_bitmap_get_copy_on_write(&r.roaring));
-        if (!is_ok) {
+    Roaring(const Roaring &r) : Roaring() {
+        if (!api::roaring_bitmap_overwrite(&roaring, &r.roaring)) {
             throw std::runtime_error("failed memory alloc in constructor");
         }
         api::roaring_bitmap_set_copy_on_write(&roaring,
@@ -58,21 +56,26 @@ class Roaring {
      * all methods can still be called on it.
      */
     Roaring(Roaring &&r) noexcept {
-        roaring = std::move(r.roaring);
-        internal::ra_init(&r.roaring.high_low_container);
+        //
+        // !!! This clones the bits of the roaring structure to a new location
+        // and then overwrites the old bits...assuming that this will still
+        // work.  There are scenarios where this could break; e.g. if some of
+        // those bits were pointers into the structure memory itself.  If such
+        // things were possible, a roaring_bitmap_move() API would be needed.
+        //
+        roaring = r.roaring;
+        api::roaring_bitmap_init_cleared(&r.roaring);
     }
 
     /**
-     * Construct a roaring object from the C struct.
+     * Construct a roaring object by taking control of a malloc()'d C struct.
      *
-     * Passing a NULL point is unsafe.
-     * the pointer to the C struct will be invalid after the call.
+     * Passing a NULL pointer is unsafe.
+     * The pointer to the C struct will be invalid after the call.
      */
     Roaring(roaring_bitmap_t *s) noexcept {
-        // steal the interior struct
-        roaring.high_low_container = s->high_low_container;
-        // deallocate the old container
-        free(s);
+        roaring = *s;  // steal the content of the roaring_bitmap_t
+        free(s);  // deallocate the passed-in pointer
     }
 
     /**
@@ -159,20 +162,17 @@ class Roaring {
     }
 
     /**
-     * Destructor
+     * Destructor.  By contract, calling roaring_bitmap_clear() is enough to
+     * release all auxiliary memory used by the structure.
      */
-    ~Roaring() { internal::ra_clear(&roaring.high_low_container); }
+    ~Roaring() { api::roaring_bitmap_clear(&roaring); }
 
     /**
      * Copies the content of the provided bitmap, and
      * discard the current content.
      */
     Roaring &operator=(const Roaring &r) {
-        internal::ra_clear(&roaring.high_low_container);
-        bool is_ok = internal::ra_copy(
-            &r.roaring.high_low_container, &roaring.high_low_container,
-                    roaring_bitmap_get_copy_on_write(&r.roaring));
-        if (!is_ok) {
+        if (!api::roaring_bitmap_overwrite(&roaring, &r.roaring)) {
             throw std::runtime_error("failed memory alloc in assignment");
         }
         api::roaring_bitmap_set_copy_on_write(&roaring,
@@ -185,9 +185,13 @@ class Roaring {
      * discard the current content.
      */
     Roaring &operator=(Roaring &&r) noexcept {
-        internal::ra_clear(&roaring.high_low_container);
-        roaring = std::move(r.roaring);
-        internal::ra_init(&r.roaring.high_low_container);
+        api::roaring_bitmap_clear(&roaring);  // free this class's allocations
+
+        // !!! See notes in the Move Constructor regaring roaring_bitmap_move()
+        //
+        roaring = r.roaring;
+        api::roaring_bitmap_init_cleared(&r.roaring);
+
         return *this;
     }
 

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -15,6 +15,8 @@ A C++ header for Roaring Bitmaps.
 #include <roaring/roaring.h>
 #undef ROARING_API_NOT_IN_GLOBAL_NAMESPACE
 
+#include <roaring/roaring_array.h>  // roaring::internal array functions used
+
 namespace roaring {
 
 class RoaringSetBitForwardIterator;

--- a/include/roaring/roaring_array.h
+++ b/include/roaring/roaring_array.h
@@ -2,46 +2,14 @@
 #define INCLUDE_ROARING_ARRAY_H
 
 #include <assert.h>
-#include <roaring/array_util.h>
-#include <roaring/containers/containers.h>
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <roaring/containers/containers.h>  // get_writable_copy_if_shared()
+#include <roaring/array_util.h>
+
 #ifdef __cplusplus
 extern "C" { namespace roaring {
-
-namespace api {
-#endif
-
-#define MAX_CONTAINERS 65536
-
-#define SERIALIZATION_ARRAY_UINT32 1
-#define SERIALIZATION_CONTAINER 2
-
-#define ROARING_FLAG_COW UINT8_C(0x1)
-#define ROARING_FLAG_FROZEN UINT8_C(0x2)
-
-/**
- * Roaring arrays are array-based key-value pairs having containers as values
- * and 16-bit integer keys. A roaring bitmap  might be implemented as such.
- */
-
-// parallel arrays.  Element sizes quite different.
-// Alternative is array
-// of structs.  Which would have better
-// cache performance through binary searches?
-
-typedef struct roaring_array_s {
-    int32_t size;
-    int32_t allocation_size;
-    void **containers;
-    uint16_t *keys;
-    uint8_t *typecodes;
-    uint8_t flags;
-} roaring_array_t;
-
-#ifdef __cplusplus
-}  // namespace api
 
 // Note: in pure C++ code, you should avoid putting `using` in header files
 using api::roaring_array_t;

--- a/include/roaring/roaring_types.h
+++ b/include/roaring/roaring_types.h
@@ -5,9 +5,40 @@
 #ifndef ROARING_TYPES_H
 #define ROARING_TYPES_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" { namespace roaring { namespace api {
 #endif
+
+#define MAX_CONTAINERS 65536
+
+#define SERIALIZATION_ARRAY_UINT32 1
+#define SERIALIZATION_CONTAINER 2
+
+#define ROARING_FLAG_COW UINT8_C(0x1)
+#define ROARING_FLAG_FROZEN UINT8_C(0x2)
+
+/**
+ * Roaring arrays are array-based key-value pairs having containers as values
+ * and 16-bit integer keys. A roaring bitmap  might be implemented as such.
+ */
+
+// parallel arrays.  Element sizes quite different.
+// Alternative is array
+// of structs.  Which would have better
+// cache performance through binary searches?
+
+typedef struct roaring_array_s {
+    int32_t size;
+    int32_t allocation_size;
+    void **containers;
+    uint16_t *keys;
+    uint8_t *typecodes;
+    uint8_t flags;
+} roaring_array_t;
+
 
 typedef bool (*roaring_iterator)(uint32_t value, void *param);
 typedef bool (*roaring_iterator64)(uint64_t value, void *param);

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -70,16 +70,6 @@ static inline void *containerptr_roaring_bitmap_add(roaring_bitmap_t *r,
     }
 }
 
-roaring_bitmap_t *roaring_bitmap_create() {
-    roaring_bitmap_t *ans =
-        (roaring_bitmap_t *)malloc(sizeof(roaring_bitmap_t));
-    if (!ans) {
-        return NULL;
-    }
-    ra_init(&ans->high_low_container);
-    return ans;
-}
-
 roaring_bitmap_t *roaring_bitmap_create_with_capacity(uint32_t cap) {
     roaring_bitmap_t *ans =
         (roaring_bitmap_t *)malloc(sizeof(roaring_bitmap_t));
@@ -93,6 +83,11 @@ roaring_bitmap_t *roaring_bitmap_create_with_capacity(uint32_t cap) {
     }
     return ans;
 }
+
+bool roaring_bitmap_init_with_capacity(roaring_bitmap_t *r, uint32_t cap) {
+    return ra_init_with_capacity(&r->high_low_container, cap);
+}
+
 
 void roaring_bitmap_add_many(roaring_bitmap_t *r, size_t n_args,
                              const uint32_t *vals) {

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -116,47 +116,6 @@ void ra_init(roaring_array_t *new_ra) {
     new_ra->flags = 0;
 }
 
-bool ra_copy(const roaring_array_t *source, roaring_array_t *dest,
-             bool copy_on_write) {
-    if (!ra_init_with_capacity(dest, source->size)) return false;
-    dest->size = source->size;
-    dest->allocation_size = source->size;
-    if(dest->size > 0) {
-      memcpy(dest->keys, source->keys, dest->size * sizeof(uint16_t));
-    }
-    // we go through the containers, turning them into shared containers...
-    if (copy_on_write) {
-        for (int32_t i = 0; i < dest->size; ++i) {
-            source->containers[i] = get_copy_of_container(
-                source->containers[i], &source->typecodes[i], copy_on_write);
-        }
-        // we do a shallow copy to the other bitmap
-        if(dest->size > 0) {
-          memcpy(dest->containers, source->containers,
-               dest->size * sizeof(void *));
-          memcpy(dest->typecodes, source->typecodes,
-               dest->size * sizeof(uint8_t));
-        }
-    } else {
-        if(dest->size > 0) {
-          memcpy(dest->typecodes, source->typecodes,
-               dest->size * sizeof(uint8_t));
-        }
-        for (int32_t i = 0; i < dest->size; i++) {
-            dest->containers[i] =
-                container_clone(source->containers[i], source->typecodes[i]);
-            if (dest->containers[i] == NULL) {
-                for (int32_t j = 0; j < i; j++) {
-                    container_free(dest->containers[j], dest->typecodes[j]);
-                }
-                ra_clear_without_containers(dest);
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
 bool ra_overwrite(const roaring_array_t *source, roaring_array_t *dest,
                   bool copy_on_write) {
     ra_clear_containers(dest);  // we are going to overwrite them

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -160,6 +160,9 @@ bool ra_copy(const roaring_array_t *source, roaring_array_t *dest,
 bool ra_overwrite(const roaring_array_t *source, roaring_array_t *dest,
                   bool copy_on_write) {
     ra_clear_containers(dest);  // we are going to overwrite them
+    if (source->size == 0) {  // Note: can't call memcpy(NULL), even w/size 0
+        return true;  // output was just cleared, so they match
+    }
     if (dest->allocation_size < source->size) {
         if (!realloc_array(dest, source->size)) {
             return false;

--- a/src/roaring_priority_queue.c
+++ b/src/roaring_priority_queue.c
@@ -1,4 +1,6 @@
 #include <roaring/roaring.h>
+#include <roaring/roaring_array.h>
+
 
 #ifdef __cplusplus
 using namespace ::roaring::internal;

--- a/tests/realdata_unit.c
+++ b/tests/realdata_unit.c
@@ -2,8 +2,12 @@
  * realdata_unit.c
  */
 #define _GNU_SOURCE
-#include <roaring/roaring.h>
-#include <roaring/roaring_types.h>
+
+#include <assert.h>
+
+#include <roaring/roaring.h>  // public api
+
+#include <roaring/array_util.h>  // union_uint32(), intersection_uint32()
 
 #include "../benchmarks/numbersfromtextfiles.h"
 #include "config.h"

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -6,6 +6,10 @@
 
 #include <roaring/roaring.h>
 
+// include internal headers for invasive testing
+#include <roaring/containers/containers.h>
+#include <roaring/roaring_array.h>
+
 #include "test.h"
 
 static unsigned int seed = 123456789;


### PR DESCRIPTION
The function roaring_bitmap_contains() in the C API was declared as
inline, pulling in a considerable set of dependencies.  Usage of the
container_contains() function brought in definitions for
bitset_container_t, array_container_t, run_container_t, as well as
all the needed support functions.

While inlining can give considerable advantages, the definition of
this particular public export as inline causes collateral damage
that is unlikely to move the needle much to client performance.

This migrates the implementation of roaring_bitmap_contains() into
roaring.c, and moves the `roaring_array_t` from roaring_array.h
into roaring_types.h.  This then allows containers.h to be removed
from the public API.

Code such as tests that wants to use the internal functions thus
must include the internal headers to do so.  (Using the internal API
to reuse code is also an axis that some clients might take in
pursuit of greater performance, if they were willing to deal with
internals changing.)

**Also: Remove dependence of C++ class on roaring_array.h**

Another step to reducing the export surface for the API, is to add
a missing routine needed by C++ to initialize a roaring
bitmap structure in client-controlled memory.

Previously the C++ class had to include roaring_array.h and use
ra_init(), otherwise the only way it could create a bitmap would
be through a malloc()'d handle.  roaring_bitmap_init_with_capacity()
is added to the API to provide this.

(roaring_bitmap_init_cleared() is created as an inline that calls
roaring_bitmap_init_capacity() with 0, to show that by contract in
the API that these are not semantically different.  Since it cuts
down on variation, the change is applied to roaring_bitmap_create()
as well, as an inline call to roaring_bitmap_create_with_capacity())

The other features used by the C++ class were ra_copy(), which
already had an export suitable for the functionality in
roaring_bitmap_overwrite() (rebased onto a bugfix for that). Also
ra_clear(), effectively available as roaring_bitmap_clear()

With this change, roaring_array.h and containers.h can be left out
of the usage of the C++ API as well; leading to *many* fewer exports.