### PR TITLE
Make C Tests Compilable in C++ Mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(ROARING_BUILD_STATIC "Build a static library" OFF) # turning it on disabl
 option(ROARING_LINK_STATIC "Link executables (tests, benchmarks) statically" OFF)
 option(ROARING_BUILD_LTO "Build library with Link Time Optimization" OFF)
 option(ROARING_BUILD_C_AS_CPP "Build library C files using C++ compilation" OFF)
+option(ROARING_BUILD_C_TESTS_AS_CPP "Build test C files using C++ compilation" OFF)
 option(ROARING_SANITIZE "Sanitize addresses" OFF)
 option(ENABLE_ROARING_TESTS "If OFF, disable unit tests altogether" ON)
 

--- a/tests/array_container_unit.c
+++ b/tests/array_container_unit.c
@@ -10,9 +10,14 @@
 #include <roaring/containers/array.h>
 #include <roaring/misc/configreport.h>
 
+#ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
+    using namespace roaring::internal;
+#endif
+
 #include "test.h"
 
-void printf_test() {
+
+DEFINE_TEST(printf_test) {
     array_container_t* B = array_container_create();
     assert_non_null(B);
 
@@ -28,7 +33,7 @@ void printf_test() {
     array_container_free(B);
 }
 
-void add_contains_test() {
+DEFINE_TEST(add_contains_test) {
     array_container_t* B = array_container_create();
     assert_non_null(B);
 
@@ -79,7 +84,7 @@ void add_contains_test() {
     array_container_free(B);
 }
 
-void and_or_test() {
+DEFINE_TEST(and_or_test) {
     DESCRIBE_TEST;
 
     array_container_t* B1 = array_container_create();
@@ -127,7 +132,7 @@ void and_or_test() {
     array_container_free(TMP);
 }
 
-void to_uint32_array_test() {
+DEFINE_TEST(to_uint32_array_test) {
     for (size_t offset = 1; offset < 128; offset *= 2) {
         array_container_t* B = array_container_create();
         assert_non_null(B);
@@ -137,7 +142,7 @@ void to_uint32_array_test() {
         }
 
         int card = array_container_cardinality(B);
-        uint32_t* out = malloc(sizeof(uint32_t) * card);
+        uint32_t* out = (uint32_t*)malloc(sizeof(uint32_t) * card);
         assert_non_null(out);
         int nc = array_container_to_uint32_array(out, B, 0);
 
@@ -152,7 +157,7 @@ void to_uint32_array_test() {
     }
 }
 
-void select_test() {
+DEFINE_TEST(select_test) {
     array_container_t* B = array_container_create();
     assert_non_null(B);
     uint16_t base = 27;
@@ -174,7 +179,7 @@ void select_test() {
     array_container_free(B);
 }
 
-void capacity_test() {
+DEFINE_TEST(capacity_test) {
     array_container_t* array = array_container_create();
     for (uint32_t i = 0; i < DEFAULT_MAX_SIZE; i++) {
         array_container_add(array, (uint16_t)i);

--- a/tests/bitset_container_unit.c
+++ b/tests/bitset_container_unit.c
@@ -11,9 +11,15 @@
 #include <roaring/containers/bitset.h>
 #include <roaring/misc/configreport.h>
 #include <roaring/bitset_util.h>
+
+#ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
+    using namespace roaring::internal;
+#endif
+
 #include "test.h"
 
-void test_bitset_lenrange_cardinality() {
+
+DEFINE_TEST(test_bitset_lenrange_cardinality) {
   uint64_t words[] = {~UINT64_C(0), ~UINT64_C(0), ~UINT64_C(0), ~UINT64_C(0), 0, 0, 0, 0};
   for(int k = 0; k < 64 * 4; k++) {
     assert(bitset_lenrange_cardinality(words, 0, k) == k + 1); // ok
@@ -23,7 +29,7 @@ void test_bitset_lenrange_cardinality() {
   }
 }
 
-void test_bitset_compute_cardinality() {
+DEFINE_TEST(test_bitset_compute_cardinality) {
     // check that overflow doesn't happen
     bitset_container_t *b = bitset_container_create();
     bitset_container_add_from_range(b, 0, 0x10000, 1);
@@ -31,7 +37,7 @@ void test_bitset_compute_cardinality() {
     bitset_container_free(b);
 }
 
-void printf_test() {
+DEFINE_TEST(printf_test) {
     bitset_container_t* B = bitset_container_create();
     assert_non_null(B);
 
@@ -47,7 +53,7 @@ void printf_test() {
     bitset_container_free(B);
 }
 
-void set_get_test() {
+DEFINE_TEST(set_get_test) {
     bitset_container_t* B = bitset_container_create();
     assert_non_null(B);
 
@@ -83,7 +89,7 @@ void set_get_test() {
     bitset_container_free(B);
 }
 
-void and_or_test() {
+DEFINE_TEST(and_or_test) {
     bitset_container_t* B1 = bitset_container_create();
     bitset_container_t* B2 = bitset_container_create();
     bitset_container_t* BI = bitset_container_create();
@@ -126,7 +132,7 @@ void and_or_test() {
     bitset_container_free(BO);
 }
 
-void xor_test() {
+DEFINE_TEST(xor_test) {
     bitset_container_t* B1 = bitset_container_create();
     bitset_container_t* B2 = bitset_container_create();
     bitset_container_t* BI = bitset_container_create();
@@ -161,7 +167,7 @@ void xor_test() {
     bitset_container_free(TMP);
 }
 
-void andnot_test() {
+DEFINE_TEST(andnot_test) {
     bitset_container_t* B1 = bitset_container_create();
     bitset_container_t* B2 = bitset_container_create();
     bitset_container_t* BI = bitset_container_create();
@@ -199,7 +205,7 @@ void andnot_test() {
     bitset_container_free(TMP);
 }
 
-void to_uint32_array_test() {
+DEFINE_TEST(to_uint32_array_test) {
     for (size_t offset = 1; offset < 128; offset *= 2) {
         bitset_container_t* B = bitset_container_create();
         assert_non_null(B);
@@ -210,7 +216,7 @@ void to_uint32_array_test() {
 
         int card = bitset_container_cardinality(B);
 
-        uint32_t* out = malloc(sizeof(uint32_t) * card);
+        uint32_t* out = (uint32_t*)malloc(sizeof(uint32_t) * card);
         assert_non_null(out);
 
         int nc = bitset_container_to_uint32_array(out, B, 0);
@@ -226,7 +232,7 @@ void to_uint32_array_test() {
     }
 }
 
-void select_test() {
+DEFINE_TEST(select_test) {
     bitset_container_t* B = bitset_container_create();
     assert_non_null(B);
     uint16_t base = 27;

--- a/tests/c_example1.c
+++ b/tests/c_example1.c
@@ -82,7 +82,7 @@ int main() {
 
     // we can write a bitmap to a pointer and recover it later
     uint32_t expectedsize = roaring_bitmap_portable_size_in_bytes(r1);
-    char *serializedbytes = malloc(expectedsize);
+    char *serializedbytes = (char*)malloc(expectedsize);
     roaring_bitmap_portable_serialize(r1, serializedbytes);
     roaring_bitmap_t *t = roaring_bitmap_portable_deserialize(serializedbytes);
     assert(roaring_bitmap_equals(r1, t));  // what we recover is equal

--- a/tests/container_comparison_unit.c
+++ b/tests/container_comparison_unit.c
@@ -14,27 +14,32 @@
 #include <roaring/containers/mixed_subset.h>
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
+    using namespace roaring::internal;
+#endif
+
 #include "test.h"
 
-static inline void container_checked_add(void *container, uint16_t val,
+
+static inline void container_checked_add(container_t *container, uint16_t val,
                                          uint8_t typecode) {
     uint8_t new_type;
-    void *new_container = container_add(container, val, typecode, &new_type);
+    container_t *new_container = container_add(container, val, typecode, &new_type);
     assert_int_equal(typecode, new_type);
     assert_true(container == new_container);
 }
 
-static inline void delegated_add(void *container, uint8_t typecode,
+static inline void delegated_add(container_t *container, uint8_t typecode,
                                  uint16_t val) {
     switch(typecode) {
         case BITSET_CONTAINER_TYPE:
-            bitset_container_add((bitset_container_t*)container, val);
+            bitset_container_add(CAST_bitset(container), val);
             break;
         case ARRAY_CONTAINER_TYPE:
-            array_container_add((array_container_t*)container, val);
+            array_container_add(CAST_array(container), val);
             break;
         case RUN_CONTAINER_TYPE:
-            run_container_add((run_container_t*)container, val);
+            run_container_add(CAST_run(container), val);
             break;
         default:
             assert(false);
@@ -42,8 +47,8 @@ static inline void delegated_add(void *container, uint8_t typecode,
     }
 }
 
-static inline void *container_create(uint8_t typecode) {
-    void *result = NULL;
+static inline container_t *container_create(uint8_t typecode) {
+    container_t *result = NULL;
     switch (typecode) {
         case BITSET_CONTAINER_TYPE:
             result = bitset_container_create();
@@ -63,8 +68,8 @@ static inline void *container_create(uint8_t typecode) {
 }
 
 void generic_equal_test(uint8_t type1, uint8_t type2) {
-    void *container1 = container_create(type1);
-    void *container2 = container_create(type2);
+    container_t *container1 = container_create(type1);
+    container_t *container2 = container_create(type2);
     assert_true(container_equals(container1, type1, container2, type2));
     for (int i = 0; i < 100; i++) {
         container_checked_add(container1, i * 10, type1);
@@ -116,45 +121,45 @@ void generic_equal_test(uint8_t type1, uint8_t type2) {
     container_free(container2, type2);
 }
 
-void equal_array_array_test() {
+DEFINE_TEST(equal_array_array_test) {
     generic_equal_test(ARRAY_CONTAINER_TYPE, ARRAY_CONTAINER_TYPE);
 }
 
-void equal_bitset_bitset_test() {
+DEFINE_TEST(equal_bitset_bitset_test) {
     generic_equal_test(BITSET_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 
-void equal_run_run_test() {
+DEFINE_TEST(equal_run_run_test) {
     generic_equal_test(RUN_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
-void equal_array_bitset_test() {
+DEFINE_TEST(equal_array_bitset_test) {
     generic_equal_test(ARRAY_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 
-void equal_bitset_array_test() {
+DEFINE_TEST(equal_bitset_array_test) {
     generic_equal_test(BITSET_CONTAINER_TYPE, ARRAY_CONTAINER_TYPE);
 }
 
-void equal_array_run_test() {
+DEFINE_TEST(equal_array_run_test) {
     generic_equal_test(ARRAY_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
-void equal_run_array_test() {
+DEFINE_TEST(equal_run_array_test) {
     generic_equal_test(RUN_CONTAINER_TYPE, ARRAY_CONTAINER_TYPE);
 }
 
-void equal_bitset_run_test() {
+DEFINE_TEST(equal_bitset_run_test) {
     generic_equal_test(BITSET_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
-void equal_run_bitset_test() {
+DEFINE_TEST(equal_run_bitset_test) {
     generic_equal_test(RUN_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 
 void generic_subset_test(uint8_t type1, uint8_t type2) {
-    void *container1 = container_create(type1);
-    void *container2 = container_create(type2);
+    container_t *container1 = container_create(type1);
+    container_t *container2 = container_create(type2);
     assert_true(container_is_subset(container1, type1, container2, type2));
     for (int i = 0; i < 100; i++) {
         container_checked_add(container1, i * 11, type1);
@@ -176,35 +181,35 @@ void generic_subset_test(uint8_t type1, uint8_t type2) {
     container_free(container2, type2);
 }
 
-void subset_array_array_test() {
+DEFINE_TEST(subset_array_array_test) {
     generic_subset_test(ARRAY_CONTAINER_TYPE, ARRAY_CONTAINER_TYPE);
 }
 
-void subset_bitset_bitset_test() {
+DEFINE_TEST(subset_bitset_bitset_test) {
     generic_subset_test(BITSET_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 
-void subset_run_run_test() {
+DEFINE_TEST(subset_run_run_test) {
     generic_subset_test(RUN_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
-void subset_array_bitset_test() {
+DEFINE_TEST(subset_array_bitset_test) {
     generic_subset_test(ARRAY_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 
-void subset_array_run_test() {
+DEFINE_TEST(subset_array_run_test) {
     generic_subset_test(ARRAY_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
-void subset_run_array_test() {
+DEFINE_TEST(subset_run_array_test) {
     generic_subset_test(RUN_CONTAINER_TYPE, ARRAY_CONTAINER_TYPE);
 }
 
-void subset_bitset_run_test() {
+DEFINE_TEST(subset_bitset_run_test) {
     generic_subset_test(BITSET_CONTAINER_TYPE, RUN_CONTAINER_TYPE);
 }
 
-void subset_run_bitset_test() {
+DEFINE_TEST(subset_run_bitset_test) {
     generic_subset_test(RUN_CONTAINER_TYPE, BITSET_CONTAINER_TYPE);
 }
 

--- a/tests/cpp_random_unit.cpp
+++ b/tests/cpp_random_unit.cpp
@@ -32,9 +32,7 @@
 #include "roaring_checked.hh"
 using doublechecked::Roaring;  // so `Roaring` means `doublecheck::Roaring` 
 
-extern "C" {
 #include "test.h"
-}
 
 
 // The tests can run as long as one wants.  Ideally, the sanitizer options
@@ -95,7 +93,7 @@ Roaring make_random_bitset() {
 }
 
 
-void sanity_check_doublechecking(void **) {
+DEFINE_TEST(sanity_check_doublechecking) {
     Roaring r;
     while (r.isEmpty())
         r = make_random_bitset();
@@ -118,7 +116,7 @@ void sanity_check_doublechecking(void **) {
 }
 
 
-void random_doublecheck_test(void **) {
+DEFINE_TEST(random_doublecheck_test) {
     //
     // Make a group of bitsets to choose from when performing operations.
     //

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -10,10 +10,6 @@
 #include <time.h>
 #include <iostream>
 
-extern "C" {
-#include "test.h"
-}
-
 #include <roaring/roaring.h>  // access to pure C exported API for testing
 
 #include "roaring.hh"
@@ -21,6 +17,8 @@ using roaring::Roaring;  // the C++ wrapper class
 
 #include "roaring64map.hh"
 using roaring::Roaring64Map;  // C++ class extended for 64-bit numbers
+
+#include "test.h"
 
 
 static_assert(std::is_nothrow_move_constructible<Roaring>::value,
@@ -37,7 +35,7 @@ bool roaring_iterator_sumall64(uint64_t value, void *param) {
 }
 
 
-void serial_test(void **) {
+DEFINE_TEST(serial_test) {
   uint32_t values[] = {5, 2, 3, 4, 1};
   Roaring r1(sizeof(values)/sizeof(uint32_t), values);
   uint32_t serializesize = r1.getSizeInBytes();
@@ -480,27 +478,27 @@ void test_example_cpp_64(bool copy_on_write) {
     }
 }
 
-void test_example_true(void **) { test_example(true); }
+DEFINE_TEST(test_example_true) { test_example(true); }
 
-void test_example_false(void **) { test_example(false); }
+DEFINE_TEST(test_example_false) { test_example(false); }
 
-void test_example_cpp_true(void **) { test_example_cpp(true); }
+DEFINE_TEST(test_example_cpp_true) { test_example_cpp(true); }
 
-void test_example_cpp_false(void **) { test_example_cpp(false); }
+DEFINE_TEST(test_example_cpp_false) { test_example_cpp(false); }
 
-void test_example_cpp_64_true(void **) { test_example_cpp_64(true); }
+DEFINE_TEST(test_example_cpp_64_true) { test_example_cpp_64(true); }
 
-void test_example_cpp_64_false(void **) { test_example_cpp_64(false); }
+DEFINE_TEST(test_example_cpp_64_false) { test_example_cpp_64(false); }
 
-void test_run_compression_cpp_64_true(void **) { test_run_compression_cpp_64(true); }
+DEFINE_TEST(test_run_compression_cpp_64_true) { test_run_compression_cpp_64(true); }
 
-void test_run_compression_cpp_64_false(void **) { test_run_compression_cpp_64(false); }
+DEFINE_TEST(test_run_compression_cpp_64_false) { test_run_compression_cpp_64(false); }
 
-void test_run_compression_cpp_true(void **) { test_run_compression_cpp(true); }
+DEFINE_TEST(test_run_compression_cpp_true) { test_run_compression_cpp(true); }
 
-void test_run_compression_cpp_false(void **) { test_run_compression_cpp(false); }
+DEFINE_TEST(test_run_compression_cpp_false) { test_run_compression_cpp(false); }
 
-void test_cpp_add_remove_checked(void **) {
+DEFINE_TEST(test_cpp_add_remove_checked) {
     Roaring roaring;
     uint32_t values[4] = { 123, 9999, 0xFFFFFFF7, 0xFFFFFFFF};
     for (int i = 0; i < 4; ++i) {
@@ -514,7 +512,7 @@ void test_cpp_add_remove_checked(void **) {
     assert_true(roaring.isEmpty());
 }
 
-void test_cpp_add_remove_checked_64(void **) {
+DEFINE_TEST(test_cpp_add_remove_checked_64) {
     Roaring64Map roaring;
 
     uint32_t values32[4] = { 123, 9999, 0xFFFFFFF7, 0xFFFFFFFF};
@@ -539,7 +537,7 @@ void test_cpp_add_remove_checked_64(void **) {
     assert_true(roaring.isEmpty());
 }
 
-void test_cpp_clear_64(void **) {
+DEFINE_TEST(test_cpp_clear_64) {
     Roaring64Map roaring;
 
     uint64_t values64[4] = { 123ULL, 0xA00000000AULL, 0xAFFFFFFF7ULL, 0xFFFFFFFFFULL};
@@ -552,7 +550,7 @@ void test_cpp_clear_64(void **) {
     assert_true(roaring.isEmpty());
 }
 
-void test_cpp_move_64(void **) {
+DEFINE_TEST(test_cpp_move_64) {
     Roaring64Map roaring;
 
     uint64_t values64[4] = { 123ULL, 0xA00000000AULL, 0xAFFFFFFF7ULL, 0xFFFFFFFFFULL};
@@ -568,7 +566,7 @@ void test_cpp_move_64(void **) {
 	assert_false(i.move(0xFFFFFFFFFFULL));
 }
 
-void test_cpp_bidirectional_iterator_64(void **) {
+DEFINE_TEST(test_cpp_bidirectional_iterator_64) {
     Roaring64Map roaring;
 
     uint64_t values64[4] = { 123ULL, 0xA00000000AULL, 0xAFFFFFFF7ULL, 0xFFFFFFFFFULL};

--- a/tests/format_portability_unit.c
+++ b/tests/format_portability_unit.c
@@ -11,7 +11,9 @@
 #include <roaring/roaring.h>
 
 #include "config.h"
+
 #include "test.h"
+
 
 long filesize(char const* path) {
     FILE* fp = fopen(path, "rb");
@@ -29,7 +31,7 @@ char* readfile(char const* path) {
     assert_int_not_equal(fseek(fp, 0L, SEEK_END), -1);
 
     long bytes = ftell(fp);
-    char* buf = malloc(bytes);
+    char* buf = (char*)malloc(bytes);
     assert_non_null(buf);
 
     rewind(fp);
@@ -60,7 +62,7 @@ void test_deserialize(char* filename) {
 
     assert_int_equal(expected_size, filesize(filename));
 
-    char* output_buffer = malloc(expected_size);
+    char* output_buffer = (char*)malloc(expected_size);
     size_t actual_size =
         roaring_bitmap_portable_serialize(bitmap, output_buffer);
 
@@ -72,7 +74,7 @@ void test_deserialize(char* filename) {
     roaring_bitmap_free(bitmap);
 }
 
-void test_deserialize_portable_norun() {
+DEFINE_TEST(test_deserialize_portable_norun) {
     char filename[1024];
 
     strcpy(filename, TEST_DATA_DIR);
@@ -81,7 +83,7 @@ void test_deserialize_portable_norun() {
     test_deserialize(filename);
 }
 
-void test_deserialize_portable_wrun() {
+DEFINE_TEST(test_deserialize_portable_wrun) {
     char filename[1024];
 
     strcpy(filename, TEST_DATA_DIR);

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -15,11 +15,16 @@
 #include <roaring/containers/mixed_union.h>
 #include <roaring/containers/mixed_xor.h>
 
+#ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
+    using namespace roaring::internal;
+#endif
+
 #include "test.h"
+
 
 //#define UNVERBOSE_MIXED_CONTAINER
 
-void array_bitset_and_or_xor_andnot_test() {
+DEFINE_TEST(array_bitset_and_or_xor_andnot_test) {
     array_container_t* A1 = array_container_create();
     array_container_t* A2 = array_container_create();
     array_container_t* AI = array_container_create();
@@ -115,46 +120,46 @@ void array_bitset_and_or_xor_andnot_test() {
     array_bitset_container_union(A2, B1, BO);
     assert_int_equal(co, bitset_container_cardinality(BO));
 
-    void* BX_1 = NULL;
+    container_t* C = NULL;
 
-    assert_true(array_bitset_container_xor(A1, B2, &BX_1));
-    assert_int_equal(cx, bitset_container_cardinality(BX_1));
+    assert_true(array_bitset_container_xor(A1, B2, &C));
+    assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
 
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
-    assert_true(array_bitset_container_xor(A2, B1, &BX_1));
-    assert_int_equal(cx, bitset_container_cardinality(BX_1));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
+    assert_true(array_bitset_container_xor(A2, B1, &C));
+    assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
 
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
-    assert_true(array_array_container_xor(A2, A1, &BX_1));
-    assert_int_equal(cx, bitset_container_cardinality(BX_1));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
+    assert_true(array_array_container_xor(A2, A1, &C));
+    assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
 
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
-    assert_true(bitset_bitset_container_xor(B2, B1, &BX_1));
-    assert_int_equal(cx, bitset_container_cardinality(BX_1));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
+    assert_true(bitset_bitset_container_xor(B2, B1, &C));
+    assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
 
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
     // xoring something with itself, getting array
-    assert_false(array_bitset_container_xor(A2, B2, &BX_1));
-    assert_int_equal(0, array_container_cardinality(BX_1));
+    assert_false(array_bitset_container_xor(A2, B2, &C));
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
 
-    array_container_free(BX_1);
-    BX_1 = NULL;
+    array_container_free(CAST_array(C));
+    C = NULL;
     // xoring array with itself, getting array
-    assert_false(array_array_container_xor(A2, A2, &BX_1));
-    assert_int_equal(0, array_container_cardinality(BX_1));
+    assert_false(array_array_container_xor(A2, A2, &C));
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
 
-    array_container_free(BX_1);
-    BX_1 = NULL;
+    array_container_free(CAST_array(C));
+    C = NULL;
     // xoring bitset with itself, getting array
-    assert_false(bitset_bitset_container_xor(B2, B2, &BX_1));
-    assert_int_equal(0, array_container_cardinality(BX_1));
+    assert_false(bitset_bitset_container_xor(B2, B2, &C));
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
 
-    array_container_free(BX_1);
-    BX_1 = NULL;
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     array_bitset_container_andnot(A1, B2, AM);
     assert_int_equal(cm, array_container_cardinality(AM));
@@ -168,48 +173,48 @@ void array_bitset_and_or_xor_andnot_test() {
     array_array_container_andnot(A1, A2, AM);
     assert_int_equal(cm, array_container_cardinality(AM));
 
-    void* some_container = NULL;  // sometimes bitmap, sometimes array.
+    // C will be sometimes bitmap, sometimes array
 
-    assert_true(bitset_bitset_container_andnot(B1, B2, &some_container));
-    assert_int_equal(cm, bitset_container_cardinality(some_container));
-    bitset_container_free(some_container);
-    some_container = NULL;
+    assert_true(bitset_bitset_container_andnot(B1, B2, &C));
+    assert_int_equal(cm, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
-    assert_true(bitset_array_container_andnot(B1, A2, &some_container));
-    assert_int_equal(cm, bitset_container_cardinality(some_container));
-    bitset_container_free(some_container);
-    some_container = NULL;
-
-    // Hopefully density means it will be an array
-    assert_false(bitset_bitset_container_andnot(B2, B1, &some_container));
-    assert_int_equal(cm1, array_container_cardinality(some_container));
-    array_container_free(some_container);
-    some_container = NULL;
+    assert_true(bitset_array_container_andnot(B1, A2, &C));
+    assert_int_equal(cm, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     // Hopefully density means it will be an array
-    assert_false(bitset_array_container_andnot(B2, A1, &some_container));
-    assert_int_equal(cm1, array_container_cardinality(some_container));
-    array_container_free(some_container);
-    some_container = NULL;
+    assert_false(bitset_bitset_container_andnot(B2, B1, &C));
+    assert_int_equal(cm1, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
+
+    // Hopefully density means it will be an array
+    assert_false(bitset_array_container_andnot(B2, A1, &C));
+    assert_int_equal(cm1, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     // subtracting something with itself, getting array
     array_bitset_container_andnot(A2, B2, AM1);
     assert_int_equal(0, array_container_cardinality(AM1));
 
     // subtracting something with itself, getting array
-    bitset_array_container_andnot(B2, A2, &some_container);
-    assert_int_equal(0, array_container_cardinality(some_container));
-    array_container_free(some_container);
-    some_container = NULL;
+    bitset_array_container_andnot(B2, A2, &C);
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     // subtracting array with itself, getting array
     array_array_container_andnot(A2, A2, AM1);
     assert_int_equal(0, array_container_cardinality(AM1));
 
     // subtracting bitset with itself, getting array
-    assert_false(bitset_bitset_container_andnot(B2, B2, &some_container));
-    assert_int_equal(0, array_container_cardinality(some_container));
-    array_container_free(some_container);
+    assert_false(bitset_bitset_container_andnot(B2, B2, &C));
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
 
     array_container_free(A1);
     array_container_free(A2);
@@ -226,11 +231,11 @@ void array_bitset_and_or_xor_andnot_test() {
     bitset_container_free(BX);
     bitset_container_free(BM);
     bitset_container_free(BM1);
-    // bitset_container_free(BX_1);
+    // bitset_container_free(CAST_bitset(C));
 }
 
 // all xor routines with lazy option
-void array_bitset_run_lazy_xor_test() {
+DEFINE_TEST(array_bitset_run_lazy_xor_test) {
     // not all these containers are currently used in tests
     array_container_t* A1 = array_container_create();
     array_container_t* A2 = array_container_create();
@@ -291,12 +296,12 @@ void array_bitset_run_lazy_xor_test() {
     assert_int_equal(cx, bitset_container_compute_cardinality(B2));
     bitset_container_copy(B2copy, B2);
 
-    void* ans = 0;
+    container_t *ans = 0;
     assert_true(array_array_container_lazy_xor(A1, A2, &ans));
     assert_int_equal(BITSET_UNKNOWN_CARDINALITY,
-                     bitset_container_cardinality(ans));
-    assert_int_equal(cx, bitset_container_compute_cardinality(ans));
-    bitset_container_free(ans);
+                     bitset_container_cardinality(CAST_bitset(ans)));
+    assert_int_equal(cx, bitset_container_compute_cardinality(CAST_bitset(ans)));
+    bitset_container_free(CAST_bitset(ans));
 
     array_run_container_lazy_xor(A1, R2, RX);  // destroys content of RX
     assert_int_equal(cx, run_container_cardinality(RX));
@@ -315,7 +320,7 @@ void array_bitset_run_lazy_xor_test() {
     run_container_free(RX);
 }
 
-void array_bitset_ixor_test() {
+DEFINE_TEST(array_bitset_ixor_test) {
     array_container_t* A1 = array_container_create();
     array_container_t* A1copy = array_container_create();
     array_container_t* A1mod = array_container_create();
@@ -354,37 +359,37 @@ void array_bitset_ixor_test() {
 
     int cx = array_container_cardinality(AX);  // expected xor
 
-    void* BX_1 = NULL;
+    container_t* C = NULL;
 
-    assert_true(bitset_array_container_ixor(B2, A1, &BX_1));
-    assert_int_equal(cx, bitset_container_cardinality(BX_1));
+    assert_true(bitset_array_container_ixor(B2, A1, &C));
+    assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
     // this case, result is inplace
-    assert_ptr_equal(BX_1, B2);
+    assert_ptr_equal(C, B2);
 
-    BX_1 = NULL;
-    assert_true(array_bitset_container_ixor(A2, B1, &BX_1));
-    assert_int_equal(cx, bitset_container_cardinality(BX_1));
-    assert_ptr_not_equal(BX_1, A2);  // nb A2 is destroyed
+    C = NULL;
+    assert_true(array_bitset_container_ixor(A2, B1, &C));
+    assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
+    assert_ptr_not_equal(C, A2);  // nb A2 is destroyed
     // don't test a case where result can fit in the array
     // until this is implemented...at that point, make sure
 
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
     // xoring something with itself, getting array
-    assert_false(array_bitset_container_ixor(A1, B1, &BX_1));
-    assert_int_equal(0, array_container_cardinality(BX_1));
+    assert_false(array_bitset_container_ixor(A1, B1, &C));
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
 
-    array_container_free(BX_1);
-    BX_1 = NULL;
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     // B1mod and B1copy differ in position 2 only
-    assert_false(bitset_bitset_container_ixor(B1mod, B1copy, &BX_1));
-    assert_int_equal(1, array_container_cardinality(BX_1));
+    assert_false(bitset_bitset_container_ixor(B1mod, B1copy, &C));
+    assert_int_equal(1, array_container_cardinality(CAST_array(C)));
 
-    array_container_free(BX_1);
-    BX_1 = NULL;
-    assert_false(array_array_container_ixor(A1mod, A1copy, &BX_1));
-    assert_int_equal(1, array_container_cardinality(BX_1));
+    array_container_free(CAST_array(C));
+    C = NULL;
+    assert_false(array_array_container_ixor(A1mod, A1copy, &C));
+    assert_int_equal(1, array_container_cardinality(CAST_array(C)));
 
     // array_container_free(A1); // disposed already
     //    array_container_free(A2); // has been disposed already
@@ -395,10 +400,10 @@ void array_bitset_ixor_test() {
     bitset_container_free(B1copy);
     bitset_container_free(B2);
     bitset_container_free(BX);
-    array_container_free(BX_1);
+    array_container_free(CAST_array(C));
 }
 
-void array_bitset_iandnot_test() {
+DEFINE_TEST(array_bitset_iandnot_test) {
     array_container_t* A1 = array_container_create();
     array_container_t* AM = array_container_create();
     array_container_t* AM1 = array_container_create();
@@ -449,20 +454,20 @@ void array_bitset_iandnot_test() {
     int cm = array_container_cardinality(AM);    // expected difference
     int cm1 = array_container_cardinality(AM1);  // expected reverse difference
 
-    void* some_container = NULL;
+    container_t *C = NULL;
 
-    assert_false(bitset_array_container_iandnot(B2, A1, &some_container));
-    assert_int_equal(cm1, array_container_cardinality(some_container));
+    assert_false(bitset_array_container_iandnot(B2, A1, &C));
+    assert_int_equal(cm1, array_container_cardinality(CAST_array(C)));
     // this case, result is not inplace
-    assert_ptr_not_equal(some_container, B2);
+    assert_ptr_not_equal(C, B2);
     B2 = bitset_container_create();  // since B2 had been destroyed.
-    array_container_free(some_container);
+    array_container_free(CAST_array(C));
     bitset_container_copy(B2copy, B2);
 
-    assert_true(bitset_array_container_iandnot(B1, A2, &some_container));
-    assert_int_equal(cm, bitset_container_cardinality(some_container));
+    assert_true(bitset_array_container_iandnot(B1, A2, &C));
+    assert_int_equal(cm, bitset_container_cardinality(CAST_bitset(C)));
     // this case, result is inplace
-    assert_ptr_equal(some_container, B1);
+    assert_ptr_equal(C, B1);
     bitset_container_copy(B1copy, B1);
 
     array_bitset_container_iandnot(A2, B1);
@@ -475,11 +480,10 @@ void array_bitset_iandnot_test() {
     array_container_copy(A1copy, A1);
 
     // B1mod and B1copy differ in position 2 only (B1mod has it)
-    assert_false(
-        bitset_bitset_container_iandnot(B1mod, B1copy, &some_container));
-    assert_int_equal(1, array_container_cardinality(some_container));
-    array_container_free(some_container);
-    some_container = NULL;
+    assert_false(bitset_bitset_container_iandnot(B1mod, B1copy, &C));
+    assert_int_equal(1, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     array_array_container_iandnot(A1mod, A1copy);
     assert_int_equal(1, array_container_cardinality(A1mod));
@@ -502,7 +506,7 @@ void array_bitset_iandnot_test() {
 }
 
 // routines where one of the containers is a run container
-void run_xor_test() {
+DEFINE_TEST(run_xor_test) {
     array_container_t* A1 = array_container_create();
     array_container_t* A2 = array_container_create();
     array_container_t* A3 = array_container_create();
@@ -563,89 +567,89 @@ void run_xor_test() {
 
     int cx12 = array_container_cardinality(AX);  // expected xor for ?1 and ?2
 
-    void* BX_1 = NULL;
+    container_t* C = NULL;
 
-    assert_false(run_bitset_container_xor(R1, B1, &BX_1));
-    assert_int_equal(0, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+    assert_false(run_bitset_container_xor(R1, B1, &C));
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     array_run_container_xor(A1, R1, &BX_1));
-    assert_int_equal(0, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+                     array_run_container_xor(A1, R1, &C));
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     // both run coding and array coding have same serialized size for
     // empty
     assert_int_equal(RUN_CONTAINER_TYPE,
-                     run_run_container_xor(R1, R1, &BX_1));
-    assert_int_equal(0, run_container_cardinality(BX_1));
-    run_container_free(BX_1);
-    BX_1 = NULL;
+                     run_run_container_xor(R1, R1, &C));
+    assert_int_equal(0, run_container_cardinality(CAST_run(C)));
+    run_container_free(CAST_run(C));
+    C = NULL;
 
-    assert_false(run_bitset_container_xor(R1, B3, &BX_1));
-    assert_int_equal(2000, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
-
-    assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     array_run_container_xor(A3, R1, &BX_1));
-    assert_int_equal(2000, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+    assert_false(run_bitset_container_xor(R1, B3, &C));
+    assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     run_run_container_xor(R1, R3, &BX_1));
-    assert_int_equal(2000, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+                     array_run_container_xor(A3, R1, &C));
+    assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
-    assert_true(run_bitset_container_xor(R1, B2, &BX_1));
-    assert_int_equal(cx12, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+    assert_int_equal(ARRAY_CONTAINER_TYPE,
+                     run_run_container_xor(R1, R3, &C));
+    assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
+
+    assert_true(run_bitset_container_xor(R1, B2, &C));
+    assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     assert_int_equal(BITSET_CONTAINER_TYPE,
-                     array_run_container_xor(A2, R1, &BX_1));
-    assert_int_equal(cx12, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+                     array_run_container_xor(A2, R1, &C));
+    assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     array_container_t* A_small = array_container_create();
     for (int i = 1000; i < 1010; ++i) array_container_add(A_small, i);
 
     assert_int_equal(RUN_CONTAINER_TYPE,
-                     array_run_container_xor(A_small, R2, &BX_1));
+                     array_run_container_xor(A_small, R2, &C));
     assert_int_equal(0x98bd,
-                     run_container_cardinality(BX_1));  // hopefully right...
-    run_container_free(BX_1);
-    BX_1 = NULL;
+                     run_container_cardinality(CAST_run(C)));
+    run_container_free(CAST_run(C));
+    C = NULL;
 
     assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_run_container_xor(R1, R2, &BX_1));
-    assert_int_equal(cx12, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+                     run_run_container_xor(R1, R2, &C));
+    assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
-    assert_true(run_bitset_container_xor(R4, B3, &BX_1));
-    int card_3_4 = bitset_container_cardinality(BX_1);
-    // assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+    assert_true(run_bitset_container_xor(R4, B3, &C));
+    int card_3_4 = bitset_container_cardinality(CAST_bitset(C));
+    // assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     assert_int_equal(BITSET_CONTAINER_TYPE,
-                     array_run_container_xor(A3, R4, &BX_1));
+                     array_run_container_xor(A3, R4, &C));
     // if this fails, either this bitset is wrong or the previous one...
-    assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+    assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_run_container_xor(R4, R3, &BX_1));
-    assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+                     run_run_container_xor(R4, R3, &C));
+    assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     array_container_free(A1);
     array_container_free(A2);
@@ -665,7 +669,7 @@ void run_xor_test() {
 }
 
 // routines where one of the containers is a run container, copied from xor code
-void run_andnot_test() {
+DEFINE_TEST(run_andnot_test) {
     array_container_t* A1 = array_container_create();
     array_container_t* A2 = array_container_create();
     array_container_t* A3 = array_container_create();
@@ -730,11 +734,11 @@ void run_andnot_test() {
 
     int cm12 = array_container_cardinality(AM);
 
-    void* BM_1 = NULL;
+    container_t* BM_1 = NULL;
 
     assert_false(run_bitset_container_andnot(R1, B1, &BM_1));
-    assert_int_equal(0, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(0, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     array_run_container_andnot(A1, R1, AM);
@@ -744,18 +748,18 @@ void run_andnot_test() {
     // empty
     assert_int_equal(RUN_CONTAINER_TYPE,
                      run_run_container_andnot(R1, R1, &BM_1));
-    assert_int_equal(0, run_container_cardinality(BM_1));
-    run_container_free(BM_1);
+    assert_int_equal(0, run_container_cardinality(CAST_run(BM_1)));
+    run_container_free(CAST_run(BM_1));
     BM_1 = NULL;
 
     assert_false(run_bitset_container_andnot(R1, B3, &BM_1));
-    assert_int_equal(2000, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(2000, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     assert_false(bitset_run_container_andnot(B1, R3, &BM_1));
-    assert_int_equal(2000, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(2000, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     array_run_container_andnot(A1, R3, AM);
@@ -763,19 +767,19 @@ void run_andnot_test() {
 
     assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_array_container_andnot(R1, A3, &BM_1));
-    assert_int_equal(2000, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(2000, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_run_container_andnot(R1, R3, &BM_1));
-    assert_int_equal(2000, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(2000, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     assert_true(run_bitset_container_andnot(R1, B2, &BM_1));
-    assert_int_equal(cm12, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(cm12, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     array_run_container_andnot(A1, R2, AM);
@@ -792,15 +796,15 @@ void run_andnot_test() {
                      array_container_cardinality(AM));  // hopefully right...
 
     assert_false(run_bitset_container_andnot(R_small, B2, &BM_1));
-    assert_int_equal(2, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(2, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     // note, result is equally small as an array or a run
     assert_int_equal(RUN_CONTAINER_TYPE,
                      run_array_container_andnot(R_small, A2, &BM_1));
-    assert_int_equal(2, run_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(2, run_container_cardinality(CAST_run(BM_1)));
+    run_container_free(CAST_run(BM_1));
     BM_1 = NULL;
 
     // test with more complicated small run structure (to do)
@@ -820,8 +824,8 @@ void run_andnot_test() {
     assert_int_equal(
         RUN_CONTAINER_TYPE,
         run_array_container_andnot(R_small_complex, temp_ac, &BM_1));
-    assert_int_equal(13, run_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(13, run_container_cardinality(CAST_run(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     array_container_free(temp_ac);
@@ -829,26 +833,26 @@ void run_andnot_test() {
 
     assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_array_container_andnot(R1, A3, &BM_1));
-    assert_int_equal(2000, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(2000, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_andnot(R1, R2, &BM_1));
-    assert_int_equal(cm12, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(cm12, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     // compute the true card for cont4 - cont3 assuming that
     // bitset-bitset implementation is known correct
     assert_true(bitset_bitset_container_andnot(B4, B3, &BM_1));
-    int card_4_3 = bitset_container_cardinality(BM_1);
-    bitset_container_free(BM_1);
+    int card_4_3 = bitset_container_cardinality(CAST_bitset(BM_1));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     assert_true(run_bitset_container_andnot(R4, B3, &BM_1));
-    assert_int_equal(card_4_3, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(card_4_3, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     array_run_container_andnot(A4, R3, AM);
@@ -857,8 +861,8 @@ void run_andnot_test() {
 
     assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_andnot(R4, R3, &BM_1));
-    assert_int_equal(card_4_3, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(card_4_3, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     array_container_free(A1);
@@ -882,7 +886,7 @@ void run_andnot_test() {
 }
 
 // routines where one of the containers is a run container
-void run_ixor_test() {
+DEFINE_TEST(run_ixor_test) {
     array_container_t* A1 = array_container_create();
     array_container_t* A2 = array_container_create();
     array_container_t* A3 = array_container_create();
@@ -945,152 +949,152 @@ void run_ixor_test() {
 
     int cx12 = array_container_cardinality(AX);  // expected xor for ?1 and ?2
 
-    void* BX_1 = NULL;
+    container_t* C = NULL;
 
     run_container_t* temp_r = run_container_clone(R1);
-    assert_false(run_bitset_container_ixor(temp_r, B1, &BX_1));
-    assert_int_equal(0, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+    assert_false(run_bitset_container_ixor(temp_r, B1, &C));
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     bitset_container_t* temp_b = bitset_container_create();
     bitset_container_copy(B1, temp_b);
-    assert_false(bitset_run_container_ixor(temp_b, R1, &BX_1));
-    assert_int_equal(0, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+    assert_false(bitset_run_container_ixor(temp_b, R1, &C));
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     array_container_t* temp_a = array_container_clone(A1);
     assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     array_run_container_ixor(temp_a, R1, &BX_1));
-    assert_int_equal(0, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+                     array_run_container_ixor(temp_a, R1, &C));
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     temp_r = run_container_clone(R1);
     assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     run_array_container_ixor(temp_r, A1, &BX_1));
-    assert_int_equal(0, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+                     run_array_container_ixor(temp_r, A1, &C));
+    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     // both run coding and array coding have same serialized size for
     // empty
     temp_r = run_container_clone(R1);
-    int ret_type = run_run_container_ixor(temp_r, R1, &BX_1);
+    int ret_type = run_run_container_ixor(temp_r, R1, &C);
     assert_int_not_equal(BITSET_CONTAINER_TYPE, ret_type);
     if (ret_type == RUN_CONTAINER_TYPE) {
-        assert_int_equal(0, run_container_cardinality(BX_1));
-        run_container_free(BX_1);
+        assert_int_equal(0, run_container_cardinality(CAST_run(C)));
+        run_container_free(CAST_run(C));
     } else {
-        assert_int_equal(0, array_container_cardinality(BX_1));
-        array_container_free(BX_1);
+        assert_int_equal(0, array_container_cardinality(CAST_array(C)));
+        array_container_free(CAST_array(C));
     }
-    BX_1 = NULL;
+    C = NULL;
 
     temp_r = run_container_clone(R1);
-    assert_false(run_bitset_container_ixor(temp_r, B3, &BX_1));
-    assert_int_equal(2000, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+    assert_false(run_bitset_container_ixor(temp_r, B3, &C));
+    assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     temp_a = array_container_clone(A3);
     assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     array_run_container_ixor(temp_a, R1, &BX_1));
-    assert_int_equal(2000, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+                     array_run_container_ixor(temp_a, R1, &C));
+    assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     temp_b = bitset_container_create();
     bitset_container_copy(B1, temp_b);
-    assert_false(bitset_run_container_ixor(temp_b, R3, &BX_1));
-    assert_int_equal(2000, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+    assert_false(bitset_run_container_ixor(temp_b, R3, &C));
+    assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     temp_r = run_container_clone(R3);
     assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     run_array_container_ixor(temp_r, A1, &BX_1));
-    assert_int_equal(2000, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+                     run_array_container_ixor(temp_r, A1, &C));
+    assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     temp_r = run_container_clone(R1);
     assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     run_run_container_ixor(temp_r, R3, &BX_1));
-    assert_int_equal(2000, array_container_cardinality(BX_1));
-    array_container_free(BX_1);
-    BX_1 = NULL;
+                     run_run_container_ixor(temp_r, R3, &C));
+    assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
+    C = NULL;
 
     temp_r = run_container_clone(R1);
-    assert_true(run_bitset_container_ixor(temp_r, B2, &BX_1));
-    assert_int_equal(cx12, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+    assert_true(run_bitset_container_ixor(temp_r, B2, &C));
+    assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     temp_a = array_container_clone(A2);
     assert_int_equal(BITSET_CONTAINER_TYPE,
-                     array_run_container_ixor(temp_a, R1, &BX_1));
-    assert_int_equal(cx12, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+                     array_run_container_ixor(temp_a, R1, &C));
+    assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     temp_b = bitset_container_create();
     bitset_container_copy(B1, temp_b);
-    assert_true(bitset_run_container_ixor(temp_b, R2, &BX_1));
-    assert_int_equal(cx12, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+    assert_true(bitset_run_container_ixor(temp_b, R2, &C));
+    assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     temp_r = run_container_clone(R1);
     assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_array_container_ixor(temp_r, A2, &BX_1));
-    assert_int_equal(cx12, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+                     run_array_container_ixor(temp_r, A2, &C));
+    assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     temp_r = run_container_clone(R1);
     assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_run_container_ixor(temp_r, R2, &BX_1));
-    assert_int_equal(cx12, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+                     run_run_container_ixor(temp_r, R2, &C));
+    assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     temp_r = run_container_clone(R4);
-    assert_true(run_bitset_container_ixor(temp_r, B3, &BX_1));
-    int card_3_4 = bitset_container_cardinality(BX_1);
-    // assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+    assert_true(run_bitset_container_ixor(temp_r, B3, &C));
+    int card_3_4 = bitset_container_cardinality(CAST_bitset(C));
+    // assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     temp_a = array_container_clone(A3);
     assert_int_equal(BITSET_CONTAINER_TYPE,
-                     array_run_container_ixor(temp_a, R4, &BX_1));
+                     array_run_container_ixor(temp_a, R4, &C));
     // if this fails, either this bitset is wrong or the previous one...
-    assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+    assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     temp_b = bitset_container_create();
     bitset_container_copy(B3, temp_b);
-    assert_true(bitset_run_container_ixor(temp_b, R4, &BX_1));
-    assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+    assert_true(bitset_run_container_ixor(temp_b, R4, &C));
+    assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     temp_r = run_container_clone(R3);
     assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_array_container_ixor(temp_r, A4, &BX_1));
-    assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+                     run_array_container_ixor(temp_r, A4, &C));
+    assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     temp_r = run_container_clone(R4);
     assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_run_container_ixor(temp_r, R3, &BX_1));
-    assert_int_equal(card_3_4, bitset_container_cardinality(BX_1));
-    bitset_container_free(BX_1);
-    BX_1 = NULL;
+                     run_run_container_ixor(temp_r, R3, &C));
+    assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+    C = NULL;
 
     array_container_free(A1);
     array_container_free(A2);
@@ -1109,7 +1113,7 @@ void run_ixor_test() {
     run_container_free(R4);
 }
 
-void run_iandnot_test() {
+DEFINE_TEST(run_iandnot_test) {
     array_container_t* A1 = array_container_create();
     array_container_t* A2 = array_container_create();
     array_container_t* A3 = array_container_create();
@@ -1169,19 +1173,19 @@ void run_iandnot_test() {
 
     int cm12 = array_container_cardinality(AM);  // expected xor for ?1 and ?2
 
-    void* BM_1 = NULL;
+    container_t* BM_1 = NULL;
 
     run_container_t* temp_r = run_container_clone(R1);
     assert_false(run_bitset_container_iandnot(temp_r, B1, &BM_1));
-    assert_int_equal(0, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(0, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     bitset_container_t* temp_b = bitset_container_create();
     bitset_container_copy(B1, temp_b);
     assert_false(bitset_run_container_iandnot(temp_b, R1, &BM_1));
-    assert_int_equal(0, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(0, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     array_container_t* temp_a = array_container_clone(A1);
@@ -1192,8 +1196,8 @@ void run_iandnot_test() {
     temp_r = run_container_clone(R1);
     assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_array_container_iandnot(temp_r, A1, &BM_1));
-    assert_int_equal(0, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(0, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     // both run coding and array coding have same serialized size for
@@ -1202,18 +1206,18 @@ void run_iandnot_test() {
     int ret_type = run_run_container_iandnot(temp_r, R1, &BM_1);
     assert_int_not_equal(BITSET_CONTAINER_TYPE, ret_type);
     if (ret_type == RUN_CONTAINER_TYPE) {
-        assert_int_equal(0, run_container_cardinality(BM_1));
-        run_container_free(BM_1);
+        assert_int_equal(0, run_container_cardinality(CAST_run(BM_1)));
+        run_container_free(CAST_run(BM_1));
     } else {
-        assert_int_equal(0, array_container_cardinality(BM_1));
-        array_container_free(BM_1);
+        assert_int_equal(0, array_container_cardinality(CAST_array(BM_1)));
+        array_container_free(CAST_array(BM_1));
     }
     BM_1 = NULL;
 
     temp_r = run_container_clone(R1);
     assert_false(run_bitset_container_iandnot(temp_r, B3, &BM_1));
-    assert_int_equal(2000, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(2000, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     temp_a = array_container_clone(A1);
@@ -1224,28 +1228,28 @@ void run_iandnot_test() {
     temp_b = bitset_container_create();
     bitset_container_copy(B1, temp_b);
     assert_false(bitset_run_container_iandnot(temp_b, R3, &BM_1));
-    assert_int_equal(2000, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(2000, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     temp_r = run_container_clone(R1);
     assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_array_container_iandnot(temp_r, A3, &BM_1));
-    assert_int_equal(2000, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(2000, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     temp_r = run_container_clone(R1);
     assert_int_equal(ARRAY_CONTAINER_TYPE,
                      run_run_container_iandnot(temp_r, R3, &BM_1));
-    assert_int_equal(2000, array_container_cardinality(BM_1));
-    array_container_free(BM_1);
+    assert_int_equal(2000, array_container_cardinality(CAST_array(BM_1)));
+    array_container_free(CAST_array(BM_1));
     BM_1 = NULL;
 
     temp_r = run_container_clone(R1);
     assert_true(run_bitset_container_iandnot(temp_r, B2, &BM_1));
-    assert_int_equal(cm12, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(cm12, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     temp_a = array_container_clone(A1);
@@ -1256,33 +1260,33 @@ void run_iandnot_test() {
     temp_b = bitset_container_create();
     bitset_container_copy(B1, temp_b);
     assert_true(bitset_run_container_iandnot(temp_b, R2, &BM_1));
-    assert_int_equal(cm12, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(cm12, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     temp_r = run_container_clone(R1);
     assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_array_container_iandnot(temp_r, A2, &BM_1));
-    assert_int_equal(cm12, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(cm12, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     temp_r = run_container_clone(R1);
     assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_iandnot(temp_r, R2, &BM_1));
-    assert_int_equal(cm12, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(cm12, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     assert_true(bitset_bitset_container_andnot(B4, B3, &BM_1));
-    int card_4_3 = bitset_container_cardinality(BM_1);
-    bitset_container_free(BM_1);
+    int card_4_3 = bitset_container_cardinality(CAST_bitset(BM_1));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     temp_r = run_container_clone(R4);
     assert_true(run_bitset_container_iandnot(temp_r, B3, &BM_1));
-    assert_int_equal(card_4_3, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(card_4_3, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     temp_a = array_container_clone(A4);
@@ -1294,22 +1298,22 @@ void run_iandnot_test() {
     temp_b = bitset_container_create();
     bitset_container_copy(B4, temp_b);
     assert_true(bitset_run_container_iandnot(temp_b, R3, &BM_1));
-    assert_int_equal(card_4_3, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(card_4_3, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     temp_r = run_container_clone(R4);
     assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_array_container_iandnot(temp_r, A3, &BM_1));
-    assert_int_equal(card_4_3, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(card_4_3, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     temp_r = run_container_clone(R4);
     assert_int_equal(BITSET_CONTAINER_TYPE,
                      run_run_container_iandnot(temp_r, R3, &BM_1));
-    assert_int_equal(card_4_3, bitset_container_cardinality(BM_1));
-    bitset_container_free(BM_1);
+    assert_int_equal(card_4_3, bitset_container_cardinality(CAST_bitset(BM_1)));
+    bitset_container_free(CAST_bitset(BM_1));
     BM_1 = NULL;
 
     array_container_free(A1);
@@ -1331,7 +1335,7 @@ void run_iandnot_test() {
 }
 
 /* test replicating bug seen on real data */
-void run_array_andnot_bug_test() {
+DEFINE_TEST(run_array_andnot_bug_test) {
     int runcontents[] = {
         196608, 196611, 196612, 196613, 196616, 196619, 196621, 196623, 196628,
         196629, 196630, 196631, 196632, 196633, 196634, 196635, 196636, 196638,
@@ -1354,17 +1358,17 @@ void run_array_andnot_bug_test() {
         array_container_add(a, *p % 65536);
 
     int kindofresult;
-    void* result = 0;
+    container_t* result = 0;
     kindofresult = run_array_container_andnot(r, a, &result);
     assert_int_equal(ARRAY_CONTAINER_TYPE, kindofresult);
-    assert_false(array_container_contains(result, 196722 % 65536));
+    assert_false(array_container_contains(CAST_array(result), 196722 % 65536));
 
     run_container_free(r);
     array_container_free(a);
-    array_container_free(result);
+    array_container_free(CAST_array(result));
 }
 
-void array_negation_empty_test() {
+DEFINE_TEST(array_negation_empty_test) {
     array_container_t* AI = array_container_create();
     bitset_container_t* BO = bitset_container_create();
 
@@ -1376,7 +1380,7 @@ void array_negation_empty_test() {
     bitset_container_free(BO);
 }
 
-void array_negation_test() {
+DEFINE_TEST(array_negation_test) {
     int ctr = 0;
     array_container_t* AI = array_container_create();
     bitset_container_t* BO = bitset_container_create();
@@ -1408,7 +1412,7 @@ static int array_negation_range_test(int r_start, int r_end, bool is_bitset) {
     int result_size_should_be = 0;
 
     array_container_t* AI = array_container_create();
-    void* BO;  // bitset or array
+    container_t* BO;  // bitset or array
 
     for (int x = 0; x < (1 << 16); x += 29) {
         array_container_add(AI, (uint16_t)x);
@@ -1425,7 +1429,7 @@ static int array_negation_range_test(int r_start, int r_end, bool is_bitset) {
     }
 
     result_is_bitset =
-        array_container_negation_range(AI, r_start, r_end, (void**)&BO);
+        array_container_negation_range(AI, r_start, r_end, &BO);
     uint8_t result_typecode = (result_is_bitset ? BITSET_CONTAINER_TYPE
                                                 : ARRAY_CONTAINER_TYPE);
 
@@ -1455,20 +1459,20 @@ static int array_negation_range_test(int r_start, int r_end, bool is_bitset) {
 }
 
 /* result is a bitset.  Range fits neatly in words */
-void array_negation_range_test1() {
+DEFINE_TEST(array_negation_range_test1) {
     array_negation_range_test(0x4000, 0xc000, true);
 }
 
 /* result is a bitset.  Range begins and ends mid word */
-void array_negation_range_test1a() {
+DEFINE_TEST(array_negation_range_test1a) {
     array_negation_range_test(0x4010, 0xc010, true);
 }
 /* result is an array */
-void array_negation_range_test2() {
+DEFINE_TEST(array_negation_range_test2) {
     array_negation_range_test(0x7f00, 0x8030, false);
 }
 /* Empty range.  result is a clone */
-void array_negation_range_test3() {
+DEFINE_TEST(array_negation_range_test3) {
     array_negation_range_test(0x7800, 0x7800, false);
 }
 
@@ -1479,7 +1483,7 @@ static int bitset_negation_range_tests(int sparsity, int r_start, int r_end,
                                        bool is_bitset, bool inplace) {
     int ctr = 0;
     bitset_container_t* BI = bitset_container_create();
-    void* BO;
+    container_t* BO;
     bool result_is_bitset;
     int result_size_should_be = 0;
 
@@ -1500,10 +1504,10 @@ static int bitset_negation_range_tests(int sparsity, int r_start, int r_end,
 
     if (inplace)
         result_is_bitset = bitset_container_negation_range_inplace(
-            BI, r_start, r_end, (void**)&BO);
+            BI, r_start, r_end, &BO);
     else
         result_is_bitset =
-            bitset_container_negation_range(BI, r_start, r_end, (void**)&BO);
+            bitset_container_negation_range(BI, r_start, r_end, &BO);
 
     uint8_t result_typecode = (result_is_bitset ? BITSET_CONTAINER_TYPE
                                                 : ARRAY_CONTAINER_TYPE);
@@ -1544,27 +1548,27 @@ static int bitset_negation_range_tests(int sparsity, int r_start, int r_end,
 }
 
 /* result is a bitset */
-void bitset_negation_range_test1() {
+DEFINE_TEST(bitset_negation_range_test1) {
     // 33% density will be a bitmap and remain so after any range
     // negated
     bitset_negation_range_tests(3, 0x7f00, 0x8030, true, false);
 }
 
 /* result is a array */
-void bitset_negation_range_test2() {
+DEFINE_TEST(bitset_negation_range_test2) {
     // 99% density will be a bitmap and become array when mostly flipped
     bitset_negation_range_tests(100, 0x080, 0xff80, false, false);
 }
 
 /* inplace: result is a bitset */
-void bitset_negation_range_inplace_test1() {
+DEFINE_TEST(bitset_negation_range_inplace_test1) {
     // 33% density will be a bitmap and remain so after any range
     // negated
     bitset_negation_range_tests(3, 0x7f00, 0x8030, true, true);
 }
 
 /* inplace: result is a array */
-void bitset_negation_range_inplace_test2() {
+DEFINE_TEST(bitset_negation_range_inplace_test2) {
     // 99% density will be a bitmap and become array when mostly flipped
     bitset_negation_range_tests(100, 0x080, 0xff80, false, true);
 }
@@ -1579,7 +1583,7 @@ static int run_negation_range_tests(int k, int h, int start_offset, int r_start,
     int card = 0;
     run_container_t* RI =
         run_container_create_given_capacity((1 << 16) / k + 1);
-    void* BO;
+    container_t* BO;
     int returned_type;
     int result_size_should_be;
     bool result_should_be[1 << 16];
@@ -1615,10 +1619,10 @@ static int run_negation_range_tests(int k, int h, int start_offset, int r_start,
     }
     if (inplace)
         returned_type = run_container_negation_range_inplace(RI, r_start, r_end,
-                                                             (void**)&BO);
+                                                             &BO);
     else
         returned_type =
-            run_container_negation_range(RI, r_start, r_end, (void**)&BO);
+            run_container_negation_range(RI, r_start, r_end, &BO);
 
     uint8_t result_typecode = (uint8_t)returned_type;
 
@@ -1662,7 +1666,7 @@ static int run_negation_range_tests_simpler(int k, int h, int start_offset,
     int card = 0;
     run_container_t* RI =
         run_container_create_given_capacity((1 << 16) / k + 1);
-    void* BO;
+    container_t* BO;
     int returned_type;
     int result_size_should_be;
     bool result_should_be[1 << 16];
@@ -1696,10 +1700,10 @@ static int run_negation_range_tests_simpler(int k, int h, int start_offset,
     }
     if (inplace)
         returned_type = run_container_negation_range_inplace(RI, r_start, r_end,
-                                                             (void**)&BO);
+                                                             &BO);
     else
         returned_type =
-            run_container_negation_range(RI, r_start, r_end, (void**)&BO);
+            run_container_negation_range(RI, r_start, r_end, &BO);
 
     uint8_t result_typecode = (uint8_t)returned_type;
 
@@ -1742,16 +1746,16 @@ static int run_many_negation_range_tests_simpler(bool inplace) {
     return 1;
 }
 
-void run_many_negation_range_tests_simpler_notinplace() {
+DEFINE_TEST(run_many_negation_range_tests_simpler_notinplace) {
     run_many_negation_range_tests_simpler(false);
 }
 
-void run_many_negation_range_tests_simpler_inplace() {
+DEFINE_TEST(run_many_negation_range_tests_simpler_inplace) {
     run_many_negation_range_tests_simpler(true);
 }
 
 /* result is a bitset */
-void run_negation_range_inplace_test1() {
+DEFINE_TEST(run_negation_range_inplace_test1) {
     // runs of length 7, 8, 9 begin every 10
     // starting at 0.
     // (should not have been run encoded, but...)
@@ -1765,7 +1769,7 @@ void run_negation_range_inplace_test1() {
                              false);  // request but don't get inplace
 }
 
-void run_negation_range_inplace_test2() {
+DEFINE_TEST(run_negation_range_inplace_test2) {
     // runs of length 7, 8, 9 begin every 10
     // starting at 1.
     // last run starts at 65531 hence we end in a
@@ -1778,7 +1782,7 @@ void run_negation_range_inplace_test2() {
                              false);  // request but don't get inplace
 }
 
-void run_negation_range_inplace_test3() {
+DEFINE_TEST(run_negation_range_inplace_test3) {
     // runs of length 2,3,..9 begin every 10
     // starting at 1.
     // last run starts at 65531. Run length is (6553
@@ -1793,7 +1797,7 @@ void run_negation_range_inplace_test3() {
 }
 
 /* Results are going to be arrays*/
-void run_negation_range_inplace_test4() {
+DEFINE_TEST(run_negation_range_inplace_test4) {
     // runs of length 999 begin every 1000 starting
     // at 0.
     // last run starts at 65000 hence we end in a
@@ -1806,7 +1810,7 @@ void run_negation_range_inplace_test4() {
                              false);  // request but don't get inplace
 }
 
-void run_negation_range_inplace_test5() {
+DEFINE_TEST(run_negation_range_inplace_test5) {
     // runs of length 999 begin every 10000 starting
     // at 1.
     // last run starts at 65001 hence we end in a
@@ -1819,7 +1823,7 @@ void run_negation_range_inplace_test5() {
                              false);  // request but don't get inplace
 }
 
-void run_negation_range_inplace_test6() {
+DEFINE_TEST(run_negation_range_inplace_test6) {
     // runs of length 999 begin every 10000 starting
     // at 536
     // last run starts at 64536.
@@ -1833,7 +1837,7 @@ void run_negation_range_inplace_test6() {
 }
 
 /* Results are going to be runs*/
-void run_negation_range_inplace_test7() {
+DEFINE_TEST(run_negation_range_inplace_test7) {
     // short runs of length 2, 3, .. 67 begin every
     // 1000 starting at 550.
     // last run starts at 65550 hence we end in a
@@ -1847,7 +1851,7 @@ void run_negation_range_inplace_test7() {
                              true);  // request and  get inplace
 }
 
-void run_negation_range_inplace_test8() {
+DEFINE_TEST(run_negation_range_inplace_test8) {
     // runs of length 2..67 begin every 10000
     // starting at 0.
     // last run starts at 65000 hence we end outside
@@ -1860,7 +1864,7 @@ void run_negation_range_inplace_test8() {
                              true);  // request, get inplace
 }
 
-void run_negation_range_inplace_test9() {
+DEFINE_TEST(run_negation_range_inplace_test9) {
     // runs of length 2..67 begin every 10000
     // starting at 1
     // last run starts at 64001.
@@ -1878,7 +1882,7 @@ void run_negation_range_inplace_test9() {
 // now, 9 more tests that do not request inplace.
 
 /* result is a bitset */
-void run_negation_range_test1() {
+DEFINE_TEST(run_negation_range_test1) {
     // runs of length 7, 8, 9 begin every 10
     // starting at 0.
     // (should not have been run encoded, but...)
@@ -1891,7 +1895,7 @@ void run_negation_range_test1() {
                              BITSET_CONTAINER_TYPE, false, false);
 }
 
-void run_negation_range_test2() {
+DEFINE_TEST(run_negation_range_test2) {
     // runs of length 7, 8, 9 begin every 10
     // starting at 1.
     // last run starts at 65531 hence we end in a
@@ -1903,7 +1907,7 @@ void run_negation_range_test2() {
                              BITSET_CONTAINER_TYPE, false, false);
 }
 
-void run_negation_range_test3() {
+DEFINE_TEST(run_negation_range_test3) {
     // runs of length 2,3,..9 begin every 10
     // starting at 1.
     // last run starts at 65531. Run length is (6553
@@ -1918,7 +1922,7 @@ void run_negation_range_test3() {
 }
 
 /* Results are going to be arrays*/
-void run_negation_range_test4() {
+DEFINE_TEST(run_negation_range_test4) {
     // runs of length 999 begin every 1000 starting
     // at 0.
     // last run starts at 65000 hence we end in a
@@ -1930,7 +1934,7 @@ void run_negation_range_test4() {
                              ARRAY_CONTAINER_TYPE, false, false);
 }
 
-void run_negation_range_test5() {
+DEFINE_TEST(run_negation_range_test5) {
     // runs of length 999 begin every 10000 starting
     // at 1.
     // last run starts at 65001 hence we end in a
@@ -1942,7 +1946,7 @@ void run_negation_range_test5() {
                              ARRAY_CONTAINER_TYPE, false, false);
 }
 
-void run_negation_range_test6() {
+DEFINE_TEST(run_negation_range_test6) {
     // runs of length 999 begin every 10000 starting
     // at 536
     // last run starts at 64536.
@@ -1955,7 +1959,7 @@ void run_negation_range_test6() {
 }
 
 /* Results are going to be runs*/
-void run_negation_range_test7() {
+DEFINE_TEST(run_negation_range_test7) {
     // short runs of length 2, 3, .. 67 begin every
     // 1000 starting at 550.
     // last run starts at 65550 hence we end in a
@@ -1968,7 +1972,7 @@ void run_negation_range_test7() {
                              RUN_CONTAINER_TYPE, false, false);
 }
 
-void run_negation_range_test8() {
+DEFINE_TEST(run_negation_range_test8) {
     // runs of length 2..67 begin every 10000
     // starting at 0.
     // last run starts at 65000 hence we end outside
@@ -1980,7 +1984,7 @@ void run_negation_range_test8() {
                              RUN_CONTAINER_TYPE, false, false);
 }
 
-void run_negation_range_test9() {
+DEFINE_TEST(run_negation_range_test9) {
     // runs of length 2..67 begin every 10000
     // starting at 1
     // last run starts at 64001.

--- a/tests/realdata_unit.c
+++ b/tests/realdata_unit.c
@@ -9,6 +9,10 @@
 
 #include <roaring/array_util.h>  // union_uint32(), intersection_uint32()
 
+#ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
+    using namespace roaring::internal;
+#endif
+
 #include "../benchmarks/numbersfromtextfiles.h"
 #include "config.h"
 
@@ -20,7 +24,8 @@ static roaring_bitmap_t **create_all_bitmaps(size_t *howmany,
                                              bool copy_on_write) {
     if (numbers == NULL) return NULL;
     printf("Constructing %d  bitmaps.\n", (int)count);
-    roaring_bitmap_t **answer = malloc(sizeof(roaring_bitmap_t *) * count);
+    roaring_bitmap_t **answer =
+            (roaring_bitmap_t**)malloc(sizeof(roaring_bitmap_t *) * count);
     for (size_t i = 0; i < count; i++) {
         printf(".");
         fflush(stdout);
@@ -38,7 +43,7 @@ const char *datadir[] = {
 
 bool serialize_correctly(roaring_bitmap_t *r) {
     uint32_t expectedsize = roaring_bitmap_portable_size_in_bytes(r);
-    char *serialized = malloc(expectedsize);
+    char *serialized = (char*)malloc(expectedsize);
     if (serialized == NULL) {
         printf("failure to allocate memory!\n");
         return false;
@@ -789,7 +794,8 @@ bool loadAndCheckAll(const char *dirname, bool copy_on_write) {
         }
     }
 
-    roaring_bitmap_t **bitmapswrun = malloc(sizeof(roaring_bitmap_t *) * count);
+    roaring_bitmap_t **bitmapswrun =
+            (roaring_bitmap_t**)malloc(sizeof(roaring_bitmap_t *) * count);
     for (int i = 0; i < (int)count; i++) {
         bitmapswrun[i] = roaring_bitmap_copy(bitmaps[i]);
         roaring_bitmap_run_optimize(bitmapswrun[i]);

--- a/tests/robust_deserialization_unit.c
+++ b/tests/robust_deserialization_unit.c
@@ -10,8 +10,8 @@
 
 #include <roaring/roaring.h>
 
-
 #include "config.h"
+
 #include "test.h"
 
 
@@ -22,7 +22,7 @@ long filesize(FILE* fp) {
 
 char* readfile(FILE* fp, size_t * bytes) {
     *bytes = filesize(fp);
-    char* buf = malloc(*bytes);
+    char* buf = (char*)malloc(*bytes);
     if(buf == NULL) return NULL;
 
     rewind(fp);
@@ -72,7 +72,7 @@ int test_deserialize(const char * filename) {
 
     size_t expected_size = roaring_bitmap_portable_size_in_bytes(bitmap);
 
-    char* output_buffer = malloc(expected_size);
+    char* output_buffer = (char*)malloc(expected_size);
     size_t actual_size =
         roaring_bitmap_portable_serialize(bitmap, output_buffer);
 
@@ -97,7 +97,7 @@ int test_deserialize(const char * filename) {
 
 
 
-void test_robust_deserialize1() {
+DEFINE_TEST(test_robust_deserialize1) {
     char filename[1024];
 
     strcpy(filename, TEST_DATA_DIR);
@@ -107,7 +107,7 @@ void test_robust_deserialize1() {
 }
 
 
-void test_robust_deserialize2() {
+DEFINE_TEST(test_robust_deserialize2) {
     char filename[1024];
 
     strcpy(filename, TEST_DATA_DIR);
@@ -117,7 +117,7 @@ void test_robust_deserialize2() {
 }
 
 
-void test_robust_deserialize3() {
+DEFINE_TEST(test_robust_deserialize3) {
     char filename[1024];
 
     strcpy(filename, TEST_DATA_DIR);
@@ -126,7 +126,7 @@ void test_robust_deserialize3() {
     test_deserialize(filename);
 }
 
-void test_robust_deserialize4() {
+DEFINE_TEST(test_robust_deserialize4) {
     char filename[1024];
 
     strcpy(filename, TEST_DATA_DIR);
@@ -135,7 +135,7 @@ void test_robust_deserialize4() {
     test_deserialize(filename);
 }
 
-void test_robust_deserialize5() {
+DEFINE_TEST(test_robust_deserialize5) {
     char filename[1024];
 
     strcpy(filename, TEST_DATA_DIR);
@@ -144,7 +144,7 @@ void test_robust_deserialize5() {
     test_deserialize(filename);
 }
 
-void test_robust_deserialize6() {
+DEFINE_TEST(test_robust_deserialize6) {
     char filename[1024];
 
     strcpy(filename, TEST_DATA_DIR);
@@ -153,7 +153,7 @@ void test_robust_deserialize6() {
     test_deserialize(filename);
 }
 
-void test_robust_deserialize7() {
+DEFINE_TEST(test_robust_deserialize7) {
     char filename[1024];
 
     strcpy(filename, TEST_DATA_DIR);
@@ -162,7 +162,7 @@ void test_robust_deserialize7() {
     test_deserialize(filename);
 }
 
-void test_robust_deserialize8() {
+DEFINE_TEST(test_robust_deserialize8) {
     char filename[1024];
 
     strcpy(filename, TEST_DATA_DIR);

--- a/tests/run_container_unit.c
+++ b/tests/run_container_unit.c
@@ -9,9 +9,14 @@
 
 #include <roaring/containers/run.h>
 
+#ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
+    using namespace roaring::internal;
+#endif
+
 #include "test.h"
 
-void printf_test() {
+
+DEFINE_TEST(printf_test) {
     run_container_t* B = run_container_create();
 
     assert_non_null(B);
@@ -28,7 +33,7 @@ void printf_test() {
     run_container_free(B);
 }
 
-void add_contains_test() {
+DEFINE_TEST(add_contains_test) {
     run_container_t* B = run_container_create();
     assert_non_null(B);
 
@@ -78,7 +83,7 @@ void add_contains_test() {
     run_container_free(B);
 }
 
-void and_or_test() {
+DEFINE_TEST(and_or_test) {
     run_container_t* B1 = run_container_create();
     run_container_t* B2 = run_container_create();
     run_container_t* BI = run_container_create();
@@ -120,7 +125,7 @@ void and_or_test() {
 }
 
 // returns 0 on error, 1 if ok.
-void to_uint32_array_test() {
+DEFINE_TEST(to_uint32_array_test) {
     for (size_t offset = 1; offset < 128; offset *= 2) {
         run_container_t* B = run_container_create();
         assert_non_null(B);
@@ -130,7 +135,7 @@ void to_uint32_array_test() {
         }
 
         int card = run_container_cardinality(B);
-        uint32_t* out = malloc(sizeof(uint32_t) * card);
+        uint32_t* out = (uint32_t*)malloc(sizeof(uint32_t) * card);
         int nc = run_container_to_uint32_array(out, B, 0);
         assert_int_equal(nc, card);
 
@@ -143,7 +148,7 @@ void to_uint32_array_test() {
     }
 }
 
-void select_test() {
+DEFINE_TEST(select_test) {
     run_container_t* B = run_container_create();
     assert_non_null(B);
     uint16_t base = 27;
@@ -165,7 +170,7 @@ void select_test() {
     run_container_free(B);
 }
 
-void remove_range_test() {
+DEFINE_TEST(remove_range_test) {
     run_container_t* run = run_container_create();
     run_container_add_range(run, 100, 150);
     run_container_add_range(run, 200, 250);

--- a/tests/test.h
+++ b/tests/test.h
@@ -1,7 +1,56 @@
+//
+// This test.h file is included by all the unit tests.
+//
+// It contains helpers for working with the cmocka unit tests.  Since that is
+// a third party file, putting common macros and functions here is better
+// than changing it.
+//
+
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
-#include "vendor/cmocka/cmocka.h"
+
+#ifdef __cplusplus
+    //
+    // It's generally not good to span a header file with `extern "C"`, but
+    // this is how the cpp_unit.cpp test was doing it.  cmocka.h apparently
+    // only has #ifdefs for extern "C" under MSC (?)
+    //
+    extern "C" {
+        #include "vendor/cmocka/cmocka.h"
+    }
+#else
+    #include "vendor/cmocka/cmocka.h"
+#endif
+
 
 #define DESCRIBE_TEST fprintf(stderr, "--- %s\n", __func__)
+
+
+// The "cmocka" test functions are supposed to look like:
+//
+//      void test_function(void **state)
+//
+// Originally the C tests would declare it like:
+//
+//      void test_function()
+//
+// But in C++ that would not match the type, so the C++ tests declared as:
+//
+//      void test_function(void **)
+//
+// There's a problem if you're trying to write code that will compile in
+// either C or C++, because it's not legal in C99 to not name a parameter...
+// and if you give it a name, then there will be complaints that the paramter
+// is not used.
+//
+// Disabling bad cast warnings in C++ defeats the point of compiling in C++,
+// and knowing when parameters aren't referenced is useful even in tests.  So
+// rather than disabling warnings, this defines a macro to declare the tests.
+//
+#ifdef __cplusplus
+    #define DEFINE_TEST(name)   void name(void**)
+#else
+    #define DEFINE_TEST(name)   void name()
+#endif

--- a/tests/util_unit.c
+++ b/tests/util_unit.c
@@ -10,23 +10,28 @@
 
 #include <roaring/bitset_util.h>
 
+#ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
+    using namespace roaring::internal;
+#endif
+
 #include "test.h"
 
-void setandextract_uint16() {
+
+DEFINE_TEST(setandextract_uint16) {
     const unsigned int bitset_size = 1 << 16;
     const unsigned int bitset_size_in_words =
         bitset_size / (sizeof(uint64_t) * 8);
 
     for (unsigned int offset = 1; offset < bitset_size; offset++) {
         const unsigned int valsize = bitset_size / offset;
-        uint16_t* vals = malloc(valsize * sizeof(uint16_t));
-        uint64_t* bitset = calloc(bitset_size_in_words, sizeof(uint64_t));
+        uint16_t* vals = (uint16_t*)malloc(valsize * sizeof(uint16_t));
+        uint64_t* bitset = (uint64_t*)calloc(bitset_size_in_words, sizeof(uint64_t));
         for (unsigned int k = 0; k < valsize; ++k) {
             vals[k] = (uint16_t)(k * offset);
         }
 
         bitset_set_list(bitset, vals, valsize);
-        uint16_t* newvals = malloc(valsize * sizeof(uint16_t));
+        uint16_t* newvals = (uint16_t*)malloc(valsize * sizeof(uint16_t));
         bitset_extract_setbits_uint16(bitset, bitset_size_in_words, newvals, 0);
 
         for (unsigned int k = 0; k < valsize; ++k) {
@@ -40,21 +45,21 @@ void setandextract_uint16() {
 }
 
 #ifdef IS_X64
-void setandextract_sse_uint16() {
+DEFINE_TEST(setandextract_sse_uint16) {
     const unsigned int bitset_size = 1 << 16;
     const unsigned int bitset_size_in_words =
         bitset_size / (sizeof(uint64_t) * 8);
 
     for (unsigned int offset = 1; offset < bitset_size; offset++) {
         const unsigned int valsize = bitset_size / offset;
-        uint16_t* vals = malloc(valsize * sizeof(uint16_t));
-        uint64_t* bitset = calloc(bitset_size_in_words, sizeof(uint64_t));
+        uint16_t* vals = (uint16_t*)malloc(valsize * sizeof(uint16_t));
+        uint64_t* bitset = (uint64_t*)calloc(bitset_size_in_words, sizeof(uint64_t));
         for (unsigned int k = 0; k < valsize; ++k) {
             vals[k] = (uint16_t)(k * offset);
         }
 
         bitset_set_list(bitset, vals, valsize);
-        uint16_t* newvals = malloc(valsize * sizeof(uint16_t) + 64);
+        uint16_t* newvals = (uint16_t*)malloc(valsize * sizeof(uint16_t) + 64);
         bitset_extract_setbits_sse_uint16(bitset, bitset_size_in_words, newvals,
                                           valsize, 0);
 
@@ -69,22 +74,22 @@ void setandextract_sse_uint16() {
 }
 #endif
 
-void setandextract_uint32() {
+DEFINE_TEST(setandextract_uint32) {
     const unsigned int bitset_size = 1 << 16;
     const unsigned int bitset_size_in_words =
         bitset_size / (sizeof(uint64_t) * 8);
 
     for (unsigned int offset = 1; offset < bitset_size; offset++) {
         const unsigned int valsize = bitset_size / offset;
-        uint16_t* vals = malloc(valsize * sizeof(uint16_t));
-        uint64_t* bitset = calloc(bitset_size_in_words, sizeof(uint64_t));
+        uint16_t* vals = (uint16_t*)malloc(valsize * sizeof(uint16_t));
+        uint64_t* bitset = (uint64_t*)calloc(bitset_size_in_words, sizeof(uint64_t));
 
         for (unsigned int k = 0; k < valsize; ++k) {
             vals[k] = (uint16_t)(k * offset);
         }
 
         bitset_set_list(bitset, vals, valsize);
-        uint32_t* newvals = malloc(valsize * sizeof(uint32_t));
+        uint32_t* newvals = (uint32_t*)malloc(valsize * sizeof(uint32_t));
         bitset_extract_setbits(bitset, bitset_size_in_words, newvals, 0);
 
         for (unsigned int k = 0; k < valsize; ++k) {

--- a/tools/cmake/FindCTargets.cmake
+++ b/tools/cmake/FindCTargets.cmake
@@ -3,6 +3,10 @@ if (CMAKE_VERSION VERSION_GREATER 3.0.0)
 endif ()
 
 function(add_c_test TEST_NAME)
+  if(ROARING_BUILD_C_TESTS_AS_CPP)  # under C++, container_t* != void*
+    SET_SOURCE_FILES_PROPERTIES(${TEST_NAME}.c PROPERTIES LANGUAGE CXX)
+  endif()
+
   add_executable(${TEST_NAME} ${TEST_NAME}.c)
   target_link_libraries(${TEST_NAME} ${ROARING_LIB_NAME} cmocka)
   add_test(${TEST_NAME} ${TEST_NAME})


### PR DESCRIPTION
The CMake build switch ROARING_BUILD_C_AS_CPP was only being
applied to the main files, and not the tests.  This commit adds
another option for the test files: ROARING_BUILD_C_TESTS_AS_CPP

(Having a separate setting is beneficial, in order to make sure
a C++ built library can be used with C clients...and vice versa)

With this change, there are no `void*` references to containers
or raw casts.  This gives compile time errors when aspects of
the internal interfaces change that would be more difficult to
debug otherwise.

Because there is no compatible way to declare a function across
C and C++ that doesn't name a `void**` argument, this required
making the test functions use a macro: DEFINE_TEST()