### PR TITLE
Safer downcasts w/macros that static_cast<> in C++ …

### DIFF
--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -43,6 +43,7 @@ typedef struct array_container_s array_container_t;
 
 #define CAST_array(c)         CAST(array_container_t *, c)  // safer downcast
 #define const_CAST_array(c)   CAST(const array_container_t *, c)
+#define movable_CAST_array(c) movable_CAST(array_container_t **, c)
 
 /* Create a new array with default. Return NULL in case of failure. See also
  * array_container_create_given_capacity. */

--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -41,6 +41,9 @@ STRUCT_CONTAINER(array_container_s) {
 
 typedef struct array_container_s array_container_t;
 
+#define CAST_array(c)         CAST(array_container_t *, c)  // safer downcast
+#define const_CAST_array(c)   CAST(const array_container_t *, c)
+
 /* Create a new array with default. Return NULL in case of failure. See also
  * array_container_create_given_capacity. */
 array_container_t *array_container_create(void);

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -43,6 +43,9 @@ STRUCT_CONTAINER(bitset_container_s) {
 
 typedef struct bitset_container_s bitset_container_t;
 
+#define CAST_bitset(c)         CAST(bitset_container_t *, c)  // safer downcast
+#define const_CAST_bitset(c)   CAST(const bitset_container_t *, c)
+
 /* Create a new bitset. Return NULL in case of failure. */
 bitset_container_t *bitset_container_create(void);
 

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -45,6 +45,7 @@ typedef struct bitset_container_s bitset_container_t;
 
 #define CAST_bitset(c)         CAST(bitset_container_t *, c)  // safer downcast
 #define const_CAST_bitset(c)   CAST(const bitset_container_t *, c)
+#define movable_CAST_bitset(c) movable_CAST(bitset_container_t **, c)
 
 /* Create a new bitset. Return NULL in case of failure. */
 bitset_container_t *bitset_container_create(void);

--- a/include/roaring/containers/container_defs.h
+++ b/include/roaring/containers/container_defs.h
@@ -54,6 +54,26 @@ typedef ROARING_CONTAINER_T container_t;
 #endif
 
 
+/**
+ * Since container_t* is not void* in C++, "dangerous" casts are not needed to
+ * downcast; only a static_cast<> is needed.  Define a macro for static casting
+ * which helps make casts more visible, and catches problems at compile-time
+ * when building the C sources in C++ mode:
+ * 
+ *     void some_func(container_t **c, ...) {  // double pointer, not single
+ *         array_container_t *ac1 = (array_container_t *)(c);  // uncaught!!
+ * 
+ *         array_container_t *ac2 = CAST(array_container_t *, c)  // C++ errors
+ *         array_container_t *ac3 = CAST_array(c);  // shorthand for #2, errors
+ *     }
+ */
+#ifdef __cplusplus
+    #define CAST(type,value)    static_cast<type>(value)
+#else
+    #define CAST(type,value)    ((type)value)
+#endif
+
+
 #ifdef __cplusplus
 } } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -66,6 +66,7 @@ typedef struct shared_container_s shared_container_t;
 
 #define CAST_shared(c)         CAST(shared_container_t *, c)  // safer downcast
 #define const_CAST_shared(c)   CAST(const shared_container_t *, c)
+#define movable_CAST_shared(c) movable_CAST(shared_container_t **, c)
 
 /*
  * With copy_on_write = true

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -66,6 +66,7 @@ typedef struct run_container_s run_container_t;
 
 #define CAST_run(c)         CAST(run_container_t *, c)  // safer downcast
 #define const_CAST_run(c)   CAST(const run_container_t *, c)
+#define movable_CAST_run(c) movable_CAST(run_container_t **, c)
 
 /* Create a new run container. Return NULL in case of failure. */
 run_container_t *run_container_create(void);

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -64,6 +64,9 @@ STRUCT_CONTAINER(run_container_s) {
 
 typedef struct run_container_s run_container_t;
 
+#define CAST_run(c)         CAST(run_container_t *, c)  // safer downcast
+#define const_CAST_run(c)   CAST(const run_container_t *, c)
+
 /* Create a new run container. Return NULL in case of failure. */
 run_container_t *run_container_create(void);
 

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -34,19 +34,19 @@ extern inline container_t *container_iandnot(
         const container_t *c2, uint8_t type2,
         uint8_t *result_type);
 
-void container_free(container_t *container, uint8_t typecode) {
-    switch (typecode) {
+void container_free(container_t *c, uint8_t type) {
+    switch (type) {
         case BITSET_CONTAINER_TYPE:
-            bitset_container_free((bitset_container_t *)container);
+            bitset_container_free(CAST_bitset(c));
             break;
         case ARRAY_CONTAINER_TYPE:
-            array_container_free((array_container_t *)container);
+            array_container_free(CAST_array(c));
             break;
         case RUN_CONTAINER_TYPE:
-            run_container_free((run_container_t *)container);
+            run_container_free(CAST_run(c));
             break;
         case SHARED_CONTAINER_TYPE:
-            shared_container_free((shared_container_t *)container);
+            shared_container_free(CAST_shared(c));
             break;
         default:
             assert(false);
@@ -54,17 +54,17 @@ void container_free(container_t *container, uint8_t typecode) {
     }
 }
 
-void container_printf(const container_t *container, uint8_t typecode) {
-    container = container_unwrap_shared(container, &typecode);
-    switch (typecode) {
+void container_printf(const container_t *c, uint8_t type) {
+    c = container_unwrap_shared(c, &type);
+    switch (type) {
         case BITSET_CONTAINER_TYPE:
-            bitset_container_printf((const bitset_container_t *)container);
+            bitset_container_printf(const_CAST_bitset(c));
             return;
         case ARRAY_CONTAINER_TYPE:
-            array_container_printf((const array_container_t *)container);
+            array_container_printf(const_CAST_array(c));
             return;
         case RUN_CONTAINER_TYPE:
-            run_container_printf((const run_container_t *)container);
+            run_container_printf(const_CAST_run(c));
             return;
         default:
             __builtin_unreachable();
@@ -79,15 +79,15 @@ void container_printf_as_uint32_array(
     switch (typecode) {
         case BITSET_CONTAINER_TYPE:
             bitset_container_printf_as_uint32_array(
-                (const bitset_container_t *)c, base);
+                const_CAST_bitset(c), base);
             return;
         case ARRAY_CONTAINER_TYPE:
             array_container_printf_as_uint32_array(
-                (const array_container_t *)c, base);
+                const_CAST_array(c), base);
             return;
         case RUN_CONTAINER_TYPE:
             run_container_printf_as_uint32_array(
-                (const run_container_t *)c, base);
+                const_CAST_run(c), base);
             return;
         default:
             __builtin_unreachable();
@@ -135,7 +135,7 @@ container_t *get_copy_of_container(
     if (copy_on_write) {
         shared_container_t *shared_container;
         if (*typecode == SHARED_CONTAINER_TYPE) {
-            shared_container = (shared_container_t *)c;
+            shared_container = CAST_shared(c);
             shared_container->counter += 1;
             return shared_container;
         }
@@ -168,11 +168,11 @@ container_t *container_clone(const container_t *c, uint8_t typecode) {
     c = container_unwrap_shared(c, &typecode);
     switch (typecode) {
         case BITSET_CONTAINER_TYPE:
-            return bitset_container_clone((const bitset_container_t *)c);
+            return bitset_container_clone(const_CAST_bitset(c));
         case ARRAY_CONTAINER_TYPE:
-            return array_container_clone((const array_container_t *)c);
+            return array_container_clone(const_CAST_array(c));
         case RUN_CONTAINER_TYPE:
-            return run_container_clone((const run_container_t *)c);
+            return run_container_clone(const_CAST_run(c));
         case SHARED_CONTAINER_TYPE:
             printf("shared containers are not cloneable\n");
             assert(false);

--- a/src/containers/convert.c
+++ b/src/containers/convert.c
@@ -200,14 +200,14 @@ container_t *convert_run_optimize(
 ){
     if (typecode_original == RUN_CONTAINER_TYPE) {
         container_t *newc = convert_run_to_efficient_container(
-                                    (run_container_t *)c, typecode_after);
+                                    CAST_run(c), typecode_after);
         if (newc != c) {
             container_free(c, typecode_original);
         }
         return newc;
     } else if (typecode_original == ARRAY_CONTAINER_TYPE) {
         // it might need to be converted to a run container.
-        array_container_t *c_qua_array = (array_container_t *)c;
+        array_container_t *c_qua_array = CAST_array(c);
         int32_t n_runs = array_container_number_of_runs(c_qua_array);
         int32_t size_as_run_container =
             run_container_serialized_size_in_bytes(n_runs);
@@ -243,7 +243,7 @@ container_t *convert_run_optimize(
     } else if (typecode_original ==
                BITSET_CONTAINER_TYPE) {  // run conversions on bitset
         // does bitset need conversion to run?
-        bitset_container_t *c_qua_bitset = (bitset_container_t *)c;
+        bitset_container_t *c_qua_bitset = CAST_bitset(c);
         int32_t n_runs = bitset_container_number_of_runs(c_qua_bitset);
         int32_t size_as_run_container =
             run_container_serialized_size_in_bytes(n_runs);

--- a/src/containers/mixed_intersection.c
+++ b/src/containers/mixed_intersection.c
@@ -146,7 +146,7 @@ bool run_bitset_container_intersection(
         return false;
     }
     if (*dst == src_2) {  // we attempt in-place
-        bitset_container_t *answer = (bitset_container_t *)*dst;
+        bitset_container_t *answer = CAST_bitset(*dst);
         uint32_t start = 0;
         for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
             const rle16_t rle = src_1->runs[rlepos];
@@ -190,7 +190,7 @@ bool run_bitset_container_intersection(
             return true;
         } else {
             array_container_t *newanswer = array_container_from_bitset(answer);
-            bitset_container_free((bitset_container_t *)*dst);
+            bitset_container_free(CAST_bitset(*dst));
             if (newanswer == NULL) {
                 *dst = NULL;
                 return false;
@@ -310,20 +310,17 @@ bool bitset_bitset_container_intersection(
     if (newCardinality > DEFAULT_MAX_SIZE) {
         *dst = bitset_container_create();
         if (*dst != NULL) {
-            bitset_container_and_nocard(src_1, src_2,
-                                        (bitset_container_t *)*dst);
-            ((bitset_container_t *)*dst)->cardinality = newCardinality;
+            bitset_container_and_nocard(src_1, src_2, CAST_bitset(*dst));
+            CAST_bitset(*dst)->cardinality = newCardinality;
         }
         return true;  // it is a bitset
     }
     *dst = array_container_create_given_capacity(newCardinality);
     if (*dst != NULL) {
-        ((array_container_t *)*dst)->cardinality = newCardinality;
+        CAST_array(*dst)->cardinality = newCardinality;
         bitset_extract_intersection_setbits_uint16(
-            ((const bitset_container_t *)src_1)->array,
-            ((const bitset_container_t *)src_2)->array,
-            BITSET_CONTAINER_SIZE_IN_WORDS, ((array_container_t *)*dst)->array,
-            0);
+            src_1->array, src_2->array, BITSET_CONTAINER_SIZE_IN_WORDS,
+            CAST_array(*dst)->array, 0);
     }
     return false;  // not a bitset
 }
@@ -336,17 +333,15 @@ bool bitset_bitset_container_intersection_inplace(
     if (newCardinality > DEFAULT_MAX_SIZE) {
         *dst = src_1;
         bitset_container_and_nocard(src_1, src_2, src_1);
-        ((bitset_container_t *)*dst)->cardinality = newCardinality;
+        CAST_bitset(*dst)->cardinality = newCardinality;
         return true;  // it is a bitset
     }
     *dst = array_container_create_given_capacity(newCardinality);
     if (*dst != NULL) {
-        ((array_container_t *)*dst)->cardinality = newCardinality;
+        CAST_array(*dst)->cardinality = newCardinality;
         bitset_extract_intersection_setbits_uint16(
-            ((const bitset_container_t *)src_1)->array,
-            ((const bitset_container_t *)src_2)->array,
-            BITSET_CONTAINER_SIZE_IN_WORDS, ((array_container_t *)*dst)->array,
-            0);
+            src_1->array, src_2->array, BITSET_CONTAINER_SIZE_IN_WORDS,
+            CAST_array(*dst)->array, 0);
     }
     return false;  // not a bitset
 }

--- a/src/containers/mixed_union.c
+++ b/src/containers/mixed_union.c
@@ -165,7 +165,7 @@ bool array_array_container_union(
     if (totalCardinality <= DEFAULT_MAX_SIZE) {
         *dst = array_container_create_given_capacity(totalCardinality);
         if (*dst != NULL) {
-            array_container_union(src_1, src_2, (array_container_t *)*dst);
+            array_container_union(src_1, src_2, CAST_array(*dst));
         } else {
             return true; // otherwise failure won't be caught
         }
@@ -174,7 +174,7 @@ bool array_array_container_union(
     *dst = bitset_container_create();
     bool returnval = true;  // expect a bitset
     if (*dst != NULL) {
-        bitset_container_t *ourbitset = (bitset_container_t *)*dst;
+        bitset_container_t *ourbitset = CAST_bitset(*dst);
         bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
         ourbitset->cardinality = (int32_t)bitset_set_list_withcard(
             ourbitset->array, src_1->cardinality, src_2->array,
@@ -199,7 +199,7 @@ bool array_array_container_inplace_union(
         if(src_1->capacity < totalCardinality) {
           *dst = array_container_create_given_capacity(2  * totalCardinality); // be purposefully generous
           if (*dst != NULL) {
-              array_container_union(src_1, src_2, (array_container_t *)*dst);
+              array_container_union(src_1, src_2, CAST_array(*dst));
           } else {
               return true; // otherwise failure won't be caught
           }
@@ -214,7 +214,7 @@ bool array_array_container_inplace_union(
     *dst = bitset_container_create();
     bool returnval = true;  // expect a bitset
     if (*dst != NULL) {
-        bitset_container_t *ourbitset = (bitset_container_t *)*dst;
+        bitset_container_t *ourbitset = CAST_bitset(*dst);
         bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
         ourbitset->cardinality = (int32_t)bitset_set_list_withcard(
             ourbitset->array, src_1->cardinality, src_2->array,
@@ -245,7 +245,7 @@ bool array_array_container_lazy_union(
     if (totalCardinality <= ARRAY_LAZY_LOWERBOUND) {
         *dst = array_container_create_given_capacity(totalCardinality);
         if (*dst != NULL) {
-            array_container_union(src_1, src_2, (array_container_t *)*dst);
+            array_container_union(src_1, src_2, CAST_array(*dst));
         } else {
               return true; // otherwise failure won't be caught
         }
@@ -254,7 +254,7 @@ bool array_array_container_lazy_union(
     *dst = bitset_container_create();
     bool returnval = true;  // expect a bitset
     if (*dst != NULL) {
-        bitset_container_t *ourbitset = (bitset_container_t *)*dst;
+        bitset_container_t *ourbitset = CAST_bitset(*dst);
         bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
         bitset_set_list(ourbitset->array, src_2->array, src_2->cardinality);
         ourbitset->cardinality = BITSET_UNKNOWN_CARDINALITY;
@@ -273,7 +273,7 @@ bool array_array_container_lazy_inplace_union(
         if(src_1->capacity < totalCardinality) {
           *dst = array_container_create_given_capacity(2  * totalCardinality); // be purposefully generous
           if (*dst != NULL) {
-              array_container_union(src_1, src_2, (array_container_t *)*dst);
+              array_container_union(src_1, src_2, CAST_array(*dst));
           } else {
             return true; // otherwise failure won't be caught
           }
@@ -288,7 +288,7 @@ bool array_array_container_lazy_inplace_union(
     *dst = bitset_container_create();
     bool returnval = true;  // expect a bitset
     if (*dst != NULL) {
-        bitset_container_t *ourbitset = (bitset_container_t *)*dst;
+        bitset_container_t *ourbitset = CAST_bitset(*dst);
         bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
         bitset_set_list(ourbitset->array, src_2->array, src_2->cardinality);
         ourbitset->cardinality = BITSET_UNKNOWN_CARDINALITY;

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -207,12 +207,12 @@ bool array_array_container_xor(
         src_1->cardinality + src_2->cardinality;  // upper bound
     if (totalCardinality <= DEFAULT_MAX_SIZE) {
         *dst = array_container_create_given_capacity(totalCardinality);
-        array_container_xor(src_1, src_2, (array_container_t *)*dst);
+        array_container_xor(src_1, src_2, CAST_array(*dst));
         return false;  // not a bitset
     }
     *dst = bitset_container_from_array(src_1);
     bool returnval = true;  // expect a bitset
-    bitset_container_t *ourbitset = (bitset_container_t *)*dst;
+    bitset_container_t *ourbitset = CAST_bitset(*dst);
     ourbitset->cardinality = (uint32_t)bitset_flip_list_withcard(
         ourbitset->array, src_1->cardinality, src_2->array, src_2->cardinality);
     if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {
@@ -234,13 +234,13 @@ bool array_array_container_lazy_xor(
     if (totalCardinality <= ARRAY_LAZY_LOWERBOUND) {
         *dst = array_container_create_given_capacity(totalCardinality);
         if (*dst != NULL)
-            array_container_xor(src_1, src_2, (array_container_t *)*dst);
+            array_container_xor(src_1, src_2, CAST_array(*dst));
         return false;  // not a bitset
     }
     *dst = bitset_container_from_array(src_1);
     bool returnval = true;  // expect a bitset (maybe, for XOR??)
     if (*dst != NULL) {
-        bitset_container_t *ourbitset = (bitset_container_t *)*dst;
+        bitset_container_t *ourbitset = CAST_bitset(*dst);
         bitset_flip_list(ourbitset->array, src_2->array, src_2->cardinality);
         ourbitset->cardinality = BITSET_UNKNOWN_CARDINALITY;
     }

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -465,13 +465,13 @@ bool ra_range_uint32_array(const roaring_array_t *ra, size_t offset, size_t limi
                                         ra->containers[i], &ra->typecodes[i]);
         switch (ra->typecodes[i]) {
             case BITSET_CONTAINER_TYPE:
-                t_limit = ((const bitset_container_t *)c)->cardinality;
+                t_limit = (const_CAST_bitset(c))->cardinality;
                 break;
             case ARRAY_CONTAINER_TYPE:
-                t_limit = ((const array_container_t *)c)->cardinality;
+                t_limit = (const_CAST_array(c))->cardinality;
                 break;
             case RUN_CONTAINER_TYPE:
-                t_limit = run_container_cardinality((const run_container_t *)c);
+                t_limit = run_container_cardinality(const_CAST_run(c));
                 break;
         }
         if (ctr + t_limit - 1 >= offset && ctr < offset + limit){
@@ -502,19 +502,19 @@ bool ra_range_uint32_array(const roaring_array_t *ra, size_t offset, size_t limi
                 case BITSET_CONTAINER_TYPE:
                     container_to_uint32_array(
                         t_ans + dtr,
-                        (const bitset_container_t *)c,  ra->typecodes[i],
+                        const_CAST_bitset(c),  ra->typecodes[i],
                         ((uint32_t)ra->keys[i]) << 16);
                     break;
                 case ARRAY_CONTAINER_TYPE:
                     container_to_uint32_array(
                         t_ans + dtr,
-                        (const array_container_t *)c, ra->typecodes[i],
+                        const_CAST_array(c), ra->typecodes[i],
                         ((uint32_t)ra->keys[i]) << 16);
                     break;
                 case RUN_CONTAINER_TYPE:
                     container_to_uint32_array(
                         t_ans + dtr,
-                        (const run_container_t *)c, ra->typecodes[i],
+                        const_CAST_run(c), ra->typecodes[i],
                         ((uint32_t)ra->keys[i]) << 16);
                     break;
             }


### PR DESCRIPTION
C's sole cast operator will cast nearly anything to anything else, which
can be dangerous...and the container subclasses in roaring make heavy
use of downcasting from container types.  This is risky, and can cause
problems the compiler won't catch e.g. when the wrong level of indirection
is used:

    void some_func(container_t **c, ...) {  // double pointer, not single
        array_container_t *ac1 = (array_container_t *)(c);  // uncaught!!
    }

When compiling as C there's nothing that can be done about that.  However,
with `container_t` being an empty-base-class-optimization base of all the
container structs, the C++ build can do better by using static_cast<>.

    void some_func(container_t **c, ...) {  // double pointer, not single
        array_container_t *ac2 = static_cast<array_container_t *>(c);
             // ^-- compiler errors due to wrong level of indirection

        array_container_t *ac3 = static_cast<array_container_t *>(*c);
             // ^-- not an error due to legal downcasting pattern
    }

To take advantage of this while still building as C, a CAST() macro is
defined in the internal headers.  When building as C++ it will act as a
static cast, but uses old-style C casts in C mode.

As a further improvement in rolling this feature out to callsites, shortcut
macros for casting to container subclasses are provided:

     array_container_t *ac4 = CAST_array(c);
     const array_container_t *ac4 = const_CAST_array(c);

Having an uppercase portion to the name helps hint at the "not-a-function"
nature of the macro, while keeping the other parts lowercase help smooth
the visual impact at the callsites.  In addition to providing added
compile-time checking, the resulting code is shorter and cleaner.