### PR TITLE
void* -> container_t*, checked in C++ builds

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -48,6 +48,7 @@ $SCRIPTPATH/cpp/roaring64map.hh
 ALL_PRIVATE_H="
 $SCRIPTPATH/include/roaring/portability.h
 $SCRIPTPATH/include/roaring/containers/perfparameters.h
+$SCRIPTPATH/include/roaring/containers/container_defs.h
 $SCRIPTPATH/include/roaring/array_util.h
 $SCRIPTPATH/include/roaring/utilasm.h
 $SCRIPTPATH/include/roaring/bitset_util.h

--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -8,10 +8,11 @@
 
 #include <string.h>
 
-#include <roaring/array_util.h>
-#include <roaring/containers/perfparameters.h>
 #include <roaring/portability.h>
-#include <roaring/roaring_types.h>
+#include <roaring/roaring_types.h>  // roaring_iterator
+#include <roaring/array_util.h>  // binarySearch()/memequals() for inlining
+
+#include <roaring/containers/container_defs.h>  // container_t, perfparameters
 
 #ifdef __cplusplus
 extern "C" { namespace roaring {
@@ -32,7 +33,7 @@ enum { DEFAULT_MAX_SIZE = 4096 };
  * @capacity:    allocated size of `array`
  * @array:       sorted list of integers
  */
-struct array_container_s {
+STRUCT_CONTAINER(array_container_s) {
     int32_t cardinality;
     int32_t capacity;
     uint16_t *array;

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -6,11 +6,14 @@
 #ifndef INCLUDE_CONTAINERS_BITSET_H_
 #define INCLUDE_CONTAINERS_BITSET_H_
 
-#include <roaring/portability.h>
-#include <roaring/roaring_types.h>
-#include <roaring/utilasm.h>
 #include <stdbool.h>
 #include <stdint.h>
+
+#include <roaring/portability.h>
+#include <roaring/roaring_types.h>  // roaring_iterator
+#include <roaring/utilasm.h>  // ASM_XXX macros
+
+#include <roaring/containers/container_defs.h>  // container_t, perfparameters
 
 #ifdef __cplusplus
 extern "C" { namespace roaring {
@@ -33,7 +36,7 @@ enum {
     BITSET_UNKNOWN_CARDINALITY = -1
 };
 
-struct bitset_container_s {
+STRUCT_CONTAINER(bitset_container_s) {
     int32_t cardinality;
     uint64_t *array;
 };

--- a/include/roaring/containers/container_defs.h
+++ b/include/roaring/containers/container_defs.h
@@ -1,0 +1,61 @@
+/*
+ * container_defs.h
+ *
+ * Unlike containers.h (which is a file aggregating all the container includes,
+ * like array.h, bitset.h, and run.h) this is a file included BY those headers
+ * to do things like define the container base class `container_t`.
+ */
+
+#ifndef INCLUDE_CONTAINERS_CONTAINER_DEFS_H_
+#define INCLUDE_CONTAINERS_CONTAINER_DEFS_H_
+
+// The preferences are a separate file to separate out tweakable parameters
+#include <roaring/containers/perfparameters.h>
+
+#ifdef __cplusplus
+extern "C" { namespace roaring { namespace internal {
+#endif
+
+
+/*
+ * Since roaring_array_t's definition is not opaque, the container type is
+ * part of the API.  If it's not going to be `void*` then it needs a name, and
+ * expectations are to prefix C library-exported names with `roaring_` etc.
+ *
+ * Rather than force the whole codebase to use the name `roaring_container_t`,
+ * the few API appearances use the macro ROARING_CONTAINER_T.  Those includes
+ * are prior to containers.h, so make a short private alias of `container_t`.
+ * Then undefine the awkward macro so it's not used any more than it has to be.
+ */
+typedef ROARING_CONTAINER_T container_t;
+#undef ROARING_CONTAINER_T
+
+
+/*
+ * See ROARING_CONTAINER_T for notes on using container_t as a base class.
+ * This macro helps make the following pattern look nicer:
+ *
+ *     #ifdef __cplusplus
+ *     struct roaring_array_s : public container_t {
+ *     #else
+ *     struct roaring_array_s {
+ *     #endif
+ *         int32_t cardinality;
+ *         int32_t capacity;
+ *         uint16_t *array;
+ *     }
+ */
+#if defined(__cplusplus)
+    #define STRUCT_CONTAINER(name) \
+        struct name : public container_t  /* { ... } */
+#else
+    #define STRUCT_CONTAINER(name) \
+        struct name  /* { ... } */
+#endif
+
+
+#ifdef __cplusplus
+} } }  // extern "C" { namespace roaring { namespace internal {
+#endif
+
+#endif  /* INCLUDE_CONTAINERS_CONTAINER_DEFS_H_ */

--- a/include/roaring/containers/convert.h
+++ b/include/roaring/containers/convert.h
@@ -34,31 +34,36 @@ run_container_t *run_container_from_array(const array_container_t *c);
 
 /* convert a run into either an array or a bitset
  * might free the container. This does not free the input run container. */
-void *convert_to_bitset_or_array_container(run_container_t *r, int32_t card,
-                                           uint8_t *resulttype);
+container_t *convert_to_bitset_or_array_container(
+        run_container_t *r, int32_t card,
+        uint8_t *resulttype);
 
 /* convert containers to and from runcontainers, as is most space efficient.
  * The container might be freed. */
-void *convert_run_optimize(void *c, uint8_t typecode_original,
-                           uint8_t *typecode_after);
+container_t *convert_run_optimize(
+        container_t *c, uint8_t typecode_original,
+        uint8_t *typecode_after);
 
 /* converts a run container to either an array or a bitset, IF it saves space.
  */
 /* If a conversion occurs, the caller is responsible to free the original
  * container and
  * he becomes reponsible to free the new one. */
-void *convert_run_to_efficient_container(run_container_t *c,
-                                         uint8_t *typecode_after);
+container_t *convert_run_to_efficient_container(
+        run_container_t *c, uint8_t *typecode_after);
+
 // like convert_run_to_efficient_container but frees the old result if needed
-void *convert_run_to_efficient_container_and_free(run_container_t *c,
-                                                  uint8_t *typecode_after);
+container_t *convert_run_to_efficient_container_and_free(
+        run_container_t *c, uint8_t *typecode_after);
 
 /**
  * Create new container which is a union of run container and
  * range [min, max]. Caller is responsible for freeing run container.
  */
-void *container_from_run_range(const run_container_t *run,
-                                                    uint32_t min, uint32_t max, uint8_t *typecode_after);
+container_t *container_from_run_range(
+        const run_container_t *run,
+        uint32_t min, uint32_t max,
+        uint8_t *typecode_after);
 
 #ifdef __cplusplus
 } } }  // extern "C" { namespace roaring { namespace internal {

--- a/include/roaring/containers/mixed_andnot.h
+++ b/include/roaring/containers/mixed_andnot.h
@@ -29,8 +29,9 @@ void array_bitset_container_iandnot(array_container_t *src_1,
  * Return true for a bitset result; false for array
  */
 
-bool bitset_array_container_andnot(const bitset_container_t *src_1,
-                                   const array_container_t *src_2, void **dst);
+bool bitset_array_container_andnot(
+        const bitset_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
 /* Compute the andnot of src_1 and src_2 and write the result to
  * dst (which has no container initially).  It will modify src_1
@@ -39,8 +40,9 @@ bool bitset_array_container_andnot(const bitset_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-bool bitset_array_container_iandnot(bitset_container_t *src_1,
-                                    const array_container_t *src_2, void **dst);
+bool bitset_array_container_iandnot(
+        bitset_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
 /* Compute the andnot of src_1 and src_2 and write the result to
  * dst. Result may be either a bitset or an array container
@@ -49,8 +51,9 @@ bool bitset_array_container_iandnot(bitset_container_t *src_1,
  * result true) or an array container.
  */
 
-bool run_bitset_container_andnot(const run_container_t *src_1,
-                                 const bitset_container_t *src_2, void **dst);
+bool run_bitset_container_andnot(
+        const run_container_t *src_1, const bitset_container_t *src_2,
+        container_t **dst);
 
 /* Compute the andnot of src_1 and src_2 and write the result to
  * dst. Result may be either a bitset or an array container
@@ -59,8 +62,9 @@ bool run_bitset_container_andnot(const run_container_t *src_1,
  * result true) or an array container.
  */
 
-bool run_bitset_container_iandnot(run_container_t *src_1,
-                                  const bitset_container_t *src_2, void **dst);
+bool run_bitset_container_iandnot(
+        run_container_t *src_1, const bitset_container_t *src_2,
+        container_t **dst);
 
 /* Compute the andnot of src_1 and src_2 and write the result to
  * dst. Result may be either a bitset or an array container
@@ -69,8 +73,9 @@ bool run_bitset_container_iandnot(run_container_t *src_1,
  * result true) or an array container.
  */
 
-bool bitset_run_container_andnot(const bitset_container_t *src_1,
-                                 const run_container_t *src_2, void **dst);
+bool bitset_run_container_andnot(
+        const bitset_container_t *src_1, const run_container_t *src_2,
+        container_t **dst);
 
 /* Compute the andnot of src_1 and src_2 and write the result to
  * dst (which has no container initially).  It will modify src_1
@@ -79,15 +84,17 @@ bool bitset_run_container_andnot(const bitset_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-bool bitset_run_container_iandnot(bitset_container_t *src_1,
-                                  const run_container_t *src_2, void **dst);
+bool bitset_run_container_iandnot(
+        bitset_container_t *src_1, const run_container_t *src_2,
+        container_t **dst);
 
 /* dst does not indicate a valid container initially.  Eventually it
  * can become any type of container.
  */
 
-int run_array_container_andnot(const run_container_t *src_1,
-                               const array_container_t *src_2, void **dst);
+int run_array_container_andnot(
+        const run_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
 /* Compute the andnot of src_1 and src_2 and write the result to
  * dst (which has no container initially).  It will modify src_1
@@ -96,8 +103,9 @@ int run_array_container_andnot(const run_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-int run_array_container_iandnot(run_container_t *src_1,
-                                const array_container_t *src_2, void **dst);
+int run_array_container_iandnot(
+        run_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
 /* dst must be a valid array container, allowed to be src_1 */
 
@@ -116,8 +124,9 @@ void array_run_container_iandnot(array_container_t *src_1,
  * can become any kind of container.
  */
 
-int run_run_container_andnot(const run_container_t *src_1,
-                             const run_container_t *src_2, void **dst);
+int run_run_container_andnot(
+        const run_container_t *src_1, const run_container_t *src_2,
+        container_t **dst);
 
 /* Compute the andnot of src_1 and src_2 and write the result to
  * dst (which has no container initially).  It will modify src_1
@@ -126,8 +135,9 @@ int run_run_container_andnot(const run_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-int run_run_container_iandnot(run_container_t *src_1,
-                              const run_container_t *src_2, void **dst);
+int run_run_container_iandnot(
+        run_container_t *src_1, const run_container_t *src_2,
+        container_t **dst);
 
 /*
  * dst is a valid array container and may be the same as src_1
@@ -147,9 +157,9 @@ void array_array_container_iandnot(array_container_t *src_1,
  * "dst is a bitset"
  */
 
-bool bitset_bitset_container_andnot(const bitset_container_t *src_1,
-                                    const bitset_container_t *src_2,
-                                    void **dst);
+bool bitset_bitset_container_andnot(
+        const bitset_container_t *src_1, const bitset_container_t *src_2,
+        container_t **dst);
 
 /* Compute the andnot of src_1 and src_2 and write the result to
  * dst (which has no container initially).  It will modify src_1
@@ -158,9 +168,9 @@ bool bitset_bitset_container_andnot(const bitset_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-bool bitset_bitset_container_iandnot(bitset_container_t *src_1,
-                                     const bitset_container_t *src_2,
-                                     void **dst);
+bool bitset_bitset_container_iandnot(
+        bitset_container_t *src_1, const bitset_container_t *src_2,
+        container_t **dst);
 
 #ifdef __cplusplus
 } } }  // extern "C" { namespace roaring { namespace internal {

--- a/include/roaring/containers/mixed_intersection.h
+++ b/include/roaring/containers/mixed_intersection.h
@@ -44,7 +44,7 @@ bool array_bitset_container_intersect(const array_container_t *src_1,
  */
 bool bitset_bitset_container_intersection(const bitset_container_t *src_1,
                                           const bitset_container_t *src_2,
-                                          void **dst);
+                                          container_t **dst);
 
 /* Compute the intersection between src_1 and src_2 and write the result to
  * dst. It is allowed for dst to be equal to src_1. We assume that dst is a
@@ -60,7 +60,7 @@ void array_run_container_intersection(const array_container_t *src_1,
  **/
 bool run_bitset_container_intersection(const run_container_t *src_1,
                                        const bitset_container_t *src_2,
-                                       void **dst);
+                                       container_t **dst);
 
 /* Compute the size of the intersection between src_1 and src_2 . */
 int array_run_container_intersection_cardinality(const array_container_t *src_1,
@@ -90,7 +90,8 @@ bool run_bitset_container_intersect(const run_container_t *src_1,
  * In all cases, the result is in *dst.
  */
 bool bitset_bitset_container_intersection_inplace(
-    bitset_container_t *src_1, const bitset_container_t *src_2, void **dst);
+    bitset_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst);
 
 #ifdef __cplusplus
 } } }  // extern "C" { namespace roaring { namespace internal {

--- a/include/roaring/containers/mixed_negation.h
+++ b/include/roaring/containers/mixed_negation.h
@@ -31,7 +31,9 @@ void array_container_negation(const array_container_t *src,
  *  We assume that dst is not pre-allocated. In
  * case of failure, *dst will be NULL.
  */
-bool bitset_container_negation(const bitset_container_t *src, void **dst);
+bool bitset_container_negation(
+        const bitset_container_t *src,
+        container_t **dst);
 
 /* inplace version */
 /*
@@ -42,7 +44,9 @@ bool bitset_container_negation(const bitset_container_t *src, void **dst);
  * to free the container.
  * In all cases, the result is in *dst.
  */
-bool bitset_container_negation_inplace(bitset_container_t *src, void **dst);
+bool bitset_container_negation_inplace(
+        bitset_container_t *src,
+        container_t **dst);
 
 /* Negation across the entire range of container
  * Compute the  negation of src  and write the result
@@ -51,7 +55,7 @@ bool bitset_container_negation_inplace(bitset_container_t *src, void **dst);
  *  We assume that dst is not pre-allocated. In
  * case of failure, *dst will be NULL.
  */
-int run_container_negation(const run_container_t *src, void **dst);
+int run_container_negation(const run_container_t *src, container_t **dst);
 
 /*
  * Same as run_container_negation except that if the output is to
@@ -60,24 +64,26 @@ int run_container_negation(const run_container_t *src, void **dst);
  * then src is modified and no allocation is made.
  * In all cases, the result is in *dst.
  */
-int run_container_negation_inplace(run_container_t *src, void **dst);
+int run_container_negation_inplace(run_container_t *src, container_t **dst);
 
 /* Negation across a range of the container.
  * Compute the  negation of src  and write the result
  * to *dst. Returns true if the result is a bitset container
  * and false for an array container.  *dst is not preallocated.
  */
-bool array_container_negation_range(const array_container_t *src,
-                                    const int range_start, const int range_end,
-                                    void **dst);
+bool array_container_negation_range(
+        const array_container_t *src,
+        const int range_start, const int range_end,
+        container_t **dst);
 
 /* Even when the result would fit, it is unclear how to make an
  * inplace version without inefficient copying.  Thus this routine
  * may be a wrapper for the non-in-place version
  */
-bool array_container_negation_range_inplace(array_container_t *src,
-                                            const int range_start,
-                                            const int range_end, void **dst);
+bool array_container_negation_range_inplace(
+        array_container_t *src,
+        const int range_start, const int range_end,
+        container_t **dst);
 
 /* Negation across a range of the container
  * Compute the  negation of src  and write the result
@@ -86,9 +92,10 @@ bool array_container_negation_range_inplace(array_container_t *src,
  *  We assume that dst is not pre-allocated. In
  * case of failure, *dst will be NULL.
  */
-bool bitset_container_negation_range(const bitset_container_t *src,
-                                     const int range_start, const int range_end,
-                                     void **dst);
+bool bitset_container_negation_range(
+        const bitset_container_t *src,
+        const int range_start, const int range_end,
+        container_t **dst);
 
 /* inplace version */
 /*
@@ -99,9 +106,10 @@ bool bitset_container_negation_range(const bitset_container_t *src,
  * to free the container.
  * In all cases, the result is in *dst.
  */
-bool bitset_container_negation_range_inplace(bitset_container_t *src,
-                                             const int range_start,
-                                             const int range_end, void **dst);
+bool bitset_container_negation_range_inplace(
+        bitset_container_t *src,
+        const int range_start, const int range_end,
+        container_t **dst);
 
 /* Negation across a range of container
  * Compute the  negation of src  and write the result
@@ -109,9 +117,10 @@ bool bitset_container_negation_range_inplace(bitset_container_t *src,
  *  We assume that dst is not pre-allocated. In
  * case of failure, *dst will be NULL.
  */
-int run_container_negation_range(const run_container_t *src,
-                                 const int range_start, const int range_end,
-                                 void **dst);
+int run_container_negation_range(
+        const run_container_t *src,
+        const int range_start, const int range_end,
+        container_t **dst);
 
 /*
  * Same as run_container_negation except that if the output is to
@@ -120,9 +129,10 @@ int run_container_negation_range(const run_container_t *src,
  * then src is modified and no allocation is made.
  * In all cases, the result is in *dst.
  */
-int run_container_negation_range_inplace(run_container_t *src,
-                                         const int range_start,
-                                         const int range_end, void **dst);
+int run_container_negation_range_inplace(
+        run_container_t *src,
+        const int range_start, const int range_end,
+        container_t **dst);
 
 #ifdef __cplusplus
 } } }  // extern "C" { namespace roaring { namespace internal {

--- a/include/roaring/containers/mixed_union.h
+++ b/include/roaring/containers/mixed_union.h
@@ -38,8 +38,9 @@ void array_bitset_container_lazy_union(const array_container_t *src_1,
  * otherwise is a array_container_t. We assume that dst is not pre-allocated. In
  * case of failure, *dst will be NULL.
  */
-bool array_array_container_union(const array_container_t *src_1,
-                                 const array_container_t *src_2, void **dst);
+bool array_array_container_union(
+        const array_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
 /*
  * Compute the union between src_1 and src_2 and write the result
@@ -49,24 +50,25 @@ bool array_array_container_union(const array_container_t *src_1,
  * it either written to src_1 (if *dst is null) or to *dst.
  * If the result is a bitset_container_t and *dst is null, then there was a failure.
  */
-bool array_array_container_inplace_union(array_container_t *src_1,
-                                 const array_container_t *src_2, void **dst);
+bool array_array_container_inplace_union(
+        array_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
 /*
  * Same as array_array_container_union except that it will more eagerly produce
  * a bitset.
  */
-bool array_array_container_lazy_union(const array_container_t *src_1,
-                                      const array_container_t *src_2,
-                                      void **dst);
+bool array_array_container_lazy_union(
+        const array_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
 /*
  * Same as array_array_container_inplace_union except that it will more eagerly produce
  * a bitset.
  */
-bool array_array_container_lazy_inplace_union(array_container_t *src_1,
-                                      const array_container_t *src_2,
-                                      void **dst);
+bool array_array_container_lazy_inplace_union(
+        array_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
 /* Compute the union of src_1 and src_2 and write the result to
  * dst. We assume that dst is a

--- a/include/roaring/containers/mixed_xor.h
+++ b/include/roaring/containers/mixed_xor.h
@@ -30,8 +30,9 @@ extern "C" { namespace roaring { namespace internal {
 /* Compute the xor of src_1 and src_2 and write the result to
  * dst (which has no container initially).
  * Result is true iff dst is a bitset  */
-bool array_bitset_container_xor(const array_container_t *src_1,
-                                const bitset_container_t *src_2, void **dst);
+bool array_bitset_container_xor(
+        const array_container_t *src_1, const bitset_container_t *src_2,
+        container_t **dst);
 
 /* Compute the xor of src_1 and src_2 and write the result to
  * dst. It is allowed for src_2 to be dst.  This version does not
@@ -46,8 +47,9 @@ void array_bitset_container_lazy_xor(const array_container_t *src_1,
  * "dst is a bitset"
  */
 
-bool bitset_bitset_container_xor(const bitset_container_t *src_1,
-                                 const bitset_container_t *src_2, void **dst);
+bool bitset_bitset_container_xor(
+        const bitset_container_t *src_1, const bitset_container_t *src_2,
+        container_t **dst);
 
 /* Compute the xor of src_1 and src_2 and write the result to
  * dst. Result may be either a bitset or an array container
@@ -56,8 +58,9 @@ bool bitset_bitset_container_xor(const bitset_container_t *src_1,
  * result true) or an array container.
  */
 
-bool run_bitset_container_xor(const run_container_t *src_1,
-                              const bitset_container_t *src_2, void **dst);
+bool run_bitset_container_xor(
+        const run_container_t *src_1, const bitset_container_t *src_2,
+        container_t **dst);
 
 /* lazy xor.  Dst is initialized and may be equal to src_2.
  *  Result is left as a bitset container, even if actual
@@ -72,15 +75,17 @@ void run_bitset_container_lazy_xor(const run_container_t *src_1,
  * can become any kind of container.
  */
 
-int array_run_container_xor(const array_container_t *src_1,
-                            const run_container_t *src_2, void **dst);
+int array_run_container_xor(
+        const array_container_t *src_1, const run_container_t *src_2,
+        container_t **dst);
 
 /* dst does not initially have a valid container.  Creates either
  * an array or a bitset container, indicated by return code
  */
 
-bool array_array_container_xor(const array_container_t *src_1,
-                               const array_container_t *src_2, void **dst);
+bool array_array_container_xor(
+        const array_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
 /* dst does not initially have a valid container.  Creates either
  * an array or a bitset container, indicated by return code.
@@ -88,8 +93,9 @@ bool array_array_container_xor(const array_container_t *src_1,
  * container type might not be correct for the actual cardinality
  */
 
-bool array_array_container_lazy_xor(const array_container_t *src_1,
-                                    const array_container_t *src_2, void **dst);
+bool array_array_container_lazy_xor(
+        const array_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
 /* Dst is a valid run container. (Can it be src_2? Let's say not.)
  * Leaves result as run container, even if other options are
@@ -104,8 +110,9 @@ void array_run_container_lazy_xor(const array_container_t *src_1,
  * can become any kind of container.
  */
 
-int run_run_container_xor(const run_container_t *src_1,
-                          const run_container_t *src_2, void **dst);
+int run_run_container_xor(
+        const run_container_t *src_1, const run_container_t *src_2,
+        container_t **dst);
 
 /* INPLACE versions (initial implementation may not exploit all inplace
  * opportunities (if any...)
@@ -118,14 +125,17 @@ int run_run_container_xor(const run_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-bool bitset_array_container_ixor(bitset_container_t *src_1,
-                                 const array_container_t *src_2, void **dst);
+bool bitset_array_container_ixor(
+        bitset_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
-bool bitset_bitset_container_ixor(bitset_container_t *src_1,
-                                  const bitset_container_t *src_2, void **dst);
+bool bitset_bitset_container_ixor(
+        bitset_container_t *src_1, const bitset_container_t *src_2,
+        container_t **dst);
 
-bool array_bitset_container_ixor(array_container_t *src_1,
-                                 const bitset_container_t *src_2, void **dst);
+bool array_bitset_container_ixor(
+        array_container_t *src_1, const bitset_container_t *src_2,
+        container_t **dst);
 
 /* Compute the xor of src_1 and src_2 and write the result to
  * dst. Result may be either a bitset or an array container
@@ -134,27 +144,33 @@ bool array_bitset_container_ixor(array_container_t *src_1,
  * result true) or an array container.
  */
 
-bool run_bitset_container_ixor(run_container_t *src_1,
-                               const bitset_container_t *src_2, void **dst);
+bool run_bitset_container_ixor(
+        run_container_t *src_1, const bitset_container_t *src_2,
+        container_t **dst);
 
-bool bitset_run_container_ixor(bitset_container_t *src_1,
-                               const run_container_t *src_2, void **dst);
+bool bitset_run_container_ixor(
+        bitset_container_t *src_1, const run_container_t *src_2,
+        container_t **dst);
 
 /* dst does not indicate a valid container initially.  Eventually it
  * can become any kind of container.
  */
 
-int array_run_container_ixor(array_container_t *src_1,
-                             const run_container_t *src_2, void **dst);
+int array_run_container_ixor(
+        array_container_t *src_1, const run_container_t *src_2,
+        container_t **dst);
 
-int run_array_container_ixor(run_container_t *src_1,
-                             const array_container_t *src_2, void **dst);
+int run_array_container_ixor(
+        run_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
-bool array_array_container_ixor(array_container_t *src_1,
-                                const array_container_t *src_2, void **dst);
+bool array_array_container_ixor(
+        array_container_t *src_1, const array_container_t *src_2,
+        container_t **dst);
 
-int run_run_container_ixor(run_container_t *src_1, const run_container_t *src_2,
-                           void **dst);
+int run_run_container_ixor(
+        run_container_t *src_1, const run_container_t *src_2,
+        container_t **dst);
 
 #ifdef __cplusplus
 } } }  // extern "C" { namespace roaring { namespace internal {

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -11,10 +11,11 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <roaring/containers/perfparameters.h>
 #include <roaring/portability.h>
-#include <roaring/roaring_types.h>
-#include <roaring/array_util.h>
+#include <roaring/roaring_types.h>  // roaring_iterator
+#include <roaring/array_util.h>  // binarySearch()/memequals() for inlining
+
+#include <roaring/containers/container_defs.h>  // container_t, perfparameters
 
 #ifdef __cplusplus
 extern "C" { namespace roaring {
@@ -54,9 +55,8 @@ typedef struct rle16_s rle16_t;
  * @n_runs:   number of rle_t pairs in `runs`.
  * @capacity: capacity in rle_t pairs `runs` can hold.
  * @runs:     pairs of rle_t.
- *
  */
-struct run_container_s {
+STRUCT_CONTAINER(run_container_s) {
     int32_t n_runs;
     int32_t capacity;
     rle16_t *runs;

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -702,7 +702,7 @@ typedef struct roaring_uint32_iterator_s {
     uint32_t current_value;
     bool has_value;
 
-    const void
+    const ROARING_CONTAINER_T
         *container;  // should be:
                      // parent->high_low_container.containers[container_index];
     uint8_t typecode;  // should be:

--- a/include/roaring/roaring_array.h
+++ b/include/roaring/roaring_array.h
@@ -83,8 +83,9 @@ inline int32_t ra_get_index(const roaring_array_t *ra, uint16_t x) {
 /**
  * Retrieves the container at index i, filling in the typecode
  */
-inline void *ra_get_container_at_index(const roaring_array_t *ra, uint16_t i,
-                                       uint8_t *typecode) {
+inline container_t *ra_get_container_at_index(
+    const roaring_array_t *ra, uint16_t i, uint8_t *typecode
+){
     *typecode = ra->typecodes[i];
     return ra->containers[i];
 }
@@ -97,13 +98,16 @@ uint16_t ra_get_key_at_index(const roaring_array_t *ra, uint16_t i);
 /**
  * Add a new key-value pair at index i
  */
-void ra_insert_new_key_value_at(roaring_array_t *ra, int32_t i, uint16_t key,
-                                void *container, uint8_t typecode);
+void ra_insert_new_key_value_at(
+        roaring_array_t *ra, int32_t i, uint16_t key,
+        container_t *c, uint8_t typecode);
 
 /**
  * Append a new key-value pair
  */
-void ra_append(roaring_array_t *ra, uint16_t s, void *c, uint8_t typecode);
+void ra_append(
+        roaring_array_t *ra, uint16_t key,
+        container_t *c, uint8_t typecode);
 
 /**
  * Append a new key-value pair to ra, cloning (in COW sense) a value from sa
@@ -153,8 +157,10 @@ void ra_append_range(roaring_array_t *ra, roaring_array_t *sa,
  * Set the container at the corresponding index using the specified
  * typecode.
  */
-inline void ra_set_container_at_index(const roaring_array_t *ra, int32_t i,
-                                      void *c, uint8_t typecode) {
+inline void ra_set_container_at_index(
+    const roaring_array_t *ra, int32_t i,
+    container_t *c, uint8_t typecode
+){
     assert(i < ra->size);
     ra->containers[i] = c;
     ra->typecodes[i] = typecode;
@@ -178,9 +184,10 @@ int32_t ra_advance_until_freeing(roaring_array_t *ra, uint16_t x, int32_t pos);
 
 void ra_downsize(roaring_array_t *ra, int32_t new_length);
 
-inline void ra_replace_key_and_container_at_index(roaring_array_t *ra,
-                                                  int32_t i, uint16_t key,
-                                                  void *c, uint8_t typecode) {
+inline void ra_replace_key_and_container_at_index(
+    roaring_array_t *ra, int32_t i, uint16_t key,
+    container_t *c, uint8_t typecode
+){
     assert(i < ra->size);
 
     ra->keys[i] = key;
@@ -246,8 +253,8 @@ uint32_t ra_portable_header_size(const roaring_array_t *ra);
 static inline void ra_unshare_container_at_index(roaring_array_t *ra,
                                                  uint16_t i) {
     assert(i < ra->size);
-    ra->containers[i] =
-        get_writable_copy_if_shared(ra->containers[i], &ra->typecodes[i]);
+    ra->containers[i] = get_writable_copy_if_shared(ra->containers[i],
+                                                    &ra->typecodes[i]);
 }
 
 /**

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -5,26 +5,36 @@
 extern "C" { namespace roaring { namespace internal {
 #endif
 
-extern inline const void *container_unwrap_shared(
-    const void *candidate_shared_container, uint8_t *type);
-extern inline void *container_mutable_unwrap_shared(
-    void *candidate_shared_container, uint8_t *type);
+extern inline const container_t *container_unwrap_shared(
+        const container_t *candidate_shared_container, uint8_t *type);
 
-extern inline int container_get_cardinality(const void *container, uint8_t typecode);
+extern inline container_t *container_mutable_unwrap_shared(
+        container_t *candidate_shared_container, uint8_t *type);
 
-extern inline void *container_iand(void *c1, uint8_t type1, const void *c2,
-                            uint8_t type2, uint8_t *result_type);
+extern inline int container_get_cardinality(
+        const container_t *c, uint8_t typecode);
 
-extern inline void *container_ior(void *c1, uint8_t type1, const void *c2,
-                           uint8_t type2, uint8_t *result_type);
+extern inline container_t *container_iand(
+        container_t *c1, uint8_t type1,
+        const container_t *c2, uint8_t type2,
+        uint8_t *result_type);
 
-extern inline void *container_ixor(void *c1, uint8_t type1, const void *c2,
-                            uint8_t type2, uint8_t *result_type);
+extern inline container_t *container_ior(
+        container_t *c1, uint8_t type1,
+        const container_t *c2, uint8_t type2,
+        uint8_t *result_type);
 
-extern inline void *container_iandnot(void *c1, uint8_t type1, const void *c2,
-                               uint8_t type2, uint8_t *result_type);
+extern inline container_t *container_ixor(
+        container_t *c1, uint8_t type1,
+        const container_t *c2, uint8_t type2,
+        uint8_t *result_type);
 
-void container_free(void *container, uint8_t typecode) {
+extern inline container_t *container_iandnot(
+        container_t *c1, uint8_t type1,
+        const container_t *c2, uint8_t type2,
+        uint8_t *result_type);
+
+void container_free(container_t *container, uint8_t typecode) {
     switch (typecode) {
         case BITSET_CONTAINER_TYPE_CODE:
             bitset_container_free((bitset_container_t *)container);
@@ -44,7 +54,7 @@ void container_free(void *container, uint8_t typecode) {
     }
 }
 
-void container_printf(const void *container, uint8_t typecode) {
+void container_printf(const container_t *container, uint8_t typecode) {
     container = container_unwrap_shared(container, &typecode);
     switch (typecode) {
         case BITSET_CONTAINER_TYPE_CODE:
@@ -61,56 +71,71 @@ void container_printf(const void *container, uint8_t typecode) {
     }
 }
 
-void container_printf_as_uint32_array(const void *container, uint8_t typecode,
-                                      uint32_t base) {
-    container = container_unwrap_shared(container, &typecode);
+void container_printf_as_uint32_array(
+    const container_t *c, uint8_t typecode,
+    uint32_t base
+){
+    c = container_unwrap_shared(c, &typecode);
     switch (typecode) {
         case BITSET_CONTAINER_TYPE_CODE:
             bitset_container_printf_as_uint32_array(
-                (const bitset_container_t *)container, base);
+                (const bitset_container_t *)c, base);
             return;
         case ARRAY_CONTAINER_TYPE_CODE:
             array_container_printf_as_uint32_array(
-                (const array_container_t *)container, base);
+                (const array_container_t *)c, base);
             return;
         case RUN_CONTAINER_TYPE_CODE:
             run_container_printf_as_uint32_array(
-                (const run_container_t *)container, base);
-            return;
+                (const run_container_t *)c, base);
             return;
         default:
             __builtin_unreachable();
     }
 }
 
-extern inline bool container_nonzero_cardinality(const void *container,
-                                          uint8_t typecode);
+extern inline bool container_nonzero_cardinality(
+        const container_t *c, uint8_t typecode);
 
+extern inline int container_to_uint32_array(
+        uint32_t *output,
+        const container_t *c, uint8_t typecode,
+        uint32_t base);
 
-extern inline int container_to_uint32_array(uint32_t *output, const void *container,
-                                     uint8_t typecode, uint32_t base);
+extern inline container_t *container_add(
+        container_t *c,
+        uint16_t val,
+        uint8_t typecode,  // !!! 2nd arg?
+        uint8_t *new_typecode);
 
-extern inline void *container_add(void *container, uint16_t val, uint8_t typecode,
-                           uint8_t *new_typecode);
+extern inline bool container_contains(
+        const container_t *c,
+        uint16_t val,
+        uint8_t typecode);  // !!! 2nd arg?
 
-extern inline bool container_contains(const void *container, uint16_t val,
-                                      uint8_t typecode);
+extern inline container_t *container_and(
+        const container_t *c1, uint8_t type1,
+        const container_t *c2, uint8_t type2,
+        uint8_t *result_type);
 
-extern inline void *container_and(const void *c1, uint8_t type1, const void *c2,
-                           uint8_t type2, uint8_t *result_type);
+extern inline container_t *container_or(
+        const container_t *c1, uint8_t type1,
+        const container_t *c2, uint8_t type2,
+        uint8_t *result_type);
 
-extern inline void *container_or(const void *c1, uint8_t type1, const void *c2,
-                          uint8_t type2, uint8_t *result_type);
+extern inline container_t *container_xor(
+        const container_t *c1, uint8_t type1,
+        const container_t *c2, uint8_t type2,
+        uint8_t *result_type);
 
-extern inline void *container_xor(const void *c1, uint8_t type1, const void *c2,
-                           uint8_t type2, uint8_t *result_type);
-
-void *get_copy_of_container(void *container, uint8_t *typecode,
-                            bool copy_on_write) {
+container_t *get_copy_of_container(
+    container_t *c, uint8_t *typecode,
+    bool copy_on_write
+){
     if (copy_on_write) {
         shared_container_t *shared_container;
         if (*typecode == SHARED_CONTAINER_TYPE_CODE) {
-            shared_container = (shared_container_t *)container;
+            shared_container = (shared_container_t *)c;
             shared_container->counter += 1;
             return shared_container;
         }
@@ -121,7 +146,7 @@ void *get_copy_of_container(void *container, uint8_t *typecode,
             return NULL;
         }
 
-        shared_container->container = container;
+        shared_container->container = c;
         shared_container->typecode = *typecode;
 
         shared_container->counter = 2;
@@ -130,24 +155,24 @@ void *get_copy_of_container(void *container, uint8_t *typecode,
         return shared_container;
     }  // copy_on_write
     // otherwise, no copy on write...
-    const void *actualcontainer =
-        container_unwrap_shared((const void *)container, typecode);
+    const container_t *actual_container = container_unwrap_shared(c, typecode);
     assert(*typecode != SHARED_CONTAINER_TYPE_CODE);
-    return container_clone(actualcontainer, *typecode);
+    return container_clone(actual_container, *typecode);
 }
+
 /**
  * Copies a container, requires a typecode. This allocates new memory, caller
  * is responsible for deallocation.
  */
-void *container_clone(const void *container, uint8_t typecode) {
-    container = container_unwrap_shared(container, &typecode);
+container_t *container_clone(const container_t *c, uint8_t typecode) {
+    c = container_unwrap_shared(c, &typecode);
     switch (typecode) {
         case BITSET_CONTAINER_TYPE_CODE:
-            return bitset_container_clone((const bitset_container_t *)container);
+            return bitset_container_clone((const bitset_container_t *)c);
         case ARRAY_CONTAINER_TYPE_CODE:
-            return array_container_clone((const array_container_t *)container);
+            return array_container_clone((const array_container_t *)c);
         case RUN_CONTAINER_TYPE_CODE:
-            return run_container_clone((const run_container_t *)container);
+            return run_container_clone((const run_container_t *)c);
         case SHARED_CONTAINER_TYPE_CODE:
             printf("shared containers are not cloneable\n");
             assert(false);
@@ -159,19 +184,20 @@ void *container_clone(const void *container, uint8_t typecode) {
     }
 }
 
-void *shared_container_extract_copy(shared_container_t *container,
-                                    uint8_t *typecode) {
-    assert(container->counter > 0);
-    assert(container->typecode != SHARED_CONTAINER_TYPE_CODE);
-    container->counter--;
-    *typecode = container->typecode;
-    void *answer;
-    if (container->counter == 0) {
-        answer = container->container;
-        container->container = NULL;  // paranoid
-        free(container);
+container_t *shared_container_extract_copy(
+    shared_container_t *sc, uint8_t *typecode
+){
+    assert(sc->counter > 0);
+    assert(sc->typecode != SHARED_CONTAINER_TYPE_CODE);
+    sc->counter--;
+    *typecode = sc->typecode;
+    container_t *answer;
+    if (sc->counter == 0) {
+        answer = sc->container;
+        sc->container = NULL;  // paranoid
+        free(sc);
     } else {
-        answer = container_clone(container->container, *typecode);
+        answer = container_clone(sc->container, *typecode);
     }
     assert(*typecode != SHARED_CONTAINER_TYPE_CODE);
     return answer;
@@ -188,29 +214,43 @@ void shared_container_free(shared_container_t *container) {
     }
 }
 
-extern inline void *container_not(const void *c1, uint8_t type1, uint8_t *result_type);
+extern inline container_t *container_not(
+        const container_t *c1, uint8_t type1,
+        uint8_t *result_type);
 
-extern inline void *container_not_range(const void *c1, uint8_t type1,
-                                 uint32_t range_start, uint32_t range_end,
-                                 uint8_t *result_type);
+extern inline container_t *container_not_range(
+        const container_t *c1, uint8_t type1,
+        uint32_t range_start, uint32_t range_end,
+        uint8_t *result_type);
 
-extern inline void *container_inot(void *c1, uint8_t type1, uint8_t *result_type);
+extern inline container_t *container_inot(
+        container_t *c1, uint8_t type1,
+        uint8_t *result_type);
 
-extern inline void *container_inot_range(void *c1, uint8_t type1, uint32_t range_start,
-                                  uint32_t range_end, uint8_t *result_type);
+extern inline container_t *container_inot_range(
+        container_t *c1, uint8_t type1,
+        uint32_t range_start, uint32_t range_end,
+        uint8_t *result_type);
 
-extern inline void *container_range_of_ones(uint32_t range_start, uint32_t range_end,
-                                     uint8_t *result_type);
+extern inline container_t *container_range_of_ones(
+        uint32_t range_start, uint32_t range_end,
+        uint8_t *result_type);
 
 // where are the correponding things for union and intersection??
-extern inline void *container_lazy_xor(const void *c1, uint8_t type1, const void *c2,
-                                uint8_t type2, uint8_t *result_type);
+extern inline container_t *container_lazy_xor(
+        const container_t *c1, uint8_t type1,
+        const container_t *c2, uint8_t type2,
+        uint8_t *result_type);
 
-extern inline void *container_lazy_ixor(void *c1, uint8_t type1, const void *c2,
-                                 uint8_t type2, uint8_t *result_type);
+extern inline container_t *container_lazy_ixor(
+        container_t *c1, uint8_t type1,
+        const container_t *c2, uint8_t type2,
+        uint8_t *result_type);
 
-extern inline void *container_andnot(const void *c1, uint8_t type1, const void *c2,
-                              uint8_t type2, uint8_t *result_type);
+extern inline container_t *container_andnot(
+        const container_t *c1, uint8_t type1,
+        const container_t *c2, uint8_t type2,
+        uint8_t *result_type);
 
 #ifdef __cplusplus
 } } }  // extern "C" { namespace roaring { namespace internal {

--- a/src/containers/convert.c
+++ b/src/containers/convert.c
@@ -91,9 +91,10 @@ run_container_t *run_container_from_array(const array_container_t *c) {
  * Allocates and returns new container, which caller is responsible for freeing.
  * It does not free the run container.
  */
-
-void *convert_to_bitset_or_array_container(run_container_t *r, int32_t card,
-                                           uint8_t *resulttype) {
+container_t *convert_to_bitset_or_array_container(
+    run_container_t *r, int32_t card,
+    uint8_t *resulttype
+){
     if (card <= DEFAULT_MAX_SIZE) {
         array_container_t *answer = array_container_create_given_capacity(card);
         answer->cardinality = 0;
@@ -126,8 +127,10 @@ void *convert_to_bitset_or_array_container(run_container_t *r, int32_t card,
 /* If a conversion occurs, the caller is responsible to free the original
  * container and
  * he becomes responsible to free the new one. */
-void *convert_run_to_efficient_container(run_container_t *c,
-                                         uint8_t *typecode_after) {
+container_t *convert_run_to_efficient_container(
+    run_container_t *c,
+    uint8_t *typecode_after
+){
     int32_t size_as_run_container =
         run_container_serialized_size_in_bytes(c->n_runs);
 
@@ -175,9 +178,11 @@ void *convert_run_to_efficient_container(run_container_t *c,
 }
 
 // like convert_run_to_efficient_container but frees the old result if needed
-void *convert_run_to_efficient_container_and_free(run_container_t *c,
-                                                  uint8_t *typecode_after) {
-    void *answer = convert_run_to_efficient_container(c, typecode_after);
+container_t *convert_run_to_efficient_container_and_free(
+    run_container_t *c,
+    uint8_t *typecode_after
+){
+    container_t *answer = convert_run_to_efficient_container(c, typecode_after);
     if (answer != c) run_container_free(c);
     return answer;
 }
@@ -189,11 +194,13 @@ void *convert_run_to_efficient_container_and_free(run_container_t *c,
 // TODO: split into run-  array-  and bitset-  subfunctions for sanity;
 // a few function calls won't really matter.
 
-void *convert_run_optimize(void *c, uint8_t typecode_original,
-                           uint8_t *typecode_after) {
+container_t *convert_run_optimize(
+    container_t *c, uint8_t typecode_original,
+    uint8_t *typecode_after
+){
     if (typecode_original == RUN_CONTAINER_TYPE_CODE) {
-        void *newc = convert_run_to_efficient_container((run_container_t *)c,
-                                                        typecode_after);
+        container_t *newc = convert_run_to_efficient_container(
+                                    (run_container_t *)c, typecode_after);
         if (newc != c) {
             container_free(c, typecode_original);
         }
@@ -296,8 +303,11 @@ void *convert_run_optimize(void *c, uint8_t typecode_original,
         return NULL;
     }
 }
-void *container_from_run_range(const run_container_t *run,
-                                                    uint32_t min, uint32_t max, uint8_t *typecode_after) {
+
+container_t *container_from_run_range(
+    const run_container_t *run,
+    uint32_t min, uint32_t max, uint8_t *typecode_after
+){
     // We expect most of the time to end up with a bitset container
     bitset_container_t *bitset = bitset_container_create();
     *typecode_after = BITSET_CONTAINER_TYPE_CODE;

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -49,8 +49,10 @@ void array_bitset_container_iandnot(array_container_t *src_1,
  * Return true for a bitset result; false for array
  */
 
-bool bitset_array_container_andnot(const bitset_container_t *src_1,
-                                   const array_container_t *src_2, void **dst) {
+bool bitset_array_container_andnot(
+    const bitset_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     // Java did this directly, but we have option of asm or avx
     bitset_container_t *result = bitset_container_create();
     bitset_container_copy(src_1, result);
@@ -75,9 +77,10 @@ bool bitset_array_container_andnot(const bitset_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-bool bitset_array_container_iandnot(bitset_container_t *src_1,
-                                    const array_container_t *src_2,
-                                    void **dst) {
+bool bitset_array_container_iandnot(
+    bitset_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     *dst = src_1;
     src_1->cardinality =
         (int32_t)bitset_clear_list(src_1->array, (uint64_t)src_1->cardinality,
@@ -98,8 +101,10 @@ bool bitset_array_container_iandnot(bitset_container_t *src_1,
  * result true) or an array container.
  */
 
-bool run_bitset_container_andnot(const run_container_t *src_1,
-                                 const bitset_container_t *src_2, void **dst) {
+bool run_bitset_container_andnot(
+    const run_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     // follows the Java implementation as of June 2016
     int card = run_container_cardinality(src_1);
     if (card <= DEFAULT_MAX_SIZE) {
@@ -152,8 +157,10 @@ bool run_bitset_container_andnot(const run_container_t *src_1,
  * result true) or an array container.
  */
 
-bool run_bitset_container_iandnot(run_container_t *src_1,
-                                  const bitset_container_t *src_2, void **dst) {
+bool run_bitset_container_iandnot(
+    run_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     // dummy implementation
     bool ans = run_bitset_container_andnot(src_1, src_2, dst);
     run_container_free(src_1);
@@ -167,8 +174,10 @@ bool run_bitset_container_iandnot(run_container_t *src_1,
  * result true) or an array container.
  */
 
-bool bitset_run_container_andnot(const bitset_container_t *src_1,
-                                 const run_container_t *src_2, void **dst) {
+bool bitset_run_container_andnot(
+    const bitset_container_t *src_1, const run_container_t *src_2,
+    container_t **dst
+){
     // follows Java implementation
     bitset_container_t *result = bitset_container_create();
 
@@ -196,8 +205,10 @@ bool bitset_run_container_andnot(const bitset_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-bool bitset_run_container_iandnot(bitset_container_t *src_1,
-                                  const run_container_t *src_2, void **dst) {
+bool bitset_run_container_iandnot(
+    bitset_container_t *src_1, const run_container_t *src_2,
+    container_t **dst
+){
     *dst = src_1;
 
     for (int32_t rlepos = 0; rlepos < src_2->n_runs; ++rlepos) {
@@ -267,8 +278,10 @@ static int run_array_array_subtract(const run_container_t *r,
  * can become any type of container.
  */
 
-int run_array_container_andnot(const run_container_t *src_1,
-                               const array_container_t *src_2, void **dst) {
+int run_array_container_andnot(
+    const run_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     // follows the Java impl as of June 2016
 
     int card = run_container_cardinality(src_1);
@@ -359,8 +372,10 @@ int run_array_container_andnot(const run_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-int run_array_container_iandnot(run_container_t *src_1,
-                                const array_container_t *src_2, void **dst) {
+int run_array_container_iandnot(
+    run_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     // dummy implementation same as June 2016 Java
     int ans = run_array_container_andnot(src_1, src_2, dst);
     run_container_free(src_1);
@@ -424,8 +439,10 @@ void array_run_container_iandnot(array_container_t *src_1,
  * can become any kind of container.
  */
 
-int run_run_container_andnot(const run_container_t *src_1,
-                             const run_container_t *src_2, void **dst) {
+int run_run_container_andnot(
+    const run_container_t *src_1, const run_container_t *src_2,
+    container_t **dst
+){
     run_container_t *ans = run_container_create();
     run_container_andnot(src_1, src_2, ans);
     uint8_t typecode_after;
@@ -440,8 +457,10 @@ int run_run_container_andnot(const run_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-int run_run_container_iandnot(run_container_t *src_1,
-                              const run_container_t *src_2, void **dst) {
+int run_run_container_iandnot(
+    run_container_t *src_1, const run_container_t *src_2,
+    container_t **dst
+){
     // following Java impl as of June 2016 (dummy)
     int ans = run_run_container_andnot(src_1, src_2, dst);
     run_container_free(src_1);
@@ -470,9 +489,10 @@ void array_array_container_iandnot(array_container_t *src_1,
  * "dst is a bitset"
  */
 
-bool bitset_bitset_container_andnot(const bitset_container_t *src_1,
-                                    const bitset_container_t *src_2,
-                                    void **dst) {
+bool bitset_bitset_container_andnot(
+    const bitset_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     bitset_container_t *ans = bitset_container_create();
     int card = bitset_container_andnot(src_1, src_2, ans);
     if (card <= DEFAULT_MAX_SIZE) {
@@ -492,9 +512,10 @@ bool bitset_bitset_container_andnot(const bitset_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-bool bitset_bitset_container_iandnot(bitset_container_t *src_1,
-                                     const bitset_container_t *src_2,
-                                     void **dst) {
+bool bitset_bitset_container_iandnot(
+    bitset_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     int card = bitset_container_andnot(src_1, src_2, src_1);
     if (card <= DEFAULT_MAX_SIZE) {
         *dst = array_container_from_bitset(src_1);

--- a/src/containers/mixed_intersection.c
+++ b/src/containers/mixed_intersection.c
@@ -113,9 +113,10 @@ void array_run_container_intersection(const array_container_t *src_1,
  * *dst. If the result is true then the result is a bitset_container_t
  * otherwise is a array_container_t. If *dst ==  src_2, an in-place processing
  * is attempted.*/
-bool run_bitset_container_intersection(const run_container_t *src_1,
-                                       const bitset_container_t *src_2,
-                                       void **dst) {
+bool run_bitset_container_intersection(
+    const run_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     if (run_container_is_full(src_1)) {
         if (*dst != src_2) *dst = bitset_container_clone(src_2);
         return true;
@@ -301,9 +302,10 @@ bool run_bitset_container_intersect(const run_container_t *src_1,
  * to *dst. If the return function is true, the result is a bitset_container_t
  * otherwise is a array_container_t.
  */
-bool bitset_bitset_container_intersection(const bitset_container_t *src_1,
-                                          const bitset_container_t *src_2,
-                                          void **dst) {
+bool bitset_bitset_container_intersection(
+    const bitset_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     const int newCardinality = bitset_container_and_justcard(src_1, src_2);
     if (newCardinality > DEFAULT_MAX_SIZE) {
         *dst = bitset_container_create();
@@ -327,7 +329,9 @@ bool bitset_bitset_container_intersection(const bitset_container_t *src_1,
 }
 
 bool bitset_bitset_container_intersection_inplace(
-    bitset_container_t *src_1, const bitset_container_t *src_2, void **dst) {
+    bitset_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     const int newCardinality = bitset_container_and_justcard(src_1, src_2);
     if (newCardinality > DEFAULT_MAX_SIZE) {
         *dst = src_1;

--- a/src/containers/mixed_negation.c
+++ b/src/containers/mixed_negation.c
@@ -43,7 +43,9 @@ void array_container_negation(const array_container_t *src,
  *  We assume that dst is not pre-allocated. In
  * case of failure, *dst will be NULL.
  */
-bool bitset_container_negation(const bitset_container_t *src, void **dst) {
+bool bitset_container_negation(
+    const bitset_container_t *src, container_t **dst
+){
     return bitset_container_negation_range(src, 0, (1 << 16), dst);
 }
 
@@ -56,7 +58,9 @@ bool bitset_container_negation(const bitset_container_t *src, void **dst) {
  * to free the container.
  * In all cases, the result is in *dst.
  */
-bool bitset_container_negation_inplace(bitset_container_t *src, void **dst) {
+bool bitset_container_negation_inplace(
+    bitset_container_t *src, container_t **dst
+){
     return bitset_container_negation_range_inplace(src, 0, (1 << 16), dst);
 }
 
@@ -66,7 +70,7 @@ bool bitset_container_negation_inplace(bitset_container_t *src, void **dst) {
  *  We assume that dst is not pre-allocated. In
  * case of failure, *dst will be NULL.
  */
-int run_container_negation(const run_container_t *src, void **dst) {
+int run_container_negation(const run_container_t *src, container_t **dst) {
     return run_container_negation_range(src, 0, (1 << 16), dst);
 }
 
@@ -77,7 +81,7 @@ int run_container_negation(const run_container_t *src, void **dst) {
  * then src is modified and no allocation is made.
  * In all cases, the result is in *dst.
  */
-int run_container_negation_inplace(run_container_t *src, void **dst) {
+int run_container_negation_inplace(run_container_t *src, container_t **dst) {
     return run_container_negation_range_inplace(src, 0, (1 << 16), dst);
 }
 
@@ -86,9 +90,11 @@ int run_container_negation_inplace(run_container_t *src, void **dst) {
  * to *dst. Returns true if the result is a bitset container
  * and false for an array container.  *dst is not preallocated.
  */
-bool array_container_negation_range(const array_container_t *src,
-                                    const int range_start, const int range_end,
-                                    void **dst) {
+bool array_container_negation_range(
+    const array_container_t *src,
+    const int range_start, const int range_end,
+    container_t **dst
+){
     /* close port of the Java implementation */
     if (range_start >= range_end) {
         *dst = array_container_clone(src);
@@ -122,7 +128,7 @@ bool array_container_negation_range(const array_container_t *src,
 
     array_container_t *arr =
         array_container_create_given_capacity(new_cardinality);
-    *dst = (void *)arr;
+    *dst = (container_t *)arr;
     if(new_cardinality == 0) {
       arr->cardinality = new_cardinality;
       return false; // we are done.
@@ -154,9 +160,11 @@ bool array_container_negation_range(const array_container_t *src,
  * inplace version without inefficient copying.
  */
 
-bool array_container_negation_range_inplace(array_container_t *src,
-                                            const int range_start,
-                                            const int range_end, void **dst) {
+bool array_container_negation_range_inplace(
+    array_container_t *src,
+    const int range_start, const int range_end,
+    container_t **dst
+){
     bool ans = array_container_negation_range(src, range_start, range_end, dst);
     // TODO : try a real inplace version
     array_container_free(src);
@@ -170,9 +178,11 @@ bool array_container_negation_range_inplace(array_container_t *src,
  *  We assume that dst is not pre-allocated. In
  * case of failure, *dst will be NULL.
  */
-bool bitset_container_negation_range(const bitset_container_t *src,
-                                     const int range_start, const int range_end,
-                                     void **dst) {
+bool bitset_container_negation_range(
+    const bitset_container_t *src,
+    const int range_start, const int range_end,
+    container_t **dst
+){
     // TODO maybe consider density-based estimate
     // and sometimes build result directly as array, with
     // conversion back to bitset if wrong.  Or determine
@@ -202,9 +212,11 @@ bool bitset_container_negation_range(const bitset_container_t *src,
  * to free the container.
  * In all cases, the result is in *dst.
  */
-bool bitset_container_negation_range_inplace(bitset_container_t *src,
-                                             const int range_start,
-                                             const int range_end, void **dst) {
+bool bitset_container_negation_range_inplace(
+    bitset_container_t *src,
+    const int range_start, const int range_end,
+    container_t **dst
+){
     bitset_flip_range(src->array, (uint32_t)range_start, (uint32_t)range_end);
     src->cardinality = bitset_container_compute_cardinality(src);
     if (src->cardinality > DEFAULT_MAX_SIZE) {
@@ -222,9 +234,11 @@ bool bitset_container_negation_range_inplace(bitset_container_t *src,
  *  We assume that dst is not pre-allocated. In
  * case of failure, *dst will be NULL.
  */
-int run_container_negation_range(const run_container_t *src,
-                                 const int range_start, const int range_end,
-                                 void **dst) {
+int run_container_negation_range(
+    const run_container_t *src,
+    const int range_start, const int range_end,
+    container_t **dst
+){
     uint8_t return_typecode;
 
     // follows the Java implementation
@@ -262,9 +276,11 @@ int run_container_negation_range(const run_container_t *src,
  * then src is modified and no allocation is made.
  * In all cases, the result is in *dst.
  */
-int run_container_negation_range_inplace(run_container_t *src,
-                                         const int range_start,
-                                         const int range_end, void **dst) {
+int run_container_negation_range_inplace(
+    run_container_t *src,
+    const int range_start, const int range_end,
+    container_t **dst
+){
     uint8_t return_typecode;
 
     if (range_end <= range_start) {

--- a/src/containers/mixed_union.c
+++ b/src/containers/mixed_union.c
@@ -157,8 +157,10 @@ void array_run_container_inplace_union(const array_container_t *src_1,
     }
 }
 
-bool array_array_container_union(const array_container_t *src_1,
-                                 const array_container_t *src_2, void **dst) {
+bool array_array_container_union(
+    const array_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     int totalCardinality = src_1->cardinality + src_2->cardinality;
     if (totalCardinality <= DEFAULT_MAX_SIZE) {
         *dst = array_container_create_given_capacity(totalCardinality);
@@ -187,8 +189,10 @@ bool array_array_container_union(const array_container_t *src_1,
     return returnval;
 }
 
-bool array_array_container_inplace_union(array_container_t *src_1,
-                                 const array_container_t *src_2, void **dst) {
+bool array_array_container_inplace_union(
+    array_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     int totalCardinality = src_1->cardinality + src_2->cardinality;
     *dst = NULL;
     if (totalCardinality <= DEFAULT_MAX_SIZE) {
@@ -233,9 +237,10 @@ bool array_array_container_inplace_union(array_container_t *src_1,
 }
 
 
-bool array_array_container_lazy_union(const array_container_t *src_1,
-                                      const array_container_t *src_2,
-                                      void **dst) {
+bool array_array_container_lazy_union(
+    const array_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     int totalCardinality = src_1->cardinality + src_2->cardinality;
     if (totalCardinality <= ARRAY_LAZY_LOWERBOUND) {
         *dst = array_container_create_given_capacity(totalCardinality);
@@ -258,9 +263,10 @@ bool array_array_container_lazy_union(const array_container_t *src_1,
 }
 
 
-bool array_array_container_lazy_inplace_union(array_container_t *src_1,
-                                      const array_container_t *src_2,
-                                      void **dst) {
+bool array_array_container_lazy_inplace_union(
+    array_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     int totalCardinality = src_1->cardinality + src_2->cardinality;
     *dst = NULL;
     if (totalCardinality <= ARRAY_LAZY_LOWERBOUND) {

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -18,8 +18,10 @@ extern "C" { namespace roaring { namespace internal {
 /* Compute the xor of src_1 and src_2 and write the result to
  * dst (which has no container initially).
  * Result is true iff dst is a bitset  */
-bool array_bitset_container_xor(const array_container_t *src_1,
-                                const bitset_container_t *src_2, void **dst) {
+bool array_bitset_container_xor(
+    const array_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     bitset_container_t *result = bitset_container_create();
     bitset_container_copy(src_2, result);
     result->cardinality = (int32_t)bitset_flip_list_withcard(
@@ -55,8 +57,10 @@ void array_bitset_container_lazy_xor(const array_container_t *src_1,
  * result true) or an array container.
  */
 
-bool run_bitset_container_xor(const run_container_t *src_1,
-                              const bitset_container_t *src_2, void **dst) {
+bool run_bitset_container_xor(
+    const run_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     bitset_container_t *result = bitset_container_create();
 
     bitset_container_copy(src_2, result);
@@ -97,8 +101,10 @@ void run_bitset_container_lazy_xor(const run_container_t *src_1,
  * can become any kind of container.
  */
 
-int array_run_container_xor(const array_container_t *src_1,
-                            const run_container_t *src_2, void **dst) {
+int array_run_container_xor(
+    const array_container_t *src_1, const run_container_t *src_2,
+    container_t **dst
+){
     // semi following Java XOR implementation as of May 2016
     // the C OR implementation works quite differently and can return a run
     // container
@@ -174,8 +180,10 @@ void array_run_container_lazy_xor(const array_container_t *src_1,
  * can become any kind of container.
  */
 
-int run_run_container_xor(const run_container_t *src_1,
-                          const run_container_t *src_2, void **dst) {
+int run_run_container_xor(
+    const run_container_t *src_1, const run_container_t *src_2,
+    container_t **dst
+){
     run_container_t *ans = run_container_create();
     run_container_xor(src_1, src_2, ans);
     uint8_t typecode_after;
@@ -191,8 +199,10 @@ int run_run_container_xor(const run_container_t *src_1,
  *
  */
 
-bool array_array_container_xor(const array_container_t *src_1,
-                               const array_container_t *src_2, void **dst) {
+bool array_array_container_xor(
+    const array_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     int totalCardinality =
         src_1->cardinality + src_2->cardinality;  // upper bound
     if (totalCardinality <= DEFAULT_MAX_SIZE) {
@@ -215,9 +225,10 @@ bool array_array_container_xor(const array_container_t *src_1,
     return returnval;
 }
 
-bool array_array_container_lazy_xor(const array_container_t *src_1,
-                                    const array_container_t *src_2,
-                                    void **dst) {
+bool array_array_container_lazy_xor(
+    const array_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     int totalCardinality = src_1->cardinality + src_2->cardinality;
     // upper bound, but probably poor estimate for xor
     if (totalCardinality <= ARRAY_LAZY_LOWERBOUND) {
@@ -241,8 +252,10 @@ bool array_array_container_lazy_xor(const array_container_t *src_1,
  * "dst is a bitset"
  */
 
-bool bitset_bitset_container_xor(const bitset_container_t *src_1,
-                                 const bitset_container_t *src_2, void **dst) {
+bool bitset_bitset_container_xor(
+    const bitset_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     bitset_container_t *ans = bitset_container_create();
     int card = bitset_container_xor(src_1, src_2, ans);
     if (card <= DEFAULT_MAX_SIZE) {
@@ -262,8 +275,10 @@ bool bitset_bitset_container_xor(const bitset_container_t *src_1,
  * cases, the caller is responsible for deallocating dst.
  * Returns true iff dst is a bitset  */
 
-bool bitset_array_container_ixor(bitset_container_t *src_1,
-                                 const array_container_t *src_2, void **dst) {
+bool bitset_array_container_ixor(
+    bitset_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     *dst = src_1;
     src_1->cardinality = (uint32_t)bitset_flip_list_withcard(
         src_1->array, src_1->cardinality, src_2->array, src_2->cardinality);
@@ -281,15 +296,19 @@ bool bitset_array_container_ixor(bitset_container_t *src_1,
  * Anything inplace with a bitset is a good candidate
  */
 
-bool bitset_bitset_container_ixor(bitset_container_t *src_1,
-                                  const bitset_container_t *src_2, void **dst) {
+bool bitset_bitset_container_ixor(
+    bitset_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     bool ans = bitset_bitset_container_xor(src_1, src_2, dst);
     bitset_container_free(src_1);
     return ans;
 }
 
-bool array_bitset_container_ixor(array_container_t *src_1,
-                                 const bitset_container_t *src_2, void **dst) {
+bool array_bitset_container_ixor(
+    array_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     bool ans = array_bitset_container_xor(src_1, src_2, dst);
     array_container_free(src_1);
     return ans;
@@ -302,15 +321,19 @@ bool array_bitset_container_ixor(array_container_t *src_1,
  * result true) or an array container.
  */
 
-bool run_bitset_container_ixor(run_container_t *src_1,
-                               const bitset_container_t *src_2, void **dst) {
+bool run_bitset_container_ixor(
+    run_container_t *src_1, const bitset_container_t *src_2,
+    container_t **dst
+){
     bool ans = run_bitset_container_xor(src_1, src_2, dst);
     run_container_free(src_1);
     return ans;
 }
 
-bool bitset_run_container_ixor(bitset_container_t *src_1,
-                               const run_container_t *src_2, void **dst) {
+bool bitset_run_container_ixor(
+    bitset_container_t *src_1, const run_container_t *src_2,
+    container_t **dst
+){
     bool ans = run_bitset_container_xor(src_2, src_1, dst);
     bitset_container_free(src_1);
     return ans;
@@ -320,29 +343,37 @@ bool bitset_run_container_ixor(bitset_container_t *src_1,
  * can become any kind of container.
  */
 
-int array_run_container_ixor(array_container_t *src_1,
-                             const run_container_t *src_2, void **dst) {
+int array_run_container_ixor(
+    array_container_t *src_1, const run_container_t *src_2,
+    container_t **dst
+){
     int ans = array_run_container_xor(src_1, src_2, dst);
     array_container_free(src_1);
     return ans;
 }
 
-int run_array_container_ixor(run_container_t *src_1,
-                             const array_container_t *src_2, void **dst) {
+int run_array_container_ixor(
+    run_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     int ans = array_run_container_xor(src_2, src_1, dst);
     run_container_free(src_1);
     return ans;
 }
 
-bool array_array_container_ixor(array_container_t *src_1,
-                                const array_container_t *src_2, void **dst) {
+bool array_array_container_ixor(
+    array_container_t *src_1, const array_container_t *src_2,
+    container_t **dst
+){
     bool ans = array_array_container_xor(src_1, src_2, dst);
     array_container_free(src_1);
     return ans;
 }
 
-int run_run_container_ixor(run_container_t *src_1, const run_container_t *src_2,
-                           void **dst) {
+int run_run_container_ixor(
+    run_container_t *src_1, const run_container_t *src_2,
+    container_t **dst
+){
     int ans = run_run_container_xor(src_1, src_2, dst);
     run_container_free(src_1);
     return ans;

--- a/src/roaring_priority_queue.c
+++ b/src/roaring_priority_queue.c
@@ -100,7 +100,7 @@ static roaring_pq_element_t pq_poll(roaring_pq_t *pq) {
 // this function consumes and frees the inputs
 static roaring_bitmap_t *lazy_or_from_lazy_inputs(roaring_bitmap_t *x1,
                                                   roaring_bitmap_t *x2) {
-    uint8_t container_result_type = 0;
+    uint8_t result_type = 0;
     const int length1 = ra_get_size(&x1->high_low_container),
               length2 = ra_get_size(&x2->high_low_container);
     if (0 == length1) {
@@ -114,7 +114,7 @@ static roaring_bitmap_t *lazy_or_from_lazy_inputs(roaring_bitmap_t *x1,
     uint32_t neededcap = length1 > length2 ? length2 : length1;
     roaring_bitmap_t *answer = roaring_bitmap_create_with_capacity(neededcap);
     int pos1 = 0, pos2 = 0;
-    uint8_t container_type_1, container_type_2;
+    uint8_t type1, type2;
     uint16_t s1 = ra_get_key_at_index(&x1->high_low_container, pos1);
     uint16_t s2 = ra_get_key_at_index(&x2->high_low_container, pos2);
     while (true) {
@@ -122,39 +122,38 @@ static roaring_bitmap_t *lazy_or_from_lazy_inputs(roaring_bitmap_t *x1,
             // todo: unsharing can be inefficient as it may create a clone where
             // none
             // is needed, but it has the benefit of being easy to reason about.
-            ra_unshare_container_at_index(&x1->high_low_container, pos1);
-            void *c1 = ra_get_container_at_index(&x1->high_low_container, pos1,
-                                                 &container_type_1);
-            assert(container_type_1 != SHARED_CONTAINER_TYPE_CODE);
-            ra_unshare_container_at_index(&x2->high_low_container, pos2);
-            void *c2 = ra_get_container_at_index(&x2->high_low_container, pos2,
-                                                 &container_type_2);
-            assert(container_type_2 != SHARED_CONTAINER_TYPE_CODE);
-            void *c;
 
-            if ((container_type_2 == BITSET_CONTAINER_TYPE_CODE) &&
-                (container_type_1 != BITSET_CONTAINER_TYPE_CODE)) {
-                c = container_lazy_ior(c2, container_type_2, c1,
-                                       container_type_1,
-                                       &container_result_type);
-                container_free(c1, container_type_1);
+            ra_unshare_container_at_index(&x1->high_low_container, pos1);
+            container_t *c1 = ra_get_container_at_index(
+                                    &x1->high_low_container, pos1, &type1);
+            assert(type1 != SHARED_CONTAINER_TYPE_CODE);
+
+            ra_unshare_container_at_index(&x2->high_low_container, pos2);
+            container_t *c2 = ra_get_container_at_index(
+                                    &x2->high_low_container, pos2, &type2);
+            assert(type2 != SHARED_CONTAINER_TYPE_CODE);
+            
+            container_t *c;
+
+            if ((type2 == BITSET_CONTAINER_TYPE_CODE) &&
+                (type1 != BITSET_CONTAINER_TYPE_CODE)
+            ){
+                c = container_lazy_ior(c2, type2, c1, type1, &result_type);
+                container_free(c1, type1);
                 if (c != c2) {
-                    container_free(c2, container_type_2);
+                    container_free(c2, type2);
                 }
             } else {
-                c = container_lazy_ior(c1, container_type_1, c2,
-                                       container_type_2,
-                                       &container_result_type);
-                container_free(c2, container_type_2);
+                c = container_lazy_ior(c1, type1, c2, type2, &result_type);
+                container_free(c2, type2);
                 if (c != c1) {
-                    container_free(c1, container_type_1);
+                    container_free(c1, type1);
                 }
             }
             // since we assume that the initial containers are non-empty, the
             // result here
             // can only be non-empty
-            ra_append(&answer->high_low_container, s1, c,
-                      container_result_type);
+            ra_append(&answer->high_low_container, s1, c, result_type);
             ++pos1;
             ++pos2;
             if (pos1 == length1) break;
@@ -163,17 +162,17 @@ static roaring_bitmap_t *lazy_or_from_lazy_inputs(roaring_bitmap_t *x1,
             s2 = ra_get_key_at_index(&x2->high_low_container, pos2);
 
         } else if (s1 < s2) {  // s1 < s2
-            void *c1 = ra_get_container_at_index(&x1->high_low_container, pos1,
-                                                 &container_type_1);
-            ra_append(&answer->high_low_container, s1, c1, container_type_1);
+            container_t *c1 = ra_get_container_at_index(
+                                    &x1->high_low_container, pos1, &type1);
+            ra_append(&answer->high_low_container, s1, c1, type1);
             pos1++;
             if (pos1 == length1) break;
             s1 = ra_get_key_at_index(&x1->high_low_container, pos1);
 
         } else {  // s1 > s2
-            void *c2 = ra_get_container_at_index(&x2->high_low_container, pos2,
-                                                 &container_type_2);
-            ra_append(&answer->high_low_container, s2, c2, container_type_2);
+            container_t *c2 = ra_get_container_at_index(
+                                    &x2->high_low_container, pos2, &type2);
+            ra_append(&answer->high_low_container, s2, c2, type2);
             pos2++;
             if (pos2 == length2) break;
             s2 = ra_get_key_at_index(&x2->high_low_container, pos2);


### PR DESCRIPTION
There are currently 4 subclasses of container in roaring.  As it is
a C codebase, their structs do not share a common "base class".  So
when passing around a generic container, void* had to be used.

This commit introduces a new type to capture the intention of a
generic container, called `container_t`.  It is defined as `void` in
the C build, and serves as documentation...which is in itself an
improvement.

However, the C++ build can define container_t as an actual base
class for the containers.  It can do so in a way that doesn't disrupt
the C compatible behavior of the structs, due to the derived class
being standard layout because of the "Empty Base Class Optimization"

https://en.cppreference.com/w/cpp/language/ebo

When this is used, you can assign any subclass xxx_container_t to a
container_t* without a cast...but unlike a void*, ONLY those
subclasses can be assigned this way.  Other type checking mechanisms
can be used as well that exploit the relationship.

In the spirit of improving namespacing and avoiding putting things
in global scope, this limits the definition of `container_t` to the
internal code.  But since container pointers are part of the public
definition of `roaring_array_t`, there is an alias for the base
class as a macro ROARING_CONTAINER_T.  It is a macro so it can be
undefined in the internal code to force use there of the shorter
name of `container_t`.

While the commit wasn't meant to be a reformatting crusade, the
`container_t` name is longer than `void` and caused disruption at
callsites...many of which were already hard to read.  And the number
of places that `void*` were used were very numerous.  In the interest
of making the code legible, the usage sites are adapted with some
shorter names being used (e.g. type1 vs. container_type_1).