### PR TITLE
Unify ra_copy() and ra_overwrite() 

### DIFF
--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -116,47 +116,6 @@ void ra_init(roaring_array_t *new_ra) {
     new_ra->flags = 0;
 }
 
-bool ra_copy(const roaring_array_t *source, roaring_array_t *dest,
-             bool copy_on_write) {
-    if (!ra_init_with_capacity(dest, source->size)) return false;
-    dest->size = source->size;
-    dest->allocation_size = source->size;
-    if(dest->size > 0) {
-      memcpy(dest->keys, source->keys, dest->size * sizeof(uint16_t));
-    }
-    // we go through the containers, turning them into shared containers...
-    if (copy_on_write) {
-        for (int32_t i = 0; i < dest->size; ++i) {
-            source->containers[i] = get_copy_of_container(
-                source->containers[i], &source->typecodes[i], copy_on_write);
-        }
-        // we do a shallow copy to the other bitmap
-        if(dest->size > 0) {
-          memcpy(dest->containers, source->containers,
-               dest->size * sizeof(void *));
-          memcpy(dest->typecodes, source->typecodes,
-               dest->size * sizeof(uint8_t));
-        }
-    } else {
-        if(dest->size > 0) {
-          memcpy(dest->typecodes, source->typecodes,
-               dest->size * sizeof(uint8_t));
-        }
-        for (int32_t i = 0; i < dest->size; i++) {
-            dest->containers[i] =
-                container_clone(source->containers[i], source->typecodes[i]);
-            if (dest->containers[i] == NULL) {
-                for (int32_t j = 0; j < i; j++) {
-                    container_free(dest->containers[j], dest->typecodes[j]);
-                }
-                ra_clear_without_containers(dest);
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
 bool ra_overwrite(const roaring_array_t *source, roaring_array_t *dest,
                   bool copy_on_write) {
     ra_clear_containers(dest);  // we are going to overwrite them

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -160,6 +160,9 @@ bool ra_copy(const roaring_array_t *source, roaring_array_t *dest,
 bool ra_overwrite(const roaring_array_t *source, roaring_array_t *dest,
                   bool copy_on_write) {
     ra_clear_containers(dest);  // we are going to overwrite them
+    if (source->size == 0) {  // Note: can't call memcpy(NULL), even w/size 0
+        return true;  // output was just cleared, so they match
+    }
     if (dest->allocation_size < source->size) {
         if (!realloc_array(dest, source->size)) {
             return false;


### PR DESCRIPTION
Finding a problem in ra_overwrite() that had been worked around in
ra_copy() drew attention to how similar the two routines were (and
that a difference was only a bug).

The semantics were that ra_copy() assumed it was writing into
uninitialized memory while ra_overwrite() was willing to reuse the
existing capacity of a roaring_array_t if it was big enough.

This reframes the roaring_bitmap_copy() routine as initializing a
list of containers of the appropriate size (so it won't need a
realloc_array()) and then calling ra_overwrite().  ra_copy() is
then deleted.