### PR TITLE
_TYPE_CODE -> _TYPE, CONTAINER_PAIR() shorthand

### DIFF
--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -36,16 +36,16 @@ extern inline container_t *container_iandnot(
 
 void container_free(container_t *container, uint8_t typecode) {
     switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
+        case BITSET_CONTAINER_TYPE:
             bitset_container_free((bitset_container_t *)container);
             break;
-        case ARRAY_CONTAINER_TYPE_CODE:
+        case ARRAY_CONTAINER_TYPE:
             array_container_free((array_container_t *)container);
             break;
-        case RUN_CONTAINER_TYPE_CODE:
+        case RUN_CONTAINER_TYPE:
             run_container_free((run_container_t *)container);
             break;
-        case SHARED_CONTAINER_TYPE_CODE:
+        case SHARED_CONTAINER_TYPE:
             shared_container_free((shared_container_t *)container);
             break;
         default:
@@ -57,13 +57,13 @@ void container_free(container_t *container, uint8_t typecode) {
 void container_printf(const container_t *container, uint8_t typecode) {
     container = container_unwrap_shared(container, &typecode);
     switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
+        case BITSET_CONTAINER_TYPE:
             bitset_container_printf((const bitset_container_t *)container);
             return;
-        case ARRAY_CONTAINER_TYPE_CODE:
+        case ARRAY_CONTAINER_TYPE:
             array_container_printf((const array_container_t *)container);
             return;
-        case RUN_CONTAINER_TYPE_CODE:
+        case RUN_CONTAINER_TYPE:
             run_container_printf((const run_container_t *)container);
             return;
         default:
@@ -77,15 +77,15 @@ void container_printf_as_uint32_array(
 ){
     c = container_unwrap_shared(c, &typecode);
     switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
+        case BITSET_CONTAINER_TYPE:
             bitset_container_printf_as_uint32_array(
                 (const bitset_container_t *)c, base);
             return;
-        case ARRAY_CONTAINER_TYPE_CODE:
+        case ARRAY_CONTAINER_TYPE:
             array_container_printf_as_uint32_array(
                 (const array_container_t *)c, base);
             return;
-        case RUN_CONTAINER_TYPE_CODE:
+        case RUN_CONTAINER_TYPE:
             run_container_printf_as_uint32_array(
                 (const run_container_t *)c, base);
             return;
@@ -134,12 +134,12 @@ container_t *get_copy_of_container(
 ){
     if (copy_on_write) {
         shared_container_t *shared_container;
-        if (*typecode == SHARED_CONTAINER_TYPE_CODE) {
+        if (*typecode == SHARED_CONTAINER_TYPE) {
             shared_container = (shared_container_t *)c;
             shared_container->counter += 1;
             return shared_container;
         }
-        assert(*typecode != SHARED_CONTAINER_TYPE_CODE);
+        assert(*typecode != SHARED_CONTAINER_TYPE);
 
         if ((shared_container = (shared_container_t *)malloc(
                  sizeof(shared_container_t))) == NULL) {
@@ -150,13 +150,13 @@ container_t *get_copy_of_container(
         shared_container->typecode = *typecode;
 
         shared_container->counter = 2;
-        *typecode = SHARED_CONTAINER_TYPE_CODE;
+        *typecode = SHARED_CONTAINER_TYPE;
 
         return shared_container;
     }  // copy_on_write
     // otherwise, no copy on write...
     const container_t *actual_container = container_unwrap_shared(c, typecode);
-    assert(*typecode != SHARED_CONTAINER_TYPE_CODE);
+    assert(*typecode != SHARED_CONTAINER_TYPE);
     return container_clone(actual_container, *typecode);
 }
 
@@ -167,13 +167,13 @@ container_t *get_copy_of_container(
 container_t *container_clone(const container_t *c, uint8_t typecode) {
     c = container_unwrap_shared(c, &typecode);
     switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
+        case BITSET_CONTAINER_TYPE:
             return bitset_container_clone((const bitset_container_t *)c);
-        case ARRAY_CONTAINER_TYPE_CODE:
+        case ARRAY_CONTAINER_TYPE:
             return array_container_clone((const array_container_t *)c);
-        case RUN_CONTAINER_TYPE_CODE:
+        case RUN_CONTAINER_TYPE:
             return run_container_clone((const run_container_t *)c);
-        case SHARED_CONTAINER_TYPE_CODE:
+        case SHARED_CONTAINER_TYPE:
             printf("shared containers are not cloneable\n");
             assert(false);
             return NULL;
@@ -188,7 +188,7 @@ container_t *shared_container_extract_copy(
     shared_container_t *sc, uint8_t *typecode
 ){
     assert(sc->counter > 0);
-    assert(sc->typecode != SHARED_CONTAINER_TYPE_CODE);
+    assert(sc->typecode != SHARED_CONTAINER_TYPE);
     sc->counter--;
     *typecode = sc->typecode;
     container_t *answer;
@@ -199,7 +199,7 @@ container_t *shared_container_extract_copy(
     } else {
         answer = container_clone(sc->container, *typecode);
     }
-    assert(*typecode != SHARED_CONTAINER_TYPE_CODE);
+    assert(*typecode != SHARED_CONTAINER_TYPE);
     return answer;
 }
 
@@ -207,7 +207,7 @@ void shared_container_free(shared_container_t *container) {
     assert(container->counter > 0);
     container->counter--;
     if (container->counter == 0) {
-        assert(container->typecode != SHARED_CONTAINER_TYPE_CODE);
+        assert(container->typecode != SHARED_CONTAINER_TYPE);
         container_free(container->container, container->typecode);
         container->container = NULL;  // paranoid
         free(container);

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -290,7 +290,7 @@ int run_array_container_andnot(
     if (card <= arbitrary_threshold) {
         if (src_2->cardinality == 0) {
             *dst = run_container_clone(src_1);
-            return RUN_CONTAINER_TYPE_CODE;
+            return RUN_CONTAINER_TYPE;
         }
         // Java's "lazyandNot.toEfficientContainer" thing
         run_container_t *answer = run_container_create_given_capacity(
@@ -357,12 +357,12 @@ int run_array_container_andnot(
         // difference
         ac->cardinality = run_array_array_subtract(src_1, src_2, ac);
         *dst = ac;
-        return ARRAY_CONTAINER_TYPE_CODE;
+        return ARRAY_CONTAINER_TYPE;
     }
     bitset_container_t *ans = bitset_container_from_run(src_1);
     bool result_is_bitset = bitset_array_container_iandnot(ans, src_2, dst);
-    return (result_is_bitset ? BITSET_CONTAINER_TYPE_CODE
-                             : ARRAY_CONTAINER_TYPE_CODE);
+    return (result_is_bitset ? BITSET_CONTAINER_TYPE
+                             : ARRAY_CONTAINER_TYPE);
 }
 
 /* Compute the andnot of src_1 and src_2 and write the result to

--- a/src/containers/mixed_negation.c
+++ b/src/containers/mixed_negation.c
@@ -244,7 +244,7 @@ int run_container_negation_range(
     // follows the Java implementation
     if (range_end <= range_start) {
         *dst = run_container_clone(src);
-        return RUN_CONTAINER_TYPE_CODE;
+        return RUN_CONTAINER_TYPE;
     }
 
     run_container_t *ans = run_container_create_given_capacity(
@@ -264,7 +264,7 @@ int run_container_negation_range(
     }
 
     *dst = convert_run_to_efficient_container(ans, &return_typecode);
-    if (return_typecode != RUN_CONTAINER_TYPE_CODE) run_container_free(ans);
+    if (return_typecode != RUN_CONTAINER_TYPE) run_container_free(ans);
 
     return return_typecode;
 }
@@ -285,7 +285,7 @@ int run_container_negation_range_inplace(
 
     if (range_end <= range_start) {
         *dst = src;
-        return RUN_CONTAINER_TYPE_CODE;
+        return RUN_CONTAINER_TYPE;
     }
 
     // TODO: efficient special case when range is 0 to 65535 inclusive
@@ -347,7 +347,7 @@ int run_container_negation_range_inplace(
     }
 
     *dst = convert_run_to_efficient_container(ans, &return_typecode);
-    if (return_typecode != RUN_CONTAINER_TYPE_CODE) run_container_free(ans);
+    if (return_typecode != RUN_CONTAINER_TYPE) run_container_free(ans);
 
     return return_typecode;
 }

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -128,15 +128,15 @@ int array_run_container_xor(
         array_container_t *temp = array_container_from_run(src_2);
         bool ret_is_bitset = array_array_container_xor(temp, src_1, dst);
         array_container_free(temp);
-        return ret_is_bitset ? BITSET_CONTAINER_TYPE_CODE
-                             : ARRAY_CONTAINER_TYPE_CODE;
+        return ret_is_bitset ? BITSET_CONTAINER_TYPE
+                             : ARRAY_CONTAINER_TYPE;
 
     } else {  // guess that it will end up as a bitset
         bitset_container_t *result = bitset_container_from_run(src_2);
         bool is_bitset = bitset_array_container_ixor(result, src_1, dst);
         // any necessary type conversion has been done by the ixor
-        int retval = (is_bitset ? BITSET_CONTAINER_TYPE_CODE
-                                : ARRAY_CONTAINER_TYPE_CODE);
+        int retval = (is_bitset ? BITSET_CONTAINER_TYPE
+                                : ARRAY_CONTAINER_TYPE);
         return retval;
     }
 }

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -473,13 +473,13 @@ bool ra_range_uint32_array(const roaring_array_t *ra, size_t offset, size_t limi
         const container_t *c = container_unwrap_shared(
                                         ra->containers[i], &ra->typecodes[i]);
         switch (ra->typecodes[i]) {
-            case BITSET_CONTAINER_TYPE_CODE:
+            case BITSET_CONTAINER_TYPE:
                 t_limit = ((const bitset_container_t *)c)->cardinality;
                 break;
-            case ARRAY_CONTAINER_TYPE_CODE:
+            case ARRAY_CONTAINER_TYPE:
                 t_limit = ((const array_container_t *)c)->cardinality;
                 break;
-            case RUN_CONTAINER_TYPE_CODE:
+            case RUN_CONTAINER_TYPE:
                 t_limit = run_container_cardinality((const run_container_t *)c);
                 break;
         }
@@ -508,19 +508,19 @@ bool ra_range_uint32_array(const roaring_array_t *ra, size_t offset, size_t limi
                 t_ans = append_ans;
             }
             switch (ra->typecodes[i]) {
-                case BITSET_CONTAINER_TYPE_CODE:
+                case BITSET_CONTAINER_TYPE:
                     container_to_uint32_array(
                         t_ans + dtr,
                         (const bitset_container_t *)c,  ra->typecodes[i],
                         ((uint32_t)ra->keys[i]) << 16);
                     break;
-                case ARRAY_CONTAINER_TYPE_CODE:
+                case ARRAY_CONTAINER_TYPE:
                     container_to_uint32_array(
                         t_ans + dtr,
                         (const array_container_t *)c, ra->typecodes[i],
                         ((uint32_t)ra->keys[i]) << 16);
                     break;
-                case RUN_CONTAINER_TYPE_CODE:
+                case RUN_CONTAINER_TYPE:
                     container_to_uint32_array(
                         t_ans + dtr,
                         (const run_container_t *)c, ra->typecodes[i],
@@ -542,7 +542,7 @@ bool ra_range_uint32_array(const roaring_array_t *ra, size_t offset, size_t limi
 bool ra_has_run_container(const roaring_array_t *ra) {
     for (int32_t k = 0; k < ra->size; ++k) {
         if (get_container_type(ra->containers[k], ra->typecodes[k]) ==
-            RUN_CONTAINER_TYPE_CODE)
+            RUN_CONTAINER_TYPE)
             return true;
     }
     return false;
@@ -583,7 +583,7 @@ size_t ra_portable_serialize(const roaring_array_t *ra, char *buf) {
         assert(bitmapOfRunContainers != NULL);  // todo: handle
         for (int32_t i = 0; i < ra->size; ++i) {
             if (get_container_type(ra->containers[i], ra->typecodes[i]) ==
-                RUN_CONTAINER_TYPE_CODE) {
+                RUN_CONTAINER_TYPE) {
                 bitmapOfRunContainers[i / 8] |= (1 << (i % 8));
             }
         }
@@ -830,7 +830,7 @@ bool ra_portable_deserialize(roaring_array_t *answer, const char *buf, const siz
             answer->size++;
             buf += bitset_container_read(thiscard, c, buf);
             answer->containers[k] = c;
-            answer->typecodes[k] = BITSET_CONTAINER_TYPE_CODE;
+            answer->typecodes[k] = BITSET_CONTAINER_TYPE;
         } else if (isrun) {
             // we check that the read is allowed
             *readbytes += sizeof(uint16_t);
@@ -859,7 +859,7 @@ bool ra_portable_deserialize(roaring_array_t *answer, const char *buf, const siz
             answer->size++;
             buf += run_container_read(thiscard, c, buf);
             answer->containers[k] = c;
-            answer->typecodes[k] = RUN_CONTAINER_TYPE_CODE;
+            answer->typecodes[k] = RUN_CONTAINER_TYPE;
         } else {
             // we check that the read is allowed
             size_t containersize = thiscard * sizeof(uint16_t);
@@ -880,7 +880,7 @@ bool ra_portable_deserialize(roaring_array_t *answer, const char *buf, const siz
             answer->size++;
             buf += array_container_read(thiscard, c, buf);
             answer->containers[k] = c;
-            answer->typecodes[k] = ARRAY_CONTAINER_TYPE_CODE;
+            answer->typecodes[k] = ARRAY_CONTAINER_TYPE;
         }
     }
     return true;

--- a/src/roaring_priority_queue.c
+++ b/src/roaring_priority_queue.c
@@ -126,17 +126,17 @@ static roaring_bitmap_t *lazy_or_from_lazy_inputs(roaring_bitmap_t *x1,
             ra_unshare_container_at_index(&x1->high_low_container, pos1);
             container_t *c1 = ra_get_container_at_index(
                                     &x1->high_low_container, pos1, &type1);
-            assert(type1 != SHARED_CONTAINER_TYPE_CODE);
+            assert(type1 != SHARED_CONTAINER_TYPE);
 
             ra_unshare_container_at_index(&x2->high_low_container, pos2);
             container_t *c2 = ra_get_container_at_index(
                                     &x2->high_low_container, pos2, &type2);
-            assert(type2 != SHARED_CONTAINER_TYPE_CODE);
+            assert(type2 != SHARED_CONTAINER_TYPE);
             
             container_t *c;
 
-            if ((type2 == BITSET_CONTAINER_TYPE_CODE) &&
-                (type1 != BITSET_CONTAINER_TYPE_CODE)
+            if ((type2 == BITSET_CONTAINER_TYPE) &&
+                (type1 != BITSET_CONTAINER_TYPE)
             ){
                 c = container_lazy_ior(c2, type2, c1, type1, &result_type);
                 container_free(c1, type1);

--- a/tests/container_comparison_unit.c
+++ b/tests/container_comparison_unit.c
@@ -27,13 +27,13 @@ static inline void container_checked_add(void *container, uint16_t val,
 static inline void delegated_add(void *container, uint8_t typecode,
                                  uint16_t val) {
     switch(typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
+        case BITSET_CONTAINER_TYPE:
             bitset_container_add((bitset_container_t*)container, val);
             break;
-        case ARRAY_CONTAINER_TYPE_CODE:
+        case ARRAY_CONTAINER_TYPE:
             array_container_add((array_container_t*)container, val);
             break;
-        case RUN_CONTAINER_TYPE_CODE:
+        case RUN_CONTAINER_TYPE:
             run_container_add((run_container_t*)container, val);
             break;
         default:
@@ -45,13 +45,13 @@ static inline void delegated_add(void *container, uint8_t typecode,
 static inline void *container_create(uint8_t typecode) {
     void *result = NULL;
     switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
+        case BITSET_CONTAINER_TYPE:
             result = bitset_container_create();
             break;
-        case ARRAY_CONTAINER_TYPE_CODE:
+        case ARRAY_CONTAINER_TYPE:
             result = array_container_create();
             break;
-        case RUN_CONTAINER_TYPE_CODE:
+        case RUN_CONTAINER_TYPE:
             result = run_container_create();
             break;
         default:
@@ -117,39 +117,39 @@ void generic_equal_test(uint8_t type1, uint8_t type2) {
 }
 
 void equal_array_array_test() {
-    generic_equal_test(ARRAY_CONTAINER_TYPE_CODE, ARRAY_CONTAINER_TYPE_CODE);
+    generic_equal_test(ARRAY_CONTAINER_TYPE, ARRAY_CONTAINER_TYPE);
 }
 
 void equal_bitset_bitset_test() {
-    generic_equal_test(BITSET_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+    generic_equal_test(BITSET_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 
 void equal_run_run_test() {
-    generic_equal_test(RUN_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+    generic_equal_test(RUN_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
 void equal_array_bitset_test() {
-    generic_equal_test(ARRAY_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+    generic_equal_test(ARRAY_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 
 void equal_bitset_array_test() {
-    generic_equal_test(BITSET_CONTAINER_TYPE_CODE, ARRAY_CONTAINER_TYPE_CODE);
+    generic_equal_test(BITSET_CONTAINER_TYPE, ARRAY_CONTAINER_TYPE);
 }
 
 void equal_array_run_test() {
-    generic_equal_test(ARRAY_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+    generic_equal_test(ARRAY_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
 void equal_run_array_test() {
-    generic_equal_test(RUN_CONTAINER_TYPE_CODE, ARRAY_CONTAINER_TYPE_CODE);
+    generic_equal_test(RUN_CONTAINER_TYPE, ARRAY_CONTAINER_TYPE);
 }
 
 void equal_bitset_run_test() {
-    generic_equal_test(BITSET_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+    generic_equal_test(BITSET_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
 void equal_run_bitset_test() {
-    generic_equal_test(RUN_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+    generic_equal_test(RUN_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 
 void generic_subset_test(uint8_t type1, uint8_t type2) {
@@ -177,35 +177,35 @@ void generic_subset_test(uint8_t type1, uint8_t type2) {
 }
 
 void subset_array_array_test() {
-    generic_subset_test(ARRAY_CONTAINER_TYPE_CODE, ARRAY_CONTAINER_TYPE_CODE);
+    generic_subset_test(ARRAY_CONTAINER_TYPE, ARRAY_CONTAINER_TYPE);
 }
 
 void subset_bitset_bitset_test() {
-    generic_subset_test(BITSET_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+    generic_subset_test(BITSET_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 
 void subset_run_run_test() {
-    generic_subset_test(RUN_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+    generic_subset_test(RUN_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
 void subset_array_bitset_test() {
-    generic_subset_test(ARRAY_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+    generic_subset_test(ARRAY_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 
 void subset_array_run_test() {
-    generic_subset_test(ARRAY_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+    generic_subset_test(ARRAY_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
 void subset_run_array_test() {
-    generic_subset_test(RUN_CONTAINER_TYPE_CODE, ARRAY_CONTAINER_TYPE_CODE);
+    generic_subset_test(RUN_CONTAINER_TYPE, ARRAY_CONTAINER_TYPE);
 }
 
 void subset_bitset_run_test() {
-    generic_subset_test(BITSET_CONTAINER_TYPE_CODE, RUN_CONTAINER_TYPE_CODE);
+    generic_subset_test(BITSET_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
 void subset_run_bitset_test() {
-    generic_subset_test(RUN_CONTAINER_TYPE_CODE, BITSET_CONTAINER_TYPE_CODE);
+    generic_subset_test(RUN_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 
 int main() {

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -570,7 +570,7 @@ void run_xor_test() {
     array_container_free(BX_1);
     BX_1 = NULL;
 
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      array_run_container_xor(A1, R1, &BX_1));
     assert_int_equal(0, array_container_cardinality(BX_1));
     array_container_free(BX_1);
@@ -578,7 +578,7 @@ void run_xor_test() {
 
     // both run coding and array coding have same serialized size for
     // empty
-    assert_int_equal(RUN_CONTAINER_TYPE_CODE,
+    assert_int_equal(RUN_CONTAINER_TYPE,
                      run_run_container_xor(R1, R1, &BX_1));
     assert_int_equal(0, run_container_cardinality(BX_1));
     run_container_free(BX_1);
@@ -589,13 +589,13 @@ void run_xor_test() {
     array_container_free(BX_1);
     BX_1 = NULL;
 
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      array_run_container_xor(A3, R1, &BX_1));
     assert_int_equal(2000, array_container_cardinality(BX_1));
     array_container_free(BX_1);
     BX_1 = NULL;
 
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_run_container_xor(R1, R3, &BX_1));
     assert_int_equal(2000, array_container_cardinality(BX_1));
     array_container_free(BX_1);
@@ -606,7 +606,7 @@ void run_xor_test() {
     bitset_container_free(BX_1);
     BX_1 = NULL;
 
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      array_run_container_xor(A2, R1, &BX_1));
     assert_int_equal(cx12, bitset_container_cardinality(BX_1));
     bitset_container_free(BX_1);
@@ -615,14 +615,14 @@ void run_xor_test() {
     array_container_t* A_small = array_container_create();
     for (int i = 1000; i < 1010; ++i) array_container_add(A_small, i);
 
-    assert_int_equal(RUN_CONTAINER_TYPE_CODE,
+    assert_int_equal(RUN_CONTAINER_TYPE,
                      array_run_container_xor(A_small, R2, &BX_1));
     assert_int_equal(0x98bd,
                      run_container_cardinality(BX_1));  // hopefully right...
     run_container_free(BX_1);
     BX_1 = NULL;
 
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_xor(R1, R2, &BX_1));
     assert_int_equal(cx12, bitset_container_cardinality(BX_1));
     bitset_container_free(BX_1);
@@ -634,14 +634,14 @@ void run_xor_test() {
     bitset_container_free(BX_1);
     BX_1 = NULL;
 
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      array_run_container_xor(A3, R4, &BX_1));
     // if this fails, either this bitset is wrong or the previous one...
     assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
     bitset_container_free(BX_1);
     BX_1 = NULL;
 
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_xor(R4, R3, &BX_1));
     assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
     bitset_container_free(BX_1);
@@ -742,7 +742,7 @@ void run_andnot_test() {
 
     // both run coding and array coding have same serialized size for
     // empty
-    assert_int_equal(RUN_CONTAINER_TYPE_CODE,
+    assert_int_equal(RUN_CONTAINER_TYPE,
                      run_run_container_andnot(R1, R1, &BM_1));
     assert_int_equal(0, run_container_cardinality(BM_1));
     run_container_free(BM_1);
@@ -761,13 +761,13 @@ void run_andnot_test() {
     array_run_container_andnot(A1, R3, AM);
     assert_int_equal(2000, array_container_cardinality(AM));
 
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_array_container_andnot(R1, A3, &BM_1));
     assert_int_equal(2000, array_container_cardinality(BM_1));
     array_container_free(BM_1);
     BM_1 = NULL;
 
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_run_container_andnot(R1, R3, &BM_1));
     assert_int_equal(2000, array_container_cardinality(BM_1));
     array_container_free(BM_1);
@@ -797,7 +797,7 @@ void run_andnot_test() {
     BM_1 = NULL;
 
     // note, result is equally small as an array or a run
-    assert_int_equal(RUN_CONTAINER_TYPE_CODE,
+    assert_int_equal(RUN_CONTAINER_TYPE,
                      run_array_container_andnot(R_small, A2, &BM_1));
     assert_int_equal(2, run_container_cardinality(BM_1));
     array_container_free(BM_1);
@@ -818,7 +818,7 @@ void run_andnot_test() {
     array_container_add(temp_ac, 2000);
 
     assert_int_equal(
-        RUN_CONTAINER_TYPE_CODE,
+        RUN_CONTAINER_TYPE,
         run_array_container_andnot(R_small_complex, temp_ac, &BM_1));
     assert_int_equal(13, run_container_cardinality(BM_1));
     array_container_free(BM_1);
@@ -827,13 +827,13 @@ void run_andnot_test() {
     array_container_free(temp_ac);
     run_container_free(R_small_complex);
 
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_array_container_andnot(R1, A3, &BM_1));
     assert_int_equal(2000, array_container_cardinality(BM_1));
     array_container_free(BM_1);
     BM_1 = NULL;
 
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_andnot(R1, R2, &BM_1));
     assert_int_equal(cm12, bitset_container_cardinality(BM_1));
     bitset_container_free(BM_1);
@@ -855,7 +855,7 @@ void run_andnot_test() {
     // if this fails, either this bitset is wrong or the previous one...
     assert_int_equal(card_4_3, array_container_cardinality(AM));
 
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_andnot(R4, R3, &BM_1));
     assert_int_equal(card_4_3, bitset_container_cardinality(BM_1));
     bitset_container_free(BM_1);
@@ -961,14 +961,14 @@ void run_ixor_test() {
     BX_1 = NULL;
 
     array_container_t* temp_a = array_container_clone(A1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      array_run_container_ixor(temp_a, R1, &BX_1));
     assert_int_equal(0, array_container_cardinality(BX_1));
     array_container_free(BX_1);
     BX_1 = NULL;
 
     temp_r = run_container_clone(R1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_array_container_ixor(temp_r, A1, &BX_1));
     assert_int_equal(0, array_container_cardinality(BX_1));
     array_container_free(BX_1);
@@ -978,8 +978,8 @@ void run_ixor_test() {
     // empty
     temp_r = run_container_clone(R1);
     int ret_type = run_run_container_ixor(temp_r, R1, &BX_1);
-    assert_int_not_equal(BITSET_CONTAINER_TYPE_CODE, ret_type);
-    if (ret_type == RUN_CONTAINER_TYPE_CODE) {
+    assert_int_not_equal(BITSET_CONTAINER_TYPE, ret_type);
+    if (ret_type == RUN_CONTAINER_TYPE) {
         assert_int_equal(0, run_container_cardinality(BX_1));
         run_container_free(BX_1);
     } else {
@@ -995,7 +995,7 @@ void run_ixor_test() {
     BX_1 = NULL;
 
     temp_a = array_container_clone(A3);
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      array_run_container_ixor(temp_a, R1, &BX_1));
     assert_int_equal(2000, array_container_cardinality(BX_1));
     array_container_free(BX_1);
@@ -1009,14 +1009,14 @@ void run_ixor_test() {
     BX_1 = NULL;
 
     temp_r = run_container_clone(R3);
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_array_container_ixor(temp_r, A1, &BX_1));
     assert_int_equal(2000, array_container_cardinality(BX_1));
     array_container_free(BX_1);
     BX_1 = NULL;
 
     temp_r = run_container_clone(R1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_run_container_ixor(temp_r, R3, &BX_1));
     assert_int_equal(2000, array_container_cardinality(BX_1));
     array_container_free(BX_1);
@@ -1029,7 +1029,7 @@ void run_ixor_test() {
     BX_1 = NULL;
 
     temp_a = array_container_clone(A2);
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      array_run_container_ixor(temp_a, R1, &BX_1));
     assert_int_equal(cx12, bitset_container_cardinality(BX_1));
     bitset_container_free(BX_1);
@@ -1043,14 +1043,14 @@ void run_ixor_test() {
     BX_1 = NULL;
 
     temp_r = run_container_clone(R1);
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_array_container_ixor(temp_r, A2, &BX_1));
     assert_int_equal(cx12, bitset_container_cardinality(BX_1));
     bitset_container_free(BX_1);
     BX_1 = NULL;
 
     temp_r = run_container_clone(R1);
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_ixor(temp_r, R2, &BX_1));
     assert_int_equal(cx12, bitset_container_cardinality(BX_1));
     bitset_container_free(BX_1);
@@ -1064,7 +1064,7 @@ void run_ixor_test() {
     BX_1 = NULL;
 
     temp_a = array_container_clone(A3);
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      array_run_container_ixor(temp_a, R4, &BX_1));
     // if this fails, either this bitset is wrong or the previous one...
     assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
@@ -1079,14 +1079,14 @@ void run_ixor_test() {
     BX_1 = NULL;
 
     temp_r = run_container_clone(R3);
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_array_container_ixor(temp_r, A4, &BX_1));
     assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
     bitset_container_free(BX_1);
     BX_1 = NULL;
 
     temp_r = run_container_clone(R4);
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_ixor(temp_r, R3, &BX_1));
     assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
     bitset_container_free(BX_1);
@@ -1190,7 +1190,7 @@ void run_iandnot_test() {
     array_container_free(temp_a);
 
     temp_r = run_container_clone(R1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_array_container_iandnot(temp_r, A1, &BM_1));
     assert_int_equal(0, array_container_cardinality(BM_1));
     array_container_free(BM_1);
@@ -1200,8 +1200,8 @@ void run_iandnot_test() {
     // empty
     temp_r = run_container_clone(R1);
     int ret_type = run_run_container_iandnot(temp_r, R1, &BM_1);
-    assert_int_not_equal(BITSET_CONTAINER_TYPE_CODE, ret_type);
-    if (ret_type == RUN_CONTAINER_TYPE_CODE) {
+    assert_int_not_equal(BITSET_CONTAINER_TYPE, ret_type);
+    if (ret_type == RUN_CONTAINER_TYPE) {
         assert_int_equal(0, run_container_cardinality(BM_1));
         run_container_free(BM_1);
     } else {
@@ -1229,14 +1229,14 @@ void run_iandnot_test() {
     BM_1 = NULL;
 
     temp_r = run_container_clone(R1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_array_container_iandnot(temp_r, A3, &BM_1));
     assert_int_equal(2000, array_container_cardinality(BM_1));
     array_container_free(BM_1);
     BM_1 = NULL;
 
     temp_r = run_container_clone(R1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE,
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_run_container_iandnot(temp_r, R3, &BM_1));
     assert_int_equal(2000, array_container_cardinality(BM_1));
     array_container_free(BM_1);
@@ -1261,14 +1261,14 @@ void run_iandnot_test() {
     BM_1 = NULL;
 
     temp_r = run_container_clone(R1);
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_array_container_iandnot(temp_r, A2, &BM_1));
     assert_int_equal(cm12, bitset_container_cardinality(BM_1));
     bitset_container_free(BM_1);
     BM_1 = NULL;
 
     temp_r = run_container_clone(R1);
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_iandnot(temp_r, R2, &BM_1));
     assert_int_equal(cm12, bitset_container_cardinality(BM_1));
     bitset_container_free(BM_1);
@@ -1299,14 +1299,14 @@ void run_iandnot_test() {
     BM_1 = NULL;
 
     temp_r = run_container_clone(R4);
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_array_container_iandnot(temp_r, A3, &BM_1));
     assert_int_equal(card_4_3, bitset_container_cardinality(BM_1));
     bitset_container_free(BM_1);
     BM_1 = NULL;
 
     temp_r = run_container_clone(R4);
-    assert_int_equal(BITSET_CONTAINER_TYPE_CODE,
+    assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_iandnot(temp_r, R3, &BM_1));
     assert_int_equal(card_4_3, bitset_container_cardinality(BM_1));
     bitset_container_free(BM_1);
@@ -1356,7 +1356,7 @@ void run_array_andnot_bug_test() {
     int kindofresult;
     void* result = 0;
     kindofresult = run_array_container_andnot(r, a, &result);
-    assert_int_equal(ARRAY_CONTAINER_TYPE_CODE, kindofresult);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, kindofresult);
     assert_false(array_container_contains(result, 196722 % 65536));
 
     run_container_free(r);
@@ -1426,8 +1426,8 @@ static int array_negation_range_test(int r_start, int r_end, bool is_bitset) {
 
     result_is_bitset =
         array_container_negation_range(AI, r_start, r_end, (void**)&BO);
-    uint8_t result_typecode = (result_is_bitset ? BITSET_CONTAINER_TYPE_CODE
-                                                : ARRAY_CONTAINER_TYPE_CODE);
+    uint8_t result_typecode = (result_is_bitset ? BITSET_CONTAINER_TYPE
+                                                : ARRAY_CONTAINER_TYPE);
 
     int result_card = container_get_cardinality(BO, result_typecode);
 
@@ -1505,8 +1505,8 @@ static int bitset_negation_range_tests(int sparsity, int r_start, int r_end,
         result_is_bitset =
             bitset_container_negation_range(BI, r_start, r_end, (void**)&BO);
 
-    uint8_t result_typecode = (result_is_bitset ? BITSET_CONTAINER_TYPE_CODE
-                                                : ARRAY_CONTAINER_TYPE_CODE);
+    uint8_t result_typecode = (result_is_bitset ? BITSET_CONTAINER_TYPE
+                                                : ARRAY_CONTAINER_TYPE);
 
     int result_card = container_get_cardinality(BO, result_typecode);
 
@@ -1761,7 +1761,7 @@ void run_negation_range_inplace_test1() {
     // bitset
 
     run_negation_range_tests(10, 7, 0, 0x0000, 0x10000,
-                             BITSET_CONTAINER_TYPE_CODE, true,
+                             BITSET_CONTAINER_TYPE, true,
                              false);  // request but don't get inplace
 }
 
@@ -1774,7 +1774,7 @@ void run_negation_range_inplace_test2() {
     // bitset
 
     run_negation_range_tests(10, 7, 1, 0x0000, 0x10000,
-                             BITSET_CONTAINER_TYPE_CODE, true,
+                             BITSET_CONTAINER_TYPE, true,
                              false);  // request but don't get inplace
 }
 
@@ -1788,7 +1788,7 @@ void run_negation_range_inplace_test3() {
     // bitset
 
     run_negation_range_tests(10, 2, 1, 0x0000, 0x10000,
-                             BITSET_CONTAINER_TYPE_CODE, true,
+                             BITSET_CONTAINER_TYPE, true,
                              false);  // request but don't get inplace
 }
 
@@ -1802,7 +1802,7 @@ void run_negation_range_inplace_test4() {
     // Result should be array
 
     run_negation_range_tests(1000, 999, 0, 0x0000, 0x10000,
-                             ARRAY_CONTAINER_TYPE_CODE, true,
+                             ARRAY_CONTAINER_TYPE, true,
                              false);  // request but don't get inplace
 }
 
@@ -1815,7 +1815,7 @@ void run_negation_range_inplace_test5() {
     // bitset
 
     run_negation_range_tests(1000, 999, 1, 0x0000, 0x10000,
-                             ARRAY_CONTAINER_TYPE_CODE, true,
+                             ARRAY_CONTAINER_TYPE, true,
                              false);  // request but don't get inplace
 }
 
@@ -1828,7 +1828,7 @@ void run_negation_range_inplace_test6() {
     // initial.  Result should be array
 
     run_negation_range_tests(1000, 999, 536, 530, 0x10000,
-                             ARRAY_CONTAINER_TYPE_CODE, true,
+                             ARRAY_CONTAINER_TYPE, true,
                              false);  // request but don't get inplace
 }
 
@@ -1843,7 +1843,7 @@ void run_negation_range_inplace_test7() {
     // should always fit in the previous space
 
     run_negation_range_tests(1000, 2, 550, 0x0000, 0x10000,
-                             RUN_CONTAINER_TYPE_CODE, true,
+                             RUN_CONTAINER_TYPE, true,
                              true);  // request and  get inplace
 }
 
@@ -1856,7 +1856,7 @@ void run_negation_range_inplace_test8() {
     // run and will fit.
 
     run_negation_range_tests(1000, 2, 0, 0x0000, 0x10000,
-                             RUN_CONTAINER_TYPE_CODE, true,
+                             RUN_CONTAINER_TYPE, true,
                              true);  // request, get inplace
 }
 
@@ -1871,7 +1871,7 @@ void run_negation_range_inplace_test9() {
     // have any extra space.
 
     run_negation_range_tests(1000, 2, 1, 0x0000, 0x10000,
-                             RUN_CONTAINER_TYPE_CODE, true,
+                             RUN_CONTAINER_TYPE, true,
                              false);  // request, but not get, inplace
 }
 
@@ -1888,7 +1888,7 @@ void run_negation_range_test1() {
     // bitset
 
     run_negation_range_tests(10, 7, 0, 0x0000, 0x10000,
-                             BITSET_CONTAINER_TYPE_CODE, false, false);
+                             BITSET_CONTAINER_TYPE, false, false);
 }
 
 void run_negation_range_test2() {
@@ -1900,7 +1900,7 @@ void run_negation_range_test2() {
     // bitset
 
     run_negation_range_tests(10, 7, 1, 0x0000, 0x10000,
-                             BITSET_CONTAINER_TYPE_CODE, false, false);
+                             BITSET_CONTAINER_TYPE, false, false);
 }
 
 void run_negation_range_test3() {
@@ -1913,7 +1913,7 @@ void run_negation_range_test3() {
     // bitset
 
     run_negation_range_tests(10, 2, 1, 0x0000, 0x10000,
-                             BITSET_CONTAINER_TYPE_CODE, false,
+                             BITSET_CONTAINER_TYPE, false,
                              false);  // request but don't get inplace
 }
 
@@ -1927,7 +1927,7 @@ void run_negation_range_test4() {
     // array
 
     run_negation_range_tests(1000, 999, 0, 0x0000, 0x10000,
-                             ARRAY_CONTAINER_TYPE_CODE, false, false);
+                             ARRAY_CONTAINER_TYPE, false, false);
 }
 
 void run_negation_range_test5() {
@@ -1939,7 +1939,7 @@ void run_negation_range_test5() {
     // bitset
 
     run_negation_range_tests(1000, 999, 1, 0x0000, 0x10000,
-                             ARRAY_CONTAINER_TYPE_CODE, false, false);
+                             ARRAY_CONTAINER_TYPE, false, false);
 }
 
 void run_negation_range_test6() {
@@ -1951,7 +1951,7 @@ void run_negation_range_test6() {
     // fragment. Result should be array
 
     run_negation_range_tests(1000, 999, 536, 530, 0x10000,
-                             ARRAY_CONTAINER_TYPE_CODE, false, false);
+                             ARRAY_CONTAINER_TYPE, false, false);
 }
 
 /* Results are going to be runs*/
@@ -1965,7 +1965,7 @@ void run_negation_range_test7() {
     // should always fit in the previous space
 
     run_negation_range_tests(1000, 2, 550, 0x0000, 0x10000,
-                             RUN_CONTAINER_TYPE_CODE, false, false);
+                             RUN_CONTAINER_TYPE, false, false);
 }
 
 void run_negation_range_test8() {
@@ -1977,7 +1977,7 @@ void run_negation_range_test8() {
     // run and will fit.
 
     run_negation_range_tests(1000, 2, 0, 0x0000, 0x10000,
-                             RUN_CONTAINER_TYPE_CODE, false, false);
+                             RUN_CONTAINER_TYPE, false, false);
 }
 
 void run_negation_range_test9() {
@@ -1991,7 +1991,7 @@ void run_negation_range_test9() {
     // usually have space  :)
 
     run_negation_range_tests(1000, 2, 1, 0x0000, 0x10000,
-                             RUN_CONTAINER_TYPE_CODE, false, false);
+                             RUN_CONTAINER_TYPE, false, false);
 }
 
 int main() {


### PR DESCRIPTION
Names like ARRAY_CONTAINER_TYPE_CODE are less belabored if they
are just like ARRAY_CONTAINER_TYPE.  (Longness for the sake of
uniqueness is significantly less of an issue with containers.h
no longer leaking into the public exports.)

This makes that change, as well as using token pasting to shorten
the switch() case instances of CONTAINER_PAIR.  It is split into
two macros, one to use with constants in case labels and one to
use with variables in the switch itself.

Before:

    switch (CONTAINER_PAIR(type1, type2)) {
        case CONTAINER_PAIR(ARRAY_CONTAINER_TYPE_CODE,
                            RUN_CONTAINER_TYPE_CODE):
            ...
    }

After:

    switch (PAIR_CONTAINER_TYPES(type1, type2)) {
        case CONTAINER_PAIR(ARRAY,RUN):
            ...
    }