### PR TITLE
XOR Reorganized for Error Reporting (Work in Progress)

### DIFF
--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -7,6 +7,7 @@
 #define INCLUDE_CONTAINERS_ARRAY_H_
 
 #include <string.h>
+#include <assert.h>
 
 #include <roaring/portability.h>
 #include <roaring/roaring_types.h>  // roaring_iterator
@@ -78,7 +79,15 @@ static inline bool array_container_nonzero_cardinality(
 }
 
 /* Copy one container into another. We assume that they are distinct. */
-void array_container_copy(const array_container_t *src, array_container_t *dst);
+bool array_container_try_copy(const array_container_t *src,
+                              array_container_t *dst);
+
+static inline void array_container_copy(
+    const array_container_t *src, array_container_t *dst
+){
+    bool success = array_container_try_copy(src, dst);
+    assert(success);
+}
 
 /*  Add all the values in [min,max) (included) at a distance k*step from min.
     The container must have a size less or equal to DEFAULT_MAX_SIZE after this
@@ -174,8 +183,15 @@ static inline int32_t array_container_serialized_size_in_bytes(int32_t card) {
  * parameter. If preserve is false, then the new content will be uninitialized,
  * otherwise the old content is copied.
  */
-void array_container_grow(array_container_t *container, int32_t min,
-                          bool preserve);
+bool array_container_try_grow(array_container_t *ac, int32_t min, bool preserve);
+
+inline static void array_container_grow(  // !!! temporary
+                              array_container_t *ac, int32_t min,
+                              bool preserve
+){
+    bool success = array_container_try_grow(ac, min, preserve);
+    assert(success);
+}
 
 bool array_container_iterate(const array_container_t *cont, uint32_t base,
                              roaring_iterator iterator, void *ptr);

--- a/include/roaring/containers/container_defs.h
+++ b/include/roaring/containers/container_defs.h
@@ -99,6 +99,23 @@ typedef ROARING_CONTAINER_T container_t;
 #define movable_CAST_base(c)   movable_CAST(container_t **, c)
 
 
+/**
+ * At the moment of return()-ing a container, handlers frequently know what
+ * kind of container they have.  This means they don't need to go through a
+ * separate dispatch to re-figure-out the container's type to ask for its
+ * cardinality, in order to free it if it is empty.  This pointer is a fixed
+ * value that is returned to indicate empty containers, heeded by the
+ * container enumeration loop.
+ *
+ * (While using a very low-numbered pointer as a magic number is not strictly
+ * standard C, it is supported by basically all known platforms.  It could
+ * be made standard by pointing at an otherwise-unused global variable, but
+ * that would mean slower comparisons to the constant value.)
+ */
+#define CONTAINER_EMPTY \
+    ((container_t*)32)  // 32-byte alignment should be good enough
+
+
 #ifdef __cplusplus
 } }  // namespace roaring { namespace internal {
 #endif

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -1616,80 +1616,52 @@ static inline container_t *container_lazy_xor(
 ){
     c1 = container_unwrap_shared(c1, &type1);
     c2 = container_unwrap_shared(c2, &type2);
-    container_t *result = NULL;
+
     switch (PAIR_CONTAINER_TYPES(type1, type2)) {
         case CONTAINER_PAIR(BITSET,BITSET):
-            result = bitset_container_create();
-            bitset_container_xor_nocard(
-                const_CAST_bitset(c1), const_CAST_bitset(c2),
-                CAST_bitset(result));  // is lazy
-            *result_type = BITSET_CONTAINER_TYPE;
-            return result;
+            return bitset_bitset_container_lazy_xor(const_CAST_bitset(c1),
+                                                    const_CAST_bitset(c2),
+                                                    result_type);
 
         case CONTAINER_PAIR(ARRAY,ARRAY):
-            *result_type = array_array_container_lazy_xor(
-                                const_CAST_array(c1),
-                                const_CAST_array(c2), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            return array_array_container_lazy_xor(const_CAST_array(c1),
+                                                  const_CAST_array(c2),
+                                                  result_type);
 
-        case CONTAINER_PAIR(RUN,RUN):  // nothing special done yet.
-            return run_run_container_xor(const_CAST_run(c1),
-                                         const_CAST_run(c2),
-                                         result_type);
+        case CONTAINER_PAIR(RUN,RUN):
+            return run_run_container_lazy_xor(const_CAST_run(c1),
+                                              const_CAST_run(c2),
+                                              result_type);
 
         case CONTAINER_PAIR(BITSET,ARRAY):
-            result = bitset_container_create();
-            *result_type = BITSET_CONTAINER_TYPE;
-            array_bitset_container_lazy_xor(const_CAST_array(c2),
-                                            const_CAST_bitset(c1),
-                                            CAST_bitset(result));
-            return result;
+            return array_bitset_container_lazy_xor(const_CAST_array(c2),
+                                                   const_CAST_bitset(c1),
+                                                   result_type);
 
         case CONTAINER_PAIR(ARRAY,BITSET):
-            result = bitset_container_create();
-            *result_type = BITSET_CONTAINER_TYPE;
-            array_bitset_container_lazy_xor(const_CAST_array(c1),
-                                            const_CAST_bitset(c2),
-                                            CAST_bitset(result));
-            return result;
+            return array_bitset_container_lazy_xor(const_CAST_array(c1),
+                                                   const_CAST_bitset(c2),
+                                                   result_type);
 
         case CONTAINER_PAIR(BITSET,RUN):
-            result = bitset_container_create();
-            run_bitset_container_lazy_xor(const_CAST_run(c2),
-                                          const_CAST_bitset(c1),
-                                          CAST_bitset(result));
-            *result_type = BITSET_CONTAINER_TYPE;
-            return result;
+            return run_bitset_container_lazy_xor(const_CAST_run(c2),
+                                                 const_CAST_bitset(c1),
+                                                 result_type);
 
         case CONTAINER_PAIR(RUN,BITSET):
-            result = bitset_container_create();
-            run_bitset_container_lazy_xor(const_CAST_run(c1),
-                                          const_CAST_bitset(c2),
-                                          CAST_bitset(result));
-            *result_type = BITSET_CONTAINER_TYPE;
-            return result;
+            return run_bitset_container_lazy_xor(const_CAST_run(c1),
+                                                 const_CAST_bitset(c2),
+                                                 result_type);
 
         case CONTAINER_PAIR(ARRAY,RUN):
-            result = run_container_create();
-            array_run_container_lazy_xor(const_CAST_array(c1),
-                                         const_CAST_run(c2),
-                                         CAST_run(result));
-            *result_type = RUN_CONTAINER_TYPE;
-            // next line skipped since we are lazy
-            // result = convert_run_to_efficient_container(result, result_type);
-            return result;
+            return array_run_container_lazy_xor(const_CAST_array(c1),
+                                                const_CAST_run(c2),
+                                                result_type);
 
         case CONTAINER_PAIR(RUN,ARRAY):
-            result = run_container_create();
-            array_run_container_lazy_xor(const_CAST_array(c2),
-                                         const_CAST_run(c1),
-                                         CAST_run(result));
-            *result_type = RUN_CONTAINER_TYPE;
-            // next line skipped since we are lazy
-            // result = convert_run_to_efficient_container(result, result_type);
-            return result;
+            return array_run_container_lazy_xor(const_CAST_array(c2),
+                                                const_CAST_run(c1),
+                                                result_type);
 
         default:
             assert(false);

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -1510,73 +1510,52 @@ static inline container_t* container_xor(
 ){
     c1 = container_unwrap_shared(c1, &type1);
     c2 = container_unwrap_shared(c2, &type2);
-    container_t *result = NULL;
+
     switch (PAIR_CONTAINER_TYPES(type1, type2)) {
         case CONTAINER_PAIR(BITSET,BITSET):
-            *result_type = bitset_bitset_container_xor(
-                                const_CAST_bitset(c1),
-                                const_CAST_bitset(c2), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            return bitset_bitset_container_xor(const_CAST_bitset(c1),
+                                               const_CAST_bitset(c2),
+                                               result_type);
 
         case CONTAINER_PAIR(ARRAY,ARRAY):
-            *result_type = array_array_container_xor(
-                                const_CAST_array(c1),
-                                const_CAST_array(c2), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            return array_array_container_xor(const_CAST_array(c1),
+                                             const_CAST_array(c2),
+                                             result_type);
 
         case CONTAINER_PAIR(RUN,RUN):
-            *result_type =
-                run_run_container_xor(const_CAST_run(c1),
-                                      const_CAST_run(c2), &result);
-            return result;
+            return run_run_container_xor(const_CAST_run(c1),
+                                         const_CAST_run(c2), 
+                                         result_type);
 
         case CONTAINER_PAIR(BITSET,ARRAY):
-            *result_type = array_bitset_container_xor(
-                                const_CAST_array(c2),
-                                const_CAST_bitset(c1), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            return array_bitset_container_xor(const_CAST_array(c2),
+                                              const_CAST_bitset(c1),
+                                              result_type);
 
         case CONTAINER_PAIR(ARRAY,BITSET):
-            *result_type = array_bitset_container_xor(
-                                const_CAST_array(c1),
-                                const_CAST_bitset(c2), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            return array_bitset_container_xor(const_CAST_array(c1),
+                                              const_CAST_bitset(c2),
+                                              result_type);
 
         case CONTAINER_PAIR(BITSET,RUN):
-            *result_type = run_bitset_container_xor(
-                                const_CAST_run(c2),
-                                const_CAST_bitset(c1), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            return run_bitset_container_xor(const_CAST_run(c2),
+                                            const_CAST_bitset(c1),
+                                            result_type);
 
         case CONTAINER_PAIR(RUN,BITSET):
-            *result_type = run_bitset_container_xor(
-                                const_CAST_run(c1),
-                                const_CAST_bitset(c2), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            return run_bitset_container_xor(const_CAST_run(c1),
+                                            const_CAST_bitset(c2),
+                                            result_type);
 
         case CONTAINER_PAIR(ARRAY,RUN):
-            *result_type =
-                array_run_container_xor(const_CAST_array(c1),
-                                        const_CAST_run(c2), &result);
-            return result;
+            return array_run_container_xor(const_CAST_array(c1),
+                                           const_CAST_run(c2),
+                                           result_type);
 
         case CONTAINER_PAIR(RUN,ARRAY):
-            *result_type =
-                array_run_container_xor(const_CAST_array(c2),
-                                        const_CAST_run(c1), &result);
-            return result;
+            return array_run_container_xor(const_CAST_array(c2),
+                                           const_CAST_run(c1),
+                                           result_type);
 
         default:
             assert(false);
@@ -1618,12 +1597,10 @@ static inline container_t *container_lazy_xor(
                                     : ARRAY_CONTAINER_TYPE;
             return result;
 
-        case CONTAINER_PAIR(RUN,RUN):
-            // nothing special done yet.
-            *result_type =
-                run_run_container_xor(const_CAST_run(c1),
-                                      const_CAST_run(c2), &result);
-            return result;
+        case CONTAINER_PAIR(RUN,RUN):  // nothing special done yet.
+            return run_run_container_xor(const_CAST_run(c1),
+                                         const_CAST_run(c2),
+                                         result_type);
 
         case CONTAINER_PAIR(BITSET,ARRAY):
             result = bitset_container_create();
@@ -1693,121 +1670,92 @@ static inline container_t *container_lazy_xor(
  * The type of the first container may change. Returns the modified
  * (and possibly new) container
 */
-static inline container_t *container_ixor(
-    container_t *c1, uint8_t type1,
-    const container_t *c2, uint8_t type2,
-    uint8_t *result_type
+static inline void container_ixor(
+    container_t **c1, uint8_t *type1,
+    const container_t *c2, uint8_t type2
 ){
-    c1 = get_writable_copy_if_shared(c1, &type1);
+    *c1 = get_writable_copy_if_shared(*c1, type1);
     c2 = container_unwrap_shared(c2, &type2);
-    container_t *result = NULL;
-    switch (PAIR_CONTAINER_TYPES(type1, type2)) {
+
+    switch (PAIR_CONTAINER_TYPES(*type1, type2)) {
         case CONTAINER_PAIR(BITSET,BITSET):
-            *result_type = bitset_bitset_container_ixor(
-                                CAST_bitset(c1), const_CAST_bitset(c2), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            bitset_bitset_container_ixor(c1, type1, const_CAST_bitset(c2));
+            return;
 
         case CONTAINER_PAIR(ARRAY,ARRAY):
-            *result_type = array_array_container_ixor(
-                                CAST_array(c1), const_CAST_array(c2), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            array_array_container_ixor(c1, type1, const_CAST_array(c2));
+            return;
 
         case CONTAINER_PAIR(RUN,RUN):
-            *result_type = run_run_container_ixor(
-                CAST_run(c1), const_CAST_run(c2), &result);
-            return result;
+            run_run_container_ixor(c1, type1, const_CAST_run(c2));
+            return;
 
         case CONTAINER_PAIR(BITSET,ARRAY):
-            *result_type = bitset_array_container_ixor(
-                                CAST_bitset(c1), const_CAST_array(c2), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            bitset_array_container_ixor(c1, type1, const_CAST_array(c2));
+            return;
 
         case CONTAINER_PAIR(ARRAY,BITSET):
-            *result_type = array_bitset_container_ixor(
-                                CAST_array(c1), const_CAST_bitset(c2), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            array_bitset_container_ixor(c1, type1, const_CAST_bitset(c2));
+            return;
 
         case CONTAINER_PAIR(BITSET,RUN):
-            *result_type =
-                bitset_run_container_ixor(
-                    CAST_bitset(c1), const_CAST_run(c2), &result)
-                        ? BITSET_CONTAINER_TYPE
-                        : ARRAY_CONTAINER_TYPE;
-
-            return result;
+            bitset_run_container_ixor(c1, type1, const_CAST_run(c2));
+            return;
 
         case CONTAINER_PAIR(RUN,BITSET):
-            *result_type = run_bitset_container_ixor(
-                                CAST_run(c1), const_CAST_bitset(c2), &result)
-                                    ? BITSET_CONTAINER_TYPE
-                                    : ARRAY_CONTAINER_TYPE;
-            return result;
+            run_bitset_container_ixor(c1, type1, const_CAST_bitset(c2));
+            return;
 
         case CONTAINER_PAIR(ARRAY,RUN):
-            *result_type = array_run_container_ixor(
-                                CAST_array(c1), const_CAST_run(c2), &result);
-            return result;
+            array_run_container_ixor(c1, type1, const_CAST_run(c2));
+            return;
 
         case CONTAINER_PAIR(RUN,ARRAY):
-            *result_type = run_array_container_ixor(
-                                CAST_run(c1), const_CAST_array(c2), &result);
-            return result;
+            run_array_container_ixor(c1, type1, const_CAST_array(c2));
+            return;
 
         default:
             assert(false);
             __builtin_unreachable();
-            return NULL;
+            return;
     }
 }
 
 /**
  * Compute the xor between two containers, with result in the first container.
- * If the returned pointer is identical to c1, then the container has been
- * modified.
- * If the returned pointer is different from c1, then a new container has been
- * created and the caller is responsible for freeing it.
- * The type of the first container may change. Returns the modified
- * (and possibly new) container
+ * The address and type of the first container may change.
  *
  * This lazy version delays some operations such as the maintenance of the
  * cardinality. It requires repair later on the generated containers.
 */
-static inline container_t *container_lazy_ixor(
-    container_t *c1, uint8_t type1,
-    const container_t *c2, uint8_t type2,
-    uint8_t *result_type
+static inline void container_lazy_ixor(
+    container_t **c1, uint8_t *type1,
+    const container_t *c2, uint8_t type2
 ){
-    assert(type1 != SHARED_CONTAINER_TYPE);
+    assert(*type1 != SHARED_CONTAINER_TYPE);
     // c1 = get_writable_copy_if_shared(c1,&type1);
     c2 = container_unwrap_shared(c2, &type2);
-    switch (PAIR_CONTAINER_TYPES(type1, type2)) {
-        case CONTAINER_PAIR(BITSET,BITSET):
-            bitset_container_xor_nocard(CAST_bitset(c1),
-                                        const_CAST_bitset(c2),
-                                        CAST_bitset(c1));  // is lazy
-            *result_type = BITSET_CONTAINER_TYPE;
-            return c1;
+
+    switch (PAIR_CONTAINER_TYPES(*type1, type2)) {
+        case CONTAINER_PAIR(BITSET,BITSET): {
+            bitset_container_t *bc1 = *movable_CAST_bitset(c1);
+            bitset_container_xor_nocard(bc1, const_CAST_bitset(c2), bc1);
+            assert(*type1 == BITSET_CONTAINER_TYPE);
+            return; }
 
         // TODO: other cases being lazy, esp. when we know inplace not likely
         // could see the corresponding code for union
         default:
             // we may have a dirty bitset (without a precomputed cardinality)
             // and calling container_ixor on it might be unsafe.
-            if (type1 == BITSET_CONTAINER_TYPE) {
-                bitset_container_t *bc = CAST_bitset(c1);
+            if (*type1 == BITSET_CONTAINER_TYPE) {
+                bitset_container_t *bc = *movable_CAST_bitset(c1);
                 if (bc->cardinality == BITSET_UNKNOWN_CARDINALITY) {
                     bc->cardinality = bitset_container_compute_cardinality(bc);
                 }
             }
-            return container_ixor(c1, type1, c2, type2, result_type);
+            container_ixor(c1, type1, c2, type2);
+            return;
     }
 }
 

--- a/include/roaring/containers/mixed_xor.h
+++ b/include/roaring/containers/mixed_xor.h
@@ -61,44 +61,38 @@ container_t *run_run_container_xor(
         uint8_t *result_type);
 
 
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst. It is allowed for src_2 to be dst.  This version does not
- * update the cardinality of dst (it is set to BITSET_UNKNOWN_CARDINALITY).
- */
-
-void array_bitset_container_lazy_xor(const array_container_t *src_1,
-                                     const bitset_container_t *src_2,
-                                     bitset_container_t *dst);
-
-
-/* lazy xor.  Dst is initialized and may be equal to src_2.
- *  Result is left as a bitset container, even if actual
- *  cardinality would dictate an array container.
- */
-
-void run_bitset_container_lazy_xor(const run_container_t *src_1,
-                                   const bitset_container_t *src_2,
-                                   bitset_container_t *dst);
-
-
-/* dst does not initially have a valid container.  Creates either
- * an array or a bitset container, indicated by return code.
- * A bitset container will not have a valid cardinality and the
- * container type might not be correct for the actual cardinality
- */
-
-bool array_array_container_lazy_xor(
-        const array_container_t *src_1, const array_container_t *src_2,
-        container_t **dst);
-
-/* Dst is a valid run container. (Can it be src_2? Let's say not.)
- * Leaves result as run container, even if other options are
+/* LAZY XOR OPERATIONS
+ *
+ * Bitset results will be left as a bitset container, even if actual
+ * cardinality would dictate an array container.  Cardinality may be left
+ * as BITSET_UNKNOWN_CARDINALITY to be calculated on demand.
+ *
+ * Run results will be left as arun container, even if other options are
  * smaller.
  */
 
-void array_run_container_lazy_xor(const array_container_t *src_1,
-                                  const run_container_t *src_2,
-                                  run_container_t *dst);
+container_t *bitset_bitset_container_lazy_xor(
+        const bitset_container_t *bc1, const bitset_container_t *bc2,
+        uint8_t *result_type);
+
+container_t *array_bitset_container_lazy_xor(
+        const array_container_t *ac1, const bitset_container_t *bc2,
+        uint8_t *result_type);
+
+container_t *run_bitset_container_lazy_xor(
+        const run_container_t *rc1, const bitset_container_t *bc2,
+        uint8_t *result_type);
+
+container_t *array_array_container_lazy_xor(
+        const array_container_t *ac1, const array_container_t *ac2,
+        uint8_t *result_type);
+
+run_container_t *array_run_container_lazy_xor(
+        const array_container_t *ac1, const run_container_t *rc2,
+        uint8_t *result_type);
+
+#define run_run_container_lazy_xor \
+        run_run_container_xor  // no `lazy` version yet
 
 
 /* EQUIVALENCIES since order does not matter for non-inplace xor.

--- a/include/roaring/containers/mixed_xor.h
+++ b/include/roaring/containers/mixed_xor.h
@@ -101,6 +101,17 @@ void array_run_container_lazy_xor(const array_container_t *src_1,
                                   run_container_t *dst);
 
 
+/* EQUIVALENCIES since order does not matter for non-inplace xor.
+ */
+
+#define bitset_run_container_xor(c1,c2,t) \
+    run_bitset_container_xor(c2,c1,t)
+
+#define run_array_container_xor(c1,c2,t) \
+    array_run_container_xor(c2,c1,t)
+
+
+
 /* INPLACE versions (initial implementation may not exploit all inplace
  * opportunities (if any...)
  *

--- a/include/roaring/containers/mixed_xor.h
+++ b/include/roaring/containers/mixed_xor.h
@@ -120,39 +120,39 @@ void array_run_container_lazy_xor(const array_container_t *src_1,
  * The type may be modified.
  */
 
-void bitset_array_container_ixor(
+bool bitset_array_container_ixor(
         container_t **c1, uint8_t *type1,
         const array_container_t *ac2);
 
-void bitset_bitset_container_ixor(
+bool bitset_bitset_container_ixor(
         container_t **c1, uint8_t *type1,
         const bitset_container_t *bc2);
 
-void array_bitset_container_ixor(
+bool array_bitset_container_ixor(
         container_t **c1, uint8_t *type1,
         const bitset_container_t *bc2);
 
-void run_bitset_container_ixor(
+bool run_bitset_container_ixor(
         container_t **c1, uint8_t *type1,
         const bitset_container_t *bc2);
 
-void bitset_run_container_ixor(
+bool bitset_run_container_ixor(
         container_t **c1, uint8_t *type1,
         const run_container_t *rc2);
 
-void array_run_container_ixor(
+bool array_run_container_ixor(
         container_t **c1, uint8_t *type1,
         const run_container_t *rc2);
 
-void run_array_container_ixor(
+bool run_array_container_ixor(
         container_t **c1, uint8_t *type1,
         const array_container_t *ac2);
 
-void array_array_container_ixor(
+bool array_array_container_ixor(
         container_t **c1, uint8_t *type1,
         const array_container_t *ac2);
 
-void run_run_container_ixor(
+bool run_run_container_ixor(
         container_t **c1, uint8_t *type1,
         const run_container_t *ac2);
 

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -189,7 +189,14 @@ static inline int32_t rle16_count_greater(const rle16_t* array, int32_t lenarray
  * existing data needs to be copied over depends on copy. If "copy" is false,
  * then the new content will be uninitialized, otherwise a copy is made.
  */
-void run_container_grow(run_container_t *run, int32_t min, bool copy);
+bool run_container_try_grow(run_container_t *run, int32_t min, bool copy);
+
+static inline void run_container_grow(  // !!! temporary
+    run_container_t *run, int32_t min, bool copy
+){
+    bool success = run_container_try_grow(run, min, copy);
+    assert(success);
+}
 
 /**
  * Moves the data so that we can write data at index
@@ -456,11 +463,9 @@ int run_container_intersection_cardinality(const run_container_t *src_1,
 bool run_container_intersect(const run_container_t *src_1,
                                 const run_container_t *src_2);
 
-/* Compute the symmetric difference of `src_1' and `src_2' and write the result
- * to `dst'
- * It is assumed that `dst' is distinct from both `src_1' and `src_2'. */
-void run_container_xor(const run_container_t *src_1,
-                       const run_container_t *src_2, run_container_t *dst);
+/* Compute the symmetric difference of `rc1' and `rc2', NULL if no memory */
+run_container_t *run_container_xor(const run_container_t *rc1,
+                                   const run_container_t *rc2);
 
 /*
  * Write out the 16-bit integers contained in this container as a list of 32-bit

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -16,6 +16,35 @@ An implementation of Roaring Bitmaps in C.
 extern "C" { namespace roaring { namespace api {
 #endif
 
+#define ROARING_ERR_ALLOC_FAILED -1
+
+/**
+ * The easy-to-use API forms do not return failure results.  They are inline
+ * functions (declared in this header) that pass a code to a handler in the
+ * event of a problem.
+ *
+ * These inlines are implemented in terms of core APIs that pass back `NULL`,
+ * or `false`, or an error code when there is a problem.  Clients who wish to
+ * handle errors at the callsites should use those directly...but be sure to
+ * read the notes on each API regarding atomicity guarantees (or lack thereof).
+ *
+ * You may override the function called in the inline helpers by defining
+ * ROARING_FAILURE_HANDLER before including the API.  It defaults to a basic
+ * `roaring_panic()` function that prints out an error message and exits.
+ */ 
+#if !defined ROARING_FAILURE_HANDLER
+    #define ROARING_FAILURE_HANDLER roaring_panic
+#endif
+
+/**
+ * Print out an error message to stdio and call exit()
+ *
+ * This function will not be included if ROARING_NO_PANIC is defined.   That
+ * can be useful for embedded clients that do not want to link to stdio.
+ */
+int roaring_panic(int error_code);
+
+
 typedef struct roaring_bitmap_s {
     roaring_array_t high_low_container;
 } roaring_bitmap_t;

--- a/include/roaring/roaring_array.h
+++ b/include/roaring/roaring_array.h
@@ -129,7 +129,7 @@ bool ra_insert_new_key_value_at(
 /**
  * Append a new key-value pair
  */
-void ra_append(
+bool ra_append(
         roaring_array_t *ra, uint16_t key,
         container_t *c, uint8_t typecode);
 
@@ -145,7 +145,7 @@ void ra_append_copy(roaring_array_t *ra, const roaring_array_t *sa,
  * at indexes
  * [start_index, end_index)
  */
-void ra_append_copy_range(roaring_array_t *ra, const roaring_array_t *sa,
+bool ra_append_copy_range(roaring_array_t *ra, const roaring_array_t *sa,
                           int32_t start_index, int32_t end_index,
                           bool copy_on_write);
 

--- a/include/roaring/roaring_array.h
+++ b/include/roaring/roaring_array.h
@@ -95,6 +95,15 @@ inline int32_t ra_get_index(const roaring_array_t *ra, uint16_t x) {
     return binarySearch(ra->keys, (int32_t)ra->size, x);
 }
 
+
+/**
+ * Accessors for a `container**` and `typecode*` that can be used to update.
+ * Macros for simplicity, but could be inline functions.
+ */
+#define ra_container_slot(ra,i)     &(ra)->containers[i]
+#define ra_typecode_slot(ra,i)      &(ra)->typecodes[i]
+
+
 /**
  * Retrieves the container at index i, filling in the typecode
  */

--- a/include/roaring/roaring_types.h
+++ b/include/roaring/roaring_types.h
@@ -40,6 +40,8 @@ extern "C" { namespace roaring { namespace api {
 
 #define ROARING_FLAG_COW UINT8_C(0x1)
 #define ROARING_FLAG_FROZEN UINT8_C(0x2)
+#define ROARING_FLAG_INDETERMINATE UINT8_C(0x4)  // can only clear()/init()
+
 
 /**
  * Roaring arrays are array-based key-value pairs having containers as values

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(ROARING_SRC
     containers/mixed_xor.c
     containers/mixed_andnot.c
     containers/run.c
+    portability.c
     roaring.c
     roaring_priority_queue.c
     roaring_array.c)

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -31,15 +31,13 @@ extern inline bool array_container_full(const array_container_t *array);
 array_container_t *array_container_create_given_capacity(int32_t size) {
     array_container_t *container;
 
-    if ((container = (array_container_t *)malloc(sizeof(array_container_t))) ==
-        NULL) {
+    if ((container = TRY_ALLOC(array_container_t)) == NULL) {
         return NULL;
     }
 
-    if( size <= 0 ) { // we don't want to rely on malloc(0)
+    if( size <= 0 ) { // we don't want to rely on ALLOC(0)
         container->array = NULL;
-    } else if ((container->array = (uint16_t *)malloc(sizeof(uint16_t) * size)) ==
-        NULL) {
+    } else if ((container->array = TRY_ALLOC_N(uint16_t, size)) == NULL) {
         free(container);
         return NULL;
     }
@@ -126,15 +124,15 @@ void array_container_grow(array_container_t *container, int32_t min,
     uint16_t *array = container->array;
 
     if (preserve) {
-        container->array =
-            (uint16_t *)realloc(array, new_capacity * sizeof(uint16_t));
-        if (container->array == NULL) free(array);
+        container->array = TRY_REALLOC_N(uint16_t, array, new_capacity);
+        if (container->array == NULL)
+            FREE(array);
     } else {
         // Jon Strabala reports that some tools complain otherwise
         if (array != NULL) {
-          free(array);
+            FREE(array);
         }
-        container->array = (uint16_t *)malloc(new_capacity * sizeof(uint16_t));
+        container->array = TRY_ALLOC_N(uint16_t, new_capacity);
     }
 
     //  handle the case where realloc fails

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -46,17 +46,15 @@ void bitset_container_set_all(bitset_container_t *bitset) {
 
 /* Create a new bitset. Return NULL in case of failure. */
 bitset_container_t *bitset_container_create(void) {
-    bitset_container_t *bitset =
-        (bitset_container_t *)malloc(sizeof(bitset_container_t));
-
-    if (!bitset) {
+    bitset_container_t *bitset = TRY_ALLOC(bitset_container_t);
+    if (bitset == NULL) {
         return NULL;
     }
     // sizeof(__m256i) == 32
-    bitset->array = (uint64_t *)roaring_bitmap_aligned_malloc(
-        32, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
-    if (!bitset->array) {
-        free(bitset);
+    bitset->array = TRY_ALIGNED_ALLOC_N(32, uint64_t,
+                                        BITSET_CONTAINER_SIZE_IN_WORDS);
+    if (bitset->array == NULL) {
+        FREE(bitset);
         return NULL;
     }
     bitset_container_clear(bitset);
@@ -102,25 +100,23 @@ void bitset_container_add_from_range(bitset_container_t *bitset, uint32_t min,
 /* Free memory. */
 void bitset_container_free(bitset_container_t *bitset) {
     if(bitset->array != NULL) {// Jon Strabala reports that some tools complain otherwise
-      roaring_bitmap_aligned_free(bitset->array);
+      ALIGNED_FREE(bitset->array);
       bitset->array = NULL; // pedantic
     }
-    free(bitset);
+    FREE(bitset);
 }
 
 /* duplicate container. */
 bitset_container_t *bitset_container_clone(const bitset_container_t *src) {
-    bitset_container_t *bitset =
-        (bitset_container_t *)malloc(sizeof(bitset_container_t));
-
-    if (!bitset) {
+    bitset_container_t *bitset = TRY_ALLOC(bitset_container_t);
+    if (bitset == NULL) {
         return NULL;
     }
     // sizeof(__m256i) == 32
-    bitset->array = (uint64_t *)roaring_bitmap_aligned_malloc(
-        32, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
-    if (!bitset->array) {
-        free(bitset);
+    bitset->array = TRY_ALIGNED_ALLOC_N(32, uint64_t,
+                                        BITSET_CONTAINER_SIZE_IN_WORDS);
+    if (bitset->array == NULL) {
+        FREE(bitset);
         return NULL;
     }
     bitset->cardinality = src->cardinality;

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -24,10 +24,9 @@ extern inline container_t *container_ior(
         const container_t *c2, uint8_t type2,
         uint8_t *result_type);
 
-extern inline container_t *container_ixor(
-        container_t *c1, uint8_t type1,
-        const container_t *c2, uint8_t type2,
-        uint8_t *result_type);
+extern inline void container_ixor(
+        container_t **c1, uint8_t *type1,
+        const container_t *c2, uint8_t type2);
 
 extern inline container_t *container_iandnot(
         container_t *c1, uint8_t type1,
@@ -242,10 +241,9 @@ extern inline container_t *container_lazy_xor(
         const container_t *c2, uint8_t type2,
         uint8_t *result_type);
 
-extern inline container_t *container_lazy_ixor(
-        container_t *c1, uint8_t type1,
-        const container_t *c2, uint8_t type2,
-        uint8_t *result_type);
+extern inline void container_lazy_ixor(
+        container_t **c1, uint8_t *type1,
+        const container_t *c2, uint8_t type2);
 
 extern inline container_t *container_andnot(
         const container_t *c1, uint8_t type1,

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -140,8 +140,7 @@ container_t *get_copy_of_container(
         }
         assert(*typecode != SHARED_CONTAINER_TYPE);
 
-        if ((shared_container = (shared_container_t *)malloc(
-                 sizeof(shared_container_t))) == NULL) {
+        if ((shared_container = TRY_ALLOC(shared_container_t)) == NULL) {
             return NULL;
         }
 

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -24,7 +24,7 @@ extern inline container_t *container_ior(
         const container_t *c2, uint8_t type2,
         uint8_t *result_type);
 
-extern inline void container_ixor(
+extern inline bool container_ixor(
         container_t **c1, uint8_t *type1,
         const container_t *c2, uint8_t type2);
 
@@ -241,7 +241,7 @@ extern inline container_t *container_lazy_xor(
         const container_t *c2, uint8_t type2,
         uint8_t *result_type);
 
-extern inline void container_lazy_ixor(
+extern inline bool container_lazy_ixor(
         container_t **c1, uint8_t *type1,
         const container_t *c2, uint8_t type2);
 

--- a/src/containers/convert.c
+++ b/src/containers/convert.c
@@ -13,6 +13,8 @@ extern "C" { namespace roaring { namespace internal {
 // types.
 bitset_container_t *bitset_container_from_array(const array_container_t *a) {
     bitset_container_t *ans = bitset_container_create();
+    if (ans == NULL)
+        return NULL;
     int limit = array_container_cardinality(a);
     for (int i = 0; i < limit; ++i) bitset_container_set(ans, a->array[i]);
     return ans;
@@ -21,6 +23,8 @@ bitset_container_t *bitset_container_from_array(const array_container_t *a) {
 bitset_container_t *bitset_container_from_run(const run_container_t *arr) {
     int card = run_container_cardinality(arr);
     bitset_container_t *answer = bitset_container_create();
+    if (answer == NULL)
+        return NULL;
     for (int rlepos = 0; rlepos < arr->n_runs; ++rlepos) {
         rle16_t vl = arr->runs[rlepos];
         bitset_set_lenrange(answer->array, vl.value, vl.length);
@@ -32,6 +36,8 @@ bitset_container_t *bitset_container_from_run(const run_container_t *arr) {
 array_container_t *array_container_from_run(const run_container_t *arr) {
     array_container_t *answer =
         array_container_create_given_capacity(run_container_cardinality(arr));
+    if (answer == NULL)
+        return NULL;
     answer->cardinality = 0;
     for (int rlepos = 0; rlepos < arr->n_runs; ++rlepos) {
         int run_start = arr->runs[rlepos].value;

--- a/src/containers/convert.c
+++ b/src/containers/convert.c
@@ -47,6 +47,8 @@ array_container_t *array_container_from_run(const run_container_t *arr) {
 array_container_t *array_container_from_bitset(const bitset_container_t *bits) {
     array_container_t *result =
         array_container_create_given_capacity(bits->cardinality);
+    if (result == NULL)
+        return NULL;
     result->cardinality = bits->cardinality;
     //  sse version ends up being slower here
     // (bitset_extract_setbits_sse_uint16)

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -15,33 +15,32 @@
 extern "C" { namespace roaring { namespace internal {
 #endif
 
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst (which has no container initially).
- * Result is true iff dst is a bitset  */
-bool array_bitset_container_xor(
-    const array_container_t *src_1, const bitset_container_t *src_2,
-    container_t **dst
-){
-    bitset_container_t *result = bitset_container_create();
-    bitset_container_copy(src_2, result);
-    result->cardinality = (int32_t)bitset_flip_list_withcard(
-        result->array, result->cardinality, src_1->array, src_1->cardinality);
 
-    // do required type conversions.
-    if (result->cardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(result);
-        bitset_container_free(result);
-        return false;  // not bitset
+container_t *array_bitset_container_xor(
+    const array_container_t *ac1, const bitset_container_t *bc2,
+    uint8_t *result_type
+){
+    bitset_container_t *new_bc = bitset_container_create();
+    bitset_container_copy(bc2, new_bc);
+    new_bc->cardinality = (int32_t)bitset_flip_list_withcard(
+                                        new_bc->array, new_bc->cardinality,
+                                        ac1->array, ac1->cardinality);
+
+    if (new_bc->cardinality <= DEFAULT_MAX_SIZE) {  // compact into array
+        array_container_t *new_ac = array_container_from_bitset(new_bc);
+        bitset_container_free(new_bc);
+        *result_type = ARRAY_CONTAINER_TYPE;
+        return new_ac;
     }
-    *dst = result;
-    return true;  // bitset
+
+    *result_type = BITSET_CONTAINER_TYPE;
+    return new_bc;
 }
 
 /* Compute the xor of src_1 and src_2 and write the result to
  * dst. It is allowed for src_2 to be dst.  This version does not
  * update the cardinality of dst (it is set to BITSET_UNKNOWN_CARDINALITY).
  */
-
 void array_bitset_container_lazy_xor(const array_container_t *src_1,
                                      const bitset_container_t *src_2,
                                      bitset_container_t *dst) {
@@ -50,41 +49,36 @@ void array_bitset_container_lazy_xor(const array_container_t *src_1,
     dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
 }
 
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst. Result may be either a bitset or an array container
- * (returns "result is bitset"). dst does not initially have
- * any container, but becomes either a bitset container (return
- * result true) or an array container.
- */
 
-bool run_bitset_container_xor(
-    const run_container_t *src_1, const bitset_container_t *src_2,
-    container_t **dst
+container_t *run_bitset_container_xor(
+    const run_container_t *rc1, const bitset_container_t *bc2,
+    uint8_t *result_type  // type of the newly created container returned
 ){
-    bitset_container_t *result = bitset_container_create();
+    bitset_container_t *new_bc = bitset_container_create();
 
-    bitset_container_copy(src_2, result);
-    for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
-        rle16_t rle = src_1->runs[rlepos];
-        bitset_flip_range(result->array, rle.value,
+    bitset_container_copy(bc2, new_bc);
+    for (int32_t rlepos = 0; rlepos < rc1->n_runs; ++rlepos) {
+        rle16_t rle = rc1->runs[rlepos];
+        bitset_flip_range(new_bc->array, rle.value,
                           rle.value + rle.length + UINT32_C(1));
     }
-    result->cardinality = bitset_container_compute_cardinality(result);
+    new_bc->cardinality = bitset_container_compute_cardinality(new_bc);
 
-    if (result->cardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(result);
-        bitset_container_free(result);
-        return false;  // not bitset
+    if (new_bc->cardinality <= DEFAULT_MAX_SIZE) {
+        array_container_t *new_ac = array_container_from_bitset(new_bc);
+        bitset_container_free(new_bc);
+        *result_type = ARRAY_CONTAINER_TYPE;
+        return new_ac;
     }
-    *dst = result;
-    return true;  // bitset
+
+    *result_type = BITSET_CONTAINER_TYPE;
+    return new_bc;
 }
 
 /* lazy xor.  Dst is initialized and may be equal to src_2.
  *  Result is left as a bitset container, even if actual
  *  cardinality would dictate an array container.
  */
-
 void run_bitset_container_lazy_xor(const run_container_t *src_1,
                                    const bitset_container_t *src_2,
                                    bitset_container_t *dst) {
@@ -97,13 +91,9 @@ void run_bitset_container_lazy_xor(const run_container_t *src_1,
     dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
 }
 
-/* dst does not indicate a valid container initially.  Eventually it
- * can become any kind of container.
- */
-
-int array_run_container_xor(
-    const array_container_t *src_1, const run_container_t *src_2,
-    container_t **dst
+container_t *array_run_container_xor(
+    const array_container_t *ac1, const run_container_t *rc2,
+    uint8_t *result_type
 ){
     // semi following Java XOR implementation as of May 2016
     // the C OR implementation works quite differently and can return a run
@@ -112,33 +102,27 @@ int array_run_container_xor(
 
     // use of lazy following Java impl.
     const int arbitrary_threshold = 32;
-    if (src_1->cardinality < arbitrary_threshold) {
-        run_container_t *ans = run_container_create();
-        array_run_container_lazy_xor(src_1, src_2, ans);  // keeps runs.
-        uint8_t typecode_after;
-        *dst =
-            convert_run_to_efficient_container_and_free(ans, &typecode_after);
-        return typecode_after;
+    if (ac1->cardinality < arbitrary_threshold) {
+        run_container_t *new_rc = run_container_create();
+        array_run_container_lazy_xor(ac1, rc2, new_rc);  // keeps runs
+        return convert_run_to_efficient_container_and_free(new_rc, result_type);
     }
 
-    int card = run_container_cardinality(src_2);
+    int card = run_container_cardinality(rc2);
     if (card <= DEFAULT_MAX_SIZE) {
         // Java implementation works with the array, xoring the run elements via
         // iterator
-        array_container_t *temp = array_container_from_run(src_2);
-        bool ret_is_bitset = array_array_container_xor(temp, src_1, dst);
+        array_container_t *temp = array_container_from_run(rc2);
+        container_t *ans = array_array_container_xor(temp, ac1, result_type);
         array_container_free(temp);
-        return ret_is_bitset ? BITSET_CONTAINER_TYPE
-                             : ARRAY_CONTAINER_TYPE;
-
-    } else {  // guess that it will end up as a bitset
-        bitset_container_t *result = bitset_container_from_run(src_2);
-        bool is_bitset = bitset_array_container_ixor(result, src_1, dst);
-        // any necessary type conversion has been done by the ixor
-        int retval = (is_bitset ? BITSET_CONTAINER_TYPE
-                                : ARRAY_CONTAINER_TYPE);
-        return retval;
+        return ans;
     }
+    
+    // guess that it will end up as a bitset
+    container_t *ans = bitset_container_from_run(rc2);
+    *result_type = BITSET_CONTAINER_TYPE;
+    bitset_array_container_ixor(&ans, result_type, ac1);
+    return ans;
 }
 
 /* Dst is a valid run container. (Can it be src_2? Let's say not.)
@@ -176,53 +160,42 @@ void array_run_container_lazy_xor(const array_container_t *src_1,
     }
 }
 
-/* dst does not indicate a valid container initially.  Eventually it
- * can become any kind of container.
- */
 
-int run_run_container_xor(
-    const run_container_t *src_1, const run_container_t *src_2,
-    container_t **dst
+container_t *run_run_container_xor(
+    const run_container_t *rc1, const run_container_t *rc2,
+    uint8_t *result_type
 ){
-    run_container_t *ans = run_container_create();
-    run_container_xor(src_1, src_2, ans);
-    uint8_t typecode_after;
-    *dst = convert_run_to_efficient_container_and_free(ans, &typecode_after);
-    return typecode_after;
+    run_container_t *new_rc = run_container_create();
+    run_container_xor(rc1, rc2, new_rc);
+    return convert_run_to_efficient_container_and_free(new_rc, result_type);
 }
 
-/*
- * Java implementation (as of May 2016) for array_run, run_run
- * and  bitset_run don't do anything different for inplace.
- * Could adopt the mixed_union.c approach instead (ie, using
- * smart_append_exclusive)
- *
- */
-
-bool array_array_container_xor(
-    const array_container_t *src_1, const array_container_t *src_2,
-    container_t **dst
+container_t *array_array_container_xor(
+    const array_container_t *ac1, const array_container_t *ac2,
+    uint8_t *result_type
 ){
-    int totalCardinality =
-        src_1->cardinality + src_2->cardinality;  // upper bound
-    if (totalCardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_create_given_capacity(totalCardinality);
-        array_container_xor(src_1, src_2, CAST_array(*dst));
-        return false;  // not a bitset
+    int ub_card = ac1->cardinality + ac2->cardinality;  // upper bound
+    if (ub_card <= DEFAULT_MAX_SIZE) {
+        array_container_t *new_ac =
+                array_container_create_given_capacity(ub_card);
+        array_container_xor(ac1, ac2, new_ac);
+        *result_type = ARRAY_CONTAINER_TYPE;
+        return new_ac;
     }
-    *dst = bitset_container_from_array(src_1);
-    bool returnval = true;  // expect a bitset
-    bitset_container_t *ourbitset = CAST_bitset(*dst);
-    ourbitset->cardinality = (uint32_t)bitset_flip_list_withcard(
-        ourbitset->array, src_1->cardinality, src_2->array, src_2->cardinality);
-    if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {
-        // need to convert!
-        *dst = array_container_from_bitset(ourbitset);
-        bitset_container_free(ourbitset);
-        returnval = false;  // not going to be a bitset
+    bitset_container_t *new_bc = bitset_container_from_array(ac1);
+    new_bc->cardinality = (uint32_t)bitset_flip_list_withcard(
+                                        new_bc->array, new_bc->cardinality,
+                                        ac2->array, ac2->cardinality);
+
+    if (new_bc->cardinality <= DEFAULT_MAX_SIZE) {  // need to convert!
+        array_container_t *new_ac = array_container_from_bitset(new_bc);
+        bitset_container_free(new_bc);
+        *result_type = ARRAY_CONTAINER_TYPE;
+        return new_ac;
     }
 
-    return returnval;
+    *result_type = BITSET_CONTAINER_TYPE;
+    return new_bc;
 }
 
 bool array_array_container_lazy_xor(
@@ -247,137 +220,140 @@ bool array_array_container_lazy_xor(
     return returnval;
 }
 
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst (which has no container initially). Return value is
- * "dst is a bitset"
- */
 
-bool bitset_bitset_container_xor(
-    const bitset_container_t *src_1, const bitset_container_t *src_2,
-    container_t **dst
+container_t *bitset_bitset_container_xor(
+    const bitset_container_t *bc1, const bitset_container_t *bc2,
+    uint8_t *result_type
 ){
-    bitset_container_t *ans = bitset_container_create();
-    int card = bitset_container_xor(src_1, src_2, ans);
+    bitset_container_t *new_bc = bitset_container_create();
+    int card = bitset_container_xor(bc1, bc2, new_bc);
     if (card <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(ans);
-        bitset_container_free(ans);
-        return false;  // not bitset
+        array_container_t *new_ac = array_container_from_bitset(new_bc);
+        bitset_container_free(new_bc);
+        *result_type = ARRAY_CONTAINER_TYPE;
+        return new_ac;
     } else {
-        *dst = ans;
-        return true;
+        *result_type = BITSET_CONTAINER_TYPE;
+        return new_bc;
     }
 }
 
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst (which has no container initially).  It will modify src_1
- * to be dst if the result is a bitset.  Otherwise, it will
- * free src_1 and dst will be a new array container.  In both
- * cases, the caller is responsible for deallocating dst.
- * Returns true iff dst is a bitset  */
 
-bool bitset_array_container_ixor(
-    bitset_container_t *src_1, const array_container_t *src_2,
-    container_t **dst
-){
-    *dst = src_1;
-    src_1->cardinality = (uint32_t)bitset_flip_list_withcard(
-        src_1->array, src_1->cardinality, src_2->array, src_2->cardinality);
-
-    if (src_1->cardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(src_1);
-        bitset_container_free(src_1);
-        return false;  // not bitset
-    } else
-        return true;
-}
-
-/* a bunch of in-place, some of which may not *really* be inplace.
- * TODO: write actual inplace routine if efficiency warrants it
- * Anything inplace with a bitset is a good candidate
+/**
+ * IN-PLACE XOR COMBINATIONS
+ *
+ * If a tailored in-place implemention is not available, then the plain xor is
+ * used to generate a new container and the old one freed.
+ *
+ * TODO: write more actual inplace routines where efficiency warrants it.
+ * Anything inplace with a bitset is a good candidate.
+ * 
+ * Java implementation (as of May 2016) for array_run, run_run and bitset_run
+ * don't do anything different for inplace.  Could adopt the mixed_union.c
+ * approach instead (ie, using smart_append_exclusive)
  */
 
-bool bitset_bitset_container_ixor(
-    bitset_container_t *src_1, const bitset_container_t *src_2,
-    container_t **dst
+void bitset_array_container_ixor(
+    container_t **c1, uint8_t *type1,
+    const array_container_t *ac2
 ){
-    bool ans = bitset_bitset_container_xor(src_1, src_2, dst);
-    bitset_container_free(src_1);
-    return ans;
+    assert(*type1 == BITSET_CONTAINER_TYPE);
+    bitset_container_t *bc1 = *movable_CAST_bitset(c1);
+
+    bc1->cardinality = (uint32_t)bitset_flip_list_withcard(
+                                        bc1->array, bc1->cardinality,
+                                        ac2->array, ac2->cardinality);
+
+    if (bc1->cardinality <= DEFAULT_MAX_SIZE) {
+        *c1 = array_container_from_bitset(bc1);
+        bitset_container_free(bc1);
+        *type1 = ARRAY_CONTAINER_TYPE;
+        return;
+    }
+
+    assert(*type1 == BITSET_CONTAINER_TYPE);
 }
 
-bool array_bitset_container_ixor(
-    array_container_t *src_1, const bitset_container_t *src_2,
-    container_t **dst
+void bitset_bitset_container_ixor(
+    container_t **c1, uint8_t *type1,
+    const bitset_container_t *bc2
 ){
-    bool ans = array_bitset_container_xor(src_1, src_2, dst);
-    array_container_free(src_1);
-    return ans;
+    assert(*type1 == BITSET_CONTAINER_TYPE);
+    bitset_container_t *bc1 = *movable_CAST_bitset(c1);
+    *c1 = bitset_bitset_container_xor(bc1, bc2, type1);
+    bitset_container_free(bc1);
 }
 
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst. Result may be either a bitset or an array container
- * (returns "result is bitset"). dst does not initially have
- * any container, but becomes either a bitset container (return
- * result true) or an array container.
- */
-
-bool run_bitset_container_ixor(
-    run_container_t *src_1, const bitset_container_t *src_2,
-    container_t **dst
+void array_bitset_container_ixor(
+    container_t **c1, uint8_t *type1,
+    const bitset_container_t *bc2
 ){
-    bool ans = run_bitset_container_xor(src_1, src_2, dst);
-    run_container_free(src_1);
-    return ans;
+    assert(*type1 == ARRAY_CONTAINER_TYPE);
+    array_container_t *ac1 = *movable_CAST_array(c1);
+    *c1 = array_bitset_container_xor(ac1, bc2, type1);
+    array_container_free(ac1);
 }
 
-bool bitset_run_container_ixor(
-    bitset_container_t *src_1, const run_container_t *src_2,
-    container_t **dst
+void run_bitset_container_ixor(
+    container_t **c1, uint8_t *type1,
+    const bitset_container_t *bc2
 ){
-    bool ans = run_bitset_container_xor(src_2, src_1, dst);
-    bitset_container_free(src_1);
-    return ans;
+    assert(*type1 == RUN_CONTAINER_TYPE);
+    run_container_t *rc1 = *movable_CAST_run(c1);
+    *c1 = run_bitset_container_xor(rc1, bc2, type1);
+    run_container_free(rc1);
 }
 
-/* dst does not indicate a valid container initially.  Eventually it
- * can become any kind of container.
- */
-
-int array_run_container_ixor(
-    array_container_t *src_1, const run_container_t *src_2,
-    container_t **dst
+void bitset_run_container_ixor(
+    container_t **c1, uint8_t *type1,
+    const run_container_t *rc2
 ){
-    int ans = array_run_container_xor(src_1, src_2, dst);
-    array_container_free(src_1);
-    return ans;
+    assert(*type1 == BITSET_CONTAINER_TYPE);
+    bitset_container_t *bc1 = *movable_CAST_bitset(c1);
+    *c1 = run_bitset_container_xor(rc2, bc1, type1);
+    bitset_container_free(bc1);
 }
 
-int run_array_container_ixor(
-    run_container_t *src_1, const array_container_t *src_2,
-    container_t **dst
+void array_run_container_ixor(
+    container_t **c1, uint8_t *type1,
+    const run_container_t *rc2
 ){
-    int ans = array_run_container_xor(src_2, src_1, dst);
-    run_container_free(src_1);
-    return ans;
+    assert(*type1 == ARRAY_CONTAINER_TYPE);
+    array_container_t *ac1 = *movable_CAST_array(c1);
+    *c1 = array_run_container_xor(ac1, rc2, type1);
+    array_container_free(ac1);
 }
 
-bool array_array_container_ixor(
-    array_container_t *src_1, const array_container_t *src_2,
-    container_t **dst
+void run_array_container_ixor(
+    container_t **c1, uint8_t *type1,
+    const array_container_t *ac2
 ){
-    bool ans = array_array_container_xor(src_1, src_2, dst);
-    array_container_free(src_1);
-    return ans;
+    assert(*type1 == RUN_CONTAINER_TYPE);
+    run_container_t *rc1 = *movable_CAST_run(c1);
+    *c1 = array_run_container_xor(ac2, rc1, type1);
+    run_container_free(rc1);
 }
 
-int run_run_container_ixor(
-    run_container_t *src_1, const run_container_t *src_2,
-    container_t **dst
+void array_array_container_ixor(
+    container_t **c1, uint8_t *type1,
+    const array_container_t *ac2
 ){
-    int ans = run_run_container_xor(src_1, src_2, dst);
-    run_container_free(src_1);
-    return ans;
+    assert(*type1 == ARRAY_CONTAINER_TYPE);
+    array_container_t *ac1 = *movable_CAST_array(c1);
+    *c1 = array_array_container_xor(ac1, ac2, type1);
+    array_container_free(ac1);
 }
+
+void run_run_container_ixor(
+    container_t **c1, uint8_t *type1,
+    const run_container_t *rc2
+){
+    assert(*type1 == RUN_CONTAINER_TYPE);
+    run_container_t *rc1 = *movable_CAST_run(c1);
+    *c1 = run_run_container_xor(rc1, rc2, type1);
+    run_container_free(rc1);
+}
+
 
 #ifdef __cplusplus
 } } }  // extern "C" { namespace roaring { namespace internal {

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -245,9 +245,6 @@ container_t *bitset_bitset_container_xor(
  * If a tailored in-place implemention is not available, then the plain xor is
  * used to generate a new container and the old one freed.
  *
- * TODO: write more actual inplace routines where efficiency warrants it.
- * Anything inplace with a bitset is a good candidate.
- * 
  * Java implementation (as of May 2016) for array_run, run_run and bitset_run
  * don't do anything different for inplace.  Could adopt the mixed_union.c
  * approach instead (ie, using smart_append_exclusive)
@@ -274,85 +271,21 @@ void bitset_array_container_ixor(
     assert(*type1 == BITSET_CONTAINER_TYPE);
 }
 
-void bitset_bitset_container_ixor(
-    container_t **c1, uint8_t *type1,
-    const bitset_container_t *bc2
-){
-    assert(*type1 == BITSET_CONTAINER_TYPE);
-    bitset_container_t *bc1 = *movable_CAST_bitset(c1);
-    *c1 = bitset_bitset_container_xor(bc1, bc2, type1);
-    bitset_container_free(bc1);
-}
+DECLARE_INPLACE_DEFAULT(bitset, bitset, xor)
 
-void array_bitset_container_ixor(
-    container_t **c1, uint8_t *type1,
-    const bitset_container_t *bc2
-){
-    assert(*type1 == ARRAY_CONTAINER_TYPE);
-    array_container_t *ac1 = *movable_CAST_array(c1);
-    *c1 = array_bitset_container_xor(ac1, bc2, type1);
-    array_container_free(ac1);
-}
+DECLARE_INPLACE_DEFAULT(array, bitset, xor)
 
-void run_bitset_container_ixor(
-    container_t **c1, uint8_t *type1,
-    const bitset_container_t *bc2
-){
-    assert(*type1 == RUN_CONTAINER_TYPE);
-    run_container_t *rc1 = *movable_CAST_run(c1);
-    *c1 = run_bitset_container_xor(rc1, bc2, type1);
-    run_container_free(rc1);
-}
+DECLARE_INPLACE_DEFAULT(run, bitset, xor)
 
-void bitset_run_container_ixor(
-    container_t **c1, uint8_t *type1,
-    const run_container_t *rc2
-){
-    assert(*type1 == BITSET_CONTAINER_TYPE);
-    bitset_container_t *bc1 = *movable_CAST_bitset(c1);
-    *c1 = run_bitset_container_xor(rc2, bc1, type1);
-    bitset_container_free(bc1);
-}
+DECLARE_INPLACE_DEFAULT(bitset, run, xor)
 
-void array_run_container_ixor(
-    container_t **c1, uint8_t *type1,
-    const run_container_t *rc2
-){
-    assert(*type1 == ARRAY_CONTAINER_TYPE);
-    array_container_t *ac1 = *movable_CAST_array(c1);
-    *c1 = array_run_container_xor(ac1, rc2, type1);
-    array_container_free(ac1);
-}
+DECLARE_INPLACE_DEFAULT(array, run, xor)
 
-void run_array_container_ixor(
-    container_t **c1, uint8_t *type1,
-    const array_container_t *ac2
-){
-    assert(*type1 == RUN_CONTAINER_TYPE);
-    run_container_t *rc1 = *movable_CAST_run(c1);
-    *c1 = array_run_container_xor(ac2, rc1, type1);
-    run_container_free(rc1);
-}
+DECLARE_INPLACE_DEFAULT(run, array, xor)
 
-void array_array_container_ixor(
-    container_t **c1, uint8_t *type1,
-    const array_container_t *ac2
-){
-    assert(*type1 == ARRAY_CONTAINER_TYPE);
-    array_container_t *ac1 = *movable_CAST_array(c1);
-    *c1 = array_array_container_xor(ac1, ac2, type1);
-    array_container_free(ac1);
-}
+DECLARE_INPLACE_DEFAULT(array, array, xor)
 
-void run_run_container_ixor(
-    container_t **c1, uint8_t *type1,
-    const run_container_t *rc2
-){
-    assert(*type1 == RUN_CONTAINER_TYPE);
-    run_container_t *rc1 = *movable_CAST_run(c1);
-    *c1 = run_run_container_xor(rc1, rc2, type1);
-    run_container_free(rc1);
-}
+DECLARE_INPLACE_DEFAULT(run, run, xor)
 
 
 #ifdef __cplusplus

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -21,6 +21,8 @@ container_t *array_bitset_container_xor(
     uint8_t *result_type
 ){
     bitset_container_t *new_bc = bitset_container_create();
+    if (new_bc == NULL)
+        return NULL;
     bitset_container_copy(bc2, new_bc);
     new_bc->cardinality = (int32_t)bitset_flip_list_withcard(
                                         new_bc->array, new_bc->cardinality,
@@ -29,6 +31,8 @@ container_t *array_bitset_container_xor(
     if (new_bc->cardinality <= DEFAULT_MAX_SIZE) {  // compact into array
         array_container_t *new_ac = array_container_from_bitset(new_bc);
         bitset_container_free(new_bc);
+        if (new_ac == NULL)
+            return NULL;
         return array_result(result_type, new_ac);
     }
 
@@ -43,6 +47,8 @@ container_t *array_bitset_container_lazy_xor(
     uint8_t *result_type
 ){
     bitset_container_t *new_bc = bitset_container_create();
+    if (new_bc == NULL)
+        return NULL;
 
     bitset_container_copy(bc2, new_bc);
     bitset_flip_list(new_bc->array, ac1->array, ac1->cardinality);
@@ -57,6 +63,8 @@ container_t *run_bitset_container_xor(
     uint8_t *result_type  // type of the newly created container returned
 ){
     bitset_container_t *new_bc = bitset_container_create();
+    if (new_bc == NULL)
+        return NULL;
 
     bitset_container_copy(bc2, new_bc);
     for (int32_t rlepos = 0; rlepos < rc1->n_runs; ++rlepos) {
@@ -69,6 +77,8 @@ container_t *run_bitset_container_xor(
     if (new_bc->cardinality <= DEFAULT_MAX_SIZE) {
         array_container_t *new_ac = array_container_from_bitset(new_bc);
         bitset_container_free(new_bc);
+        if (new_ac == NULL)
+            return NULL;
         return array_result(result_type, new_ac);
     }
 
@@ -83,6 +93,8 @@ container_t *run_bitset_container_lazy_xor(
     uint8_t *result_type
 ){
     bitset_container_t *new_bc = bitset_container_create();
+    if (new_bc == NULL)
+        return NULL;
     bitset_container_copy(bc2, new_bc);
 
     for (int32_t rlepos = 0; rlepos < rc1->n_runs; ++rlepos) {
@@ -109,6 +121,8 @@ container_t *array_run_container_xor(
     if (ac1->cardinality < arbitrary_threshold) {
         run_container_t *new_rc = array_run_container_lazy_xor(ac1, rc2,
                                   result_type);  // keeps runs
+        if (new_rc == NULL)
+            return NULL;
         if (new_rc == CONTAINER_EMPTY)
             return new_rc;
         assert(*result_type == RUN_CONTAINER_TYPE);  // (and not empty)
@@ -120,13 +134,19 @@ container_t *array_run_container_xor(
         // Java implementation works with the array, xoring the run elements via
         // iterator
         array_container_t *temp = array_container_from_run(rc2);
+        if (temp == NULL)
+            return NULL;
         container_t *ans = array_array_container_xor(temp, ac1, result_type);
         array_container_free(temp);
+        if (ans == NULL)
+            return NULL;
         return ans;
     }
     
     // guess that it will end up as a bitset
     container_t *ans = bitset_container_from_run(rc2);
+    if (ans == NULL)
+        return NULL;
     *result_type = BITSET_CONTAINER_TYPE;
     bitset_array_container_ixor(&ans, result_type, ac1);
     return ans;
@@ -141,6 +161,8 @@ run_container_t *array_run_container_lazy_xor(
 ){
     run_container_t *new_rc =
         run_container_create_given_capacity(ac1->cardinality + rc2->n_runs);
+    if (new_rc == NULL)
+        return NULL;
 
     int32_t rlepos = 0;
     int32_t arraypos = 0;
@@ -179,9 +201,9 @@ container_t *run_run_container_xor(
     const run_container_t *rc1, const run_container_t *rc2,
     uint8_t *result_type
 ){
-    run_container_t *new_rc = run_container_create();
-    run_container_xor(rc1, rc2, new_rc);
-
+    run_container_t *new_rc = run_container_xor(rc1, rc2);
+    if (new_rc == NULL)
+        return NULL;
     if (run_container_empty(new_rc)) {
         run_container_free(new_rc);
         TRASH_TYPECODE_IF_DEBUG(result_type);
@@ -198,10 +220,14 @@ container_t *array_array_container_xor(
     if (ub_card <= DEFAULT_MAX_SIZE) {
         array_container_t *new_ac =
                 array_container_create_given_capacity(ub_card);
+        if (new_ac == NULL)
+            return NULL;
         array_container_xor(ac1, ac2, new_ac);
         return array_result(result_type, new_ac);
     }
     bitset_container_t *new_bc = bitset_container_from_array(ac1);
+    if (new_bc == NULL)
+        return NULL;
     new_bc->cardinality = (uint32_t)bitset_flip_list_withcard(
                                         new_bc->array, new_bc->cardinality,
                                         ac2->array, ac2->cardinality);
@@ -209,6 +235,8 @@ container_t *array_array_container_xor(
     if (new_bc->cardinality <= DEFAULT_MAX_SIZE) {  // need to convert!
         array_container_t *new_ac = array_container_from_bitset(new_bc);
         bitset_container_free(new_bc);
+        if (new_ac == NULL)
+            return NULL;
         return array_result(result_type, new_ac);
     }
 
@@ -220,6 +248,8 @@ container_t *bitset_bitset_container_lazy_xor(
     uint8_t *result_type
 ){
     bitset_container_t *new_bc = bitset_container_create();
+    if (new_bc == NULL)
+        return NULL;
     bitset_container_xor_nocard(bc1, bc2, new_bc);  // is lazy
     return bitset_result(result_type, new_bc);
 }
@@ -254,10 +284,14 @@ container_t *bitset_bitset_container_xor(
     uint8_t *result_type
 ){
     bitset_container_t *new_bc = bitset_container_create();
+    if (new_bc == NULL)
+        return NULL;
     int card = bitset_container_xor(bc1, bc2, new_bc);
     if (card <= DEFAULT_MAX_SIZE) {
         array_container_t *new_ac = array_container_from_bitset(new_bc);
         bitset_container_free(new_bc);
+        if (new_ac == NULL)
+            return NULL;
         return array_result(result_type, new_ac);
     } else {
         return bitset_result(result_type, new_bc);

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -250,7 +250,7 @@ container_t *bitset_bitset_container_xor(
  * approach instead (ie, using smart_append_exclusive)
  */
 
-void bitset_array_container_ixor(
+bool bitset_array_container_ixor(
     container_t **c1, uint8_t *type1,
     const array_container_t *ac2
 ){
@@ -262,13 +262,18 @@ void bitset_array_container_ixor(
                                         ac2->array, ac2->cardinality);
 
     if (bc1->cardinality <= DEFAULT_MAX_SIZE) {
-        *c1 = array_container_from_bitset(bc1);
+        array_container_t *ac1 = array_container_from_bitset(bc1);
+        if (ac1 == NULL)
+            return false;
+
+        *c1 = ac1;
         bitset_container_free(bc1);
         *type1 = ARRAY_CONTAINER_TYPE;
-        return;
+        return true;
     }
 
     assert(*type1 == BITSET_CONTAINER_TYPE);
+    return true;
 }
 
 DECLARE_INPLACE_DEFAULT(bitset, bitset, xor)

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -37,16 +37,21 @@ container_t *array_bitset_container_xor(
     return new_bc;
 }
 
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst. It is allowed for src_2 to be dst.  This version does not
- * update the cardinality of dst (it is set to BITSET_UNKNOWN_CARDINALITY).
+/* Compute the xor of ac1 and bc2.  This version does not update the
+ * cardinality of dst (it is set to BITSET_UNKNOWN_CARDINALITY).
  */
-void array_bitset_container_lazy_xor(const array_container_t *src_1,
-                                     const bitset_container_t *src_2,
-                                     bitset_container_t *dst) {
-    if (src_2 != dst) bitset_container_copy(src_2, dst);
-    bitset_flip_list(dst->array, src_1->array, src_1->cardinality);
-    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
+container_t *array_bitset_container_lazy_xor(
+    const array_container_t *ac1, const bitset_container_t *bc2,
+    uint8_t *result_type
+){
+    bitset_container_t *new_bc = bitset_container_create();
+
+    bitset_container_copy(bc2, new_bc);
+    bitset_flip_list(new_bc->array, ac1->array, ac1->cardinality);
+    new_bc->cardinality = BITSET_UNKNOWN_CARDINALITY;
+
+    *result_type = BITSET_CONTAINER_TYPE;
+    return new_bc;
 }
 
 
@@ -75,20 +80,25 @@ container_t *run_bitset_container_xor(
     return new_bc;
 }
 
-/* lazy xor.  Dst is initialized and may be equal to src_2.
- *  Result is left as a bitset container, even if actual
- *  cardinality would dictate an array container.
+/* lazy xor. Result is left as a bitset container, even if actual
+ * cardinality would dictate an array container.
  */
-void run_bitset_container_lazy_xor(const run_container_t *src_1,
-                                   const bitset_container_t *src_2,
-                                   bitset_container_t *dst) {
-    if (src_2 != dst) bitset_container_copy(src_2, dst);
-    for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
-        rle16_t rle = src_1->runs[rlepos];
-        bitset_flip_range(dst->array, rle.value,
+container_t *run_bitset_container_lazy_xor(
+    const run_container_t *rc1, const bitset_container_t *bc2,
+    uint8_t *result_type
+){
+    bitset_container_t *new_bc = bitset_container_create();
+    bitset_container_copy(bc2, new_bc);
+
+    for (int32_t rlepos = 0; rlepos < rc1->n_runs; ++rlepos) {
+        rle16_t rle = rc1->runs[rlepos];
+        bitset_flip_range(new_bc->array, rle.value,
                           rle.value + rle.length + UINT32_C(1));
     }
-    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
+    new_bc->cardinality = BITSET_UNKNOWN_CARDINALITY;
+
+    *result_type = BITSET_CONTAINER_TYPE;
+    return new_bc;
 }
 
 container_t *array_run_container_xor(
@@ -103,8 +113,9 @@ container_t *array_run_container_xor(
     // use of lazy following Java impl.
     const int arbitrary_threshold = 32;
     if (ac1->cardinality < arbitrary_threshold) {
-        run_container_t *new_rc = run_container_create();
-        array_run_container_lazy_xor(ac1, rc2, new_rc);  // keeps runs
+        run_container_t *new_rc = array_run_container_lazy_xor(ac1, rc2,
+                                  result_type);  // keeps runs
+        assert(*result_type == RUN_CONTAINER_TYPE);
         return convert_run_to_efficient_container_and_free(new_rc, result_type);
     }
 
@@ -125,39 +136,47 @@ container_t *array_run_container_xor(
     return ans;
 }
 
-/* Dst is a valid run container. (Can it be src_2? Let's say not.)
- * Leaves result as run container, even if other options are
+/* Leaves result as run container, even if other options are
  * smaller.
  */
+run_container_t *array_run_container_lazy_xor(
+    const array_container_t *ac1, const run_container_t *rc2,
+    uint8_t *result_type  // currently always RUN_CONTAINER_TYPE
+){
+    run_container_t *new_rc = run_container_create();
+    run_container_grow(new_rc, ac1->cardinality + rc2->n_runs, false);
 
-void array_run_container_lazy_xor(const array_container_t *src_1,
-                                  const run_container_t *src_2,
-                                  run_container_t *dst) {
-    run_container_grow(dst, src_1->cardinality + src_2->n_runs, false);
     int32_t rlepos = 0;
     int32_t arraypos = 0;
-    dst->n_runs = 0;
+    new_rc->n_runs = 0;
 
-    while ((rlepos < src_2->n_runs) && (arraypos < src_1->cardinality)) {
-        if (src_2->runs[rlepos].value <= src_1->array[arraypos]) {
-            run_container_smart_append_exclusive(dst, src_2->runs[rlepos].value,
-                                                 src_2->runs[rlepos].length);
+    while ((rlepos < rc2->n_runs) && (arraypos < ac1->cardinality)) {
+        if (rc2->runs[rlepos].value <= ac1->array[arraypos]) {
+            run_container_smart_append_exclusive(new_rc,
+                                                 rc2->runs[rlepos].value,
+                                                 rc2->runs[rlepos].length);
             rlepos++;
         } else {
-            run_container_smart_append_exclusive(dst, src_1->array[arraypos],
+            run_container_smart_append_exclusive(new_rc, ac1->array[arraypos],
                                                  0);
             arraypos++;
         }
     }
-    while (arraypos < src_1->cardinality) {
-        run_container_smart_append_exclusive(dst, src_1->array[arraypos], 0);
+    while (arraypos < ac1->cardinality) {
+        run_container_smart_append_exclusive(new_rc, ac1->array[arraypos], 0);
         arraypos++;
     }
-    while (rlepos < src_2->n_runs) {
-        run_container_smart_append_exclusive(dst, src_2->runs[rlepos].value,
-                                             src_2->runs[rlepos].length);
+    while (rlepos < rc2->n_runs) {
+        run_container_smart_append_exclusive(new_rc, rc2->runs[rlepos].value,
+                                             rc2->runs[rlepos].length);
         rlepos++;
     }
+
+    // Since we are lazy, `convert_run_to_efficient_container` is not called.
+    // Caller must do it if non-lazy.
+    //
+    *result_type = RUN_CONTAINER_TYPE;
+    return new_rc;
 }
 
 
@@ -198,26 +217,40 @@ container_t *array_array_container_xor(
     return new_bc;
 }
 
-bool array_array_container_lazy_xor(
-    const array_container_t *src_1, const array_container_t *src_2,
-    container_t **dst
+container_t *bitset_bitset_container_lazy_xor(
+    const bitset_container_t *bc1, const bitset_container_t *bc2,
+    uint8_t *result_type
 ){
-    int totalCardinality = src_1->cardinality + src_2->cardinality;
+    bitset_container_t *new_bc = bitset_container_create();
+    bitset_container_xor_nocard(bc1, bc2, new_bc);  // is lazy
+    *result_type = BITSET_CONTAINER_TYPE;
+    return new_bc;
+}
+
+container_t *array_array_container_lazy_xor(
+    const array_container_t *ac1, const array_container_t *ac2,
+    uint8_t *result_type
+){
+    int ub_card = ac1->cardinality + ac2->cardinality;
     // upper bound, but probably poor estimate for xor
-    if (totalCardinality <= ARRAY_LAZY_LOWERBOUND) {
-        *dst = array_container_create_given_capacity(totalCardinality);
-        if (*dst != NULL)
-            array_container_xor(src_1, src_2, CAST_array(*dst));
-        return false;  // not a bitset
+    if (ub_card <= ARRAY_LAZY_LOWERBOUND) {
+        array_container_t *new_ac =
+                array_container_create_given_capacity(ub_card);
+        if (new_ac == NULL)
+            return NULL;
+        array_container_xor(ac1, ac2, new_ac);
+        *result_type = ARRAY_CONTAINER_TYPE;
+        return new_ac;
     }
-    *dst = bitset_container_from_array(src_1);
-    bool returnval = true;  // expect a bitset (maybe, for XOR??)
-    if (*dst != NULL) {
-        bitset_container_t *ourbitset = CAST_bitset(*dst);
-        bitset_flip_list(ourbitset->array, src_2->array, src_2->cardinality);
-        ourbitset->cardinality = BITSET_UNKNOWN_CARDINALITY;
-    }
-    return returnval;
+
+    bitset_container_t *new_bc = bitset_container_from_array(ac1);
+    if (new_bc == NULL)
+        return NULL;
+    bitset_flip_list(new_bc->array, ac2->array, ac2->cardinality);
+    new_bc->cardinality = BITSET_UNKNOWN_CARDINALITY;
+
+    *result_type = BITSET_CONTAINER_TYPE;
+    return new_bc;
 }
 
 

--- a/src/portability.c
+++ b/src/portability.c
@@ -1,0 +1,101 @@
+/*
+ * portability.c
+ *
+ * This file contains definitions for non-inlinable contents of portability.h
+ *
+ * At time of writing, that's the function pointer values for hooking the
+ * debug build's malloc()/realloc()/free() at runtime.
+ */
+
+#include "portability.h"
+
+#if !defined NDEBUG
+
+static alloc_hook_t *alloc_hook;
+static realloc_hook_t *realloc_hook;
+static free_hook_t *free_hook;
+static aligned_alloc_hook_t *aligned_alloc_hook;
+static free_hook_t *aligned_free_hook;
+
+// Hooked versions (call default versions if hook is NULL)
+
+void* roaring_debug_alloc(size_t size)
+{
+   if (alloc_hook != NULL)
+       return alloc_hook(size);
+   return malloc(size);
+}
+
+void* roaring_debug_realloc(void *p, size_t size)
+{
+    if (realloc_hook != NULL)
+       return realloc_hook(p, size);
+    return realloc(p, size);
+}
+
+void roaring_debug_free(void *p)
+{
+    if (free_hook != NULL)
+        free_hook(p);
+    else
+        free(p);
+}
+
+void* roaring_debug_aligned_alloc(size_t alignment, size_t size)
+{
+    if (aligned_alloc_hook != NULL)
+       return aligned_alloc_hook(alignment, size);
+    return roaring_bitmap_aligned_malloc(alignment, size);
+}
+
+void roaring_debug_aligned_free(void *p)
+{
+    if (aligned_free_hook != NULL)
+        aligned_free_hook(p);
+    else
+        roaring_bitmap_aligned_free(p);
+}
+
+
+// Functions for setting the hook function pointers
+
+alloc_hook_t *roaring_debug_set_alloc_hook(alloc_hook_t *hook)
+{
+    alloc_hook_t *old = alloc_hook ? alloc_hook : &malloc;
+    alloc_hook = hook;
+    return old;
+}
+
+realloc_hook_t *roaring_debug_set_realloc_hook(realloc_hook_t *hook)
+{
+    realloc_hook_t *old = realloc_hook ? realloc_hook : &realloc;
+    realloc_hook = hook;
+    return old;
+}
+
+free_hook_t *roaring_debug_set_free_hook(free_hook_t *hook)
+{
+    free_hook_t *old = free_hook ? free_hook : &free;
+    free_hook = hook;
+    return old;
+}
+
+aligned_alloc_hook_t *roaring_debug_set_aligned_alloc_hook(aligned_alloc_hook_t *hook)
+{
+    aligned_alloc_hook_t *old = aligned_alloc_hook
+            ? aligned_alloc_hook
+            : &roaring_bitmap_aligned_malloc;
+    aligned_alloc_hook = hook;
+    return old;
+}
+
+free_hook_t *roaring_debug_set_aligned_free_hook(free_hook_t *hook)
+{
+    free_hook_t *old = aligned_free_hook
+            ? aligned_free_hook
+            : &roaring_bitmap_aligned_free;
+    aligned_free_hook = hook;
+    return old;
+}
+
+#endif

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -921,10 +921,9 @@ roaring_bitmap_t *roaring_bitmap_try_xor(
                                     &x2->high_low_container, pos2, &type2);
             container_t *c = container_xor(c1, type1, c2, type2, &result_type);
 
-            if (container_nonzero_cardinality(c, result_type)) {
+            if (c != CONTAINER_EMPTY) {
+                assert(container_nonzero_cardinality(c, result_type));
                 ra_append(&answer->high_low_container, s1, c, result_type);
-            } else {
-                container_free(c, result_type);
             }
             ++pos1;
             ++pos2;
@@ -2263,10 +2262,9 @@ roaring_bitmap_t *roaring_bitmap_lazy_xor(const roaring_bitmap_t *x1,
             container_t *c = container_lazy_xor(
                                     c1, type1, c2, type2, &result_type);
 
-            if (container_nonzero_cardinality(c, result_type)) {
+            if (c != CONTAINER_EMPTY) {
+                assert(container_nonzero_cardinality(c, result_type));
                 ra_append(&answer->high_low_container, s1, c, result_type);
-            } else {
-                container_free(c, result_type);
             }
 
             ++pos1;
@@ -2355,10 +2353,10 @@ static bool xor_inplace_core(
             if (!(*dispatcher)(c1, type1, c2, type2))
                 goto alloc_failure;  // c1 should still be freeable
 
-            if (container_nonzero_cardinality(*c1, *type1)) {
+            if (*c1 != CONTAINER_EMPTY) {
+                assert(container_nonzero_cardinality(*c1, *type1));
                 ++pos1;  // not recycling this slot, so advance to next one
             } else {
-                container_free(*c1, *type1);
                 ra_remove_at_index(&x1->high_low_container, pos1);
                 --length1;
             }

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1005,26 +1005,8 @@ bool roaring_bitmap_xor_inplace_completed(
             container_t *c2 = ra_get_container_at_index(
                                     &x2->high_low_container, pos2, &type2);
 
-            // We do the computation "in place" only when c1 is not a shared container.
-            // Rationale: using a shared container safely with in place computation would 
-            // require making a copy and then doing the computation in place which is likely 
-            // less efficient than avoiding in place entirely and always generating a new 
-            // container.
-
-            if (*type1 == SHARED_CONTAINER_TYPE) {
-                container_t *c = container_xor(*c1, *type1, c2, type2,
-                                               type1);
-                if (c == NULL) {
-                    assert(*type1 == SHARED_CONTAINER_TYPE);
-                    goto alloc_failed;
-                }
-                shared_container_free(CAST_shared(*c1));
-                *c1 = c;
-            }
-            else {
-                if (!container_ixor(c1, type1, c2, type2))
-                    goto alloc_failed;  // c1 should still be freeable
-            }
+            if (!container_ixor(c1, type1, c2, type2))
+                goto alloc_failed;  // c1 should still be freeable
 
             if (container_nonzero_cardinality(*c1, *type1)) {
                 ++pos1;  // not recycling this slot, so advance to next one
@@ -2446,26 +2428,8 @@ bool roaring_bitmap_lazy_xor_inplace_completed(
             container_t *c2 = ra_get_container_at_index(
                                     &x2->high_low_container, pos2, &type2);
  
-            // We do the computation "in place" only when c1 is not a shared container.
-            // Rationale: using a shared container safely with in place computation would 
-            // require making a copy and then doing the computation in place which is likely 
-            // less efficient than avoiding in place entirely and always generating a new 
-            // container.
-
-            if (*type1 == SHARED_CONTAINER_TYPE) {
-                container_t *c = container_lazy_xor(*c1, *type1, c2, type2,
-                                                    type1);
-                if (c == NULL) {
-                    assert(*type1 == SHARED_CONTAINER_TYPE);  // untouched
-                    goto alloc_failure;
-                }
-                shared_container_free(CAST_shared(*c1));
-                *c1 = c;
-            }
-            else {
-                if (!container_lazy_ixor(c1, type1, c2, type2))
-                    goto alloc_failure;
-            }
+            if (!container_lazy_ixor(c1, type1, c2, type2))
+                goto alloc_failure;
         
             if (container_nonzero_cardinality(*c1, *type1)) {
                 ++pos1;  // not recycling this slot, so advance to next one

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2436,7 +2436,7 @@ static bool xor_inplace_core(
 
   alloc_failure:
     ra_reset(&x1->high_low_container);
-    ra_mark_corrupt(&x1->high_low_container);
+    ra_mark_indeterminate(&x1->high_low_container);
     return false;
 }
 

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -989,7 +989,9 @@ void roaring_bitmap_xor_inplace(roaring_bitmap_t *x1,
                 shared_container_free((shared_container_t *)c1);  // so release
             }
             else {
-                c = container_ixor(c1, type1, c2, type2, &result_type);
+                result_type = type1;
+                c = c1;
+                container_ixor(&c, &result_type, c2, type2);
             }
 
             if (container_nonzero_cardinality(c, result_type)) {
@@ -2415,7 +2417,9 @@ void roaring_bitmap_lazy_xor_inplace(roaring_bitmap_t *x1,
                 shared_container_free((shared_container_t *)c1);  // release
             }
             else {
-                c = container_lazy_ixor(c1, type1, c2, type2, &result_type);
+                result_type = type1;
+                c = c1;
+                container_lazy_ixor(&c, &result_type, c2, type2);
             }
         
             if (container_nonzero_cardinality(c, result_type)) {

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -18,6 +18,23 @@ using namespace ::roaring::internal;
 extern "C" { namespace roaring { namespace api {
 #endif
 
+#if !defined(ROARING_NO_PANIC)
+int roaring_panic(int id) {
+    switch (id) {
+      case ROARING_ERR_ALLOC_FAILED:
+        fprintf(stderr, "Allocation Failed in Roaring Bitmaps\n");
+        break;
+
+      default:
+        fprintf(stderr, "Unknown Error in Roaring Bitmaps\n");
+        break;
+    }
+    fprintf(stderr, "https://github.com/RoaringBitmap/CRoaring/issues/174\n");
+    exit(EXIT_FAILURE);
+}
+#endif
+
+
 extern inline bool roaring_bitmap_contains(const roaring_bitmap_t *r,
                                            uint32_t val);
 extern inline bool roaring_bitmap_get_copy_on_write(const roaring_bitmap_t* r);

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -119,7 +119,7 @@ bool ra_overwrite(const roaring_array_t *source, roaring_array_t *dest,
     }
     if (dest->allocation_size < source->size) {
         if (!realloc_array(dest, source->size)) {
-            ra_mark_corrupt(dest);
+            ra_mark_indeterminate(dest);
             return false;
         }
     }
@@ -147,7 +147,7 @@ bool ra_overwrite(const roaring_array_t *source, roaring_array_t *dest,
                     container_free(dest->containers[j], dest->typecodes[j]);
                 }
                 ra_clear_without_containers(dest);
-                ra_mark_corrupt(dest);
+                ra_mark_indeterminate(dest);
                 return false;
             }
         }

--- a/src/roaring_priority_queue.c
+++ b/src/roaring_priority_queue.c
@@ -41,9 +41,9 @@ static void pq_add(roaring_pq_t *pq, roaring_pq_element_t *t) {
 }
 
 static void pq_free(roaring_pq_t *pq) {
-    free(pq->elements);
+    FREE(pq->elements);
     pq->elements = NULL;  // paranoid
-    free(pq);
+    FREE(pq);
 }
 
 static void percolate_down(roaring_pq_t *pq, uint32_t i) {
@@ -70,9 +70,8 @@ static void percolate_down(roaring_pq_t *pq, uint32_t i) {
 }
 
 static roaring_pq_t *create_pq(const roaring_bitmap_t **arr, uint32_t length) {
-    roaring_pq_t *answer = (roaring_pq_t *)malloc(sizeof(roaring_pq_t));
-    answer->elements =
-        (roaring_pq_element_t *)malloc(sizeof(roaring_pq_element_t) * length);
+    roaring_pq_t *answer = TRY_ALLOC(roaring_pq_t);
+    answer->elements = TRY_ALLOC_N(roaring_pq_element_t, length);
     answer->size = length;
     for (uint32_t i = 0; i < length; i++) {
         answer->elements[i].bitmap = (roaring_bitmap_t *)arr[i];

--- a/tests/array_container_unit.c
+++ b/tests/array_container_unit.c
@@ -14,7 +14,7 @@
     using namespace roaring::internal;
 #endif
 
-#include "test.h"
+#include "test.inc"
 
 
 DEFINE_TEST(printf_test) {

--- a/tests/bitset_container_unit.c
+++ b/tests/bitset_container_unit.c
@@ -16,7 +16,7 @@
     using namespace roaring::internal;
 #endif
 
-#include "test.h"
+#include "test.inc"
 
 
 DEFINE_TEST(test_bitset_lenrange_cardinality) {

--- a/tests/container_comparison_unit.c
+++ b/tests/container_comparison_unit.c
@@ -18,7 +18,7 @@
     using namespace roaring::internal;
 #endif
 
-#include "test.h"
+#include "test.inc"
 
 
 static inline void container_checked_add(container_t *container, uint16_t val,

--- a/tests/cpp_random_unit.cpp
+++ b/tests/cpp_random_unit.cpp
@@ -69,7 +69,7 @@ Roaring make_random_bitset() {
 
           case 2: {
             uint32_t start = gravity + (rand() % 50) - 25;
-            r.flip(start, rand() % 50);
+            r.flip(start, start + rand() % 50);
             break; }
 
           case 3: {  // tests remove(), select(), rank()
@@ -228,7 +228,7 @@ DEFINE_TEST(random_doublecheck_test) {
                 gravity = element;
             }
             uint32_t start = gravity + (rand() % 50) - 25;
-            out.flip(start, rand() % 50);
+            out.flip(start, start + rand() % 50);
             break; }
 
           default:

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -18,7 +18,7 @@ using roaring::Roaring;  // the C++ wrapper class
 #include "roaring64map.hh"
 using roaring::Roaring64Map;  // C++ class extended for 64-bit numbers
 
-#include "test.h"
+#include "test.inc"
 
 
 static_assert(std::is_nothrow_move_constructible<Roaring>::value,

--- a/tests/format_portability_unit.c
+++ b/tests/format_portability_unit.c
@@ -12,7 +12,7 @@
 
 #include "config.h"
 
-#include "test.h"
+#include "test.inc"
 
 
 long filesize(char const* path) {

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -149,24 +149,18 @@ DEFINE_TEST(array_bitset_and_or_xor_andnot_test) {
 
     CT = 255;
     C = array_bitset_container_xor(A2, B2, &CT);
-    // xoring something with itself, getting array
-    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
-    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-    array_container_free(CAST_array(C));
+    // xoring something with itself, getting empty back
+    assert_ptr_equal(C, CONTAINER_EMPTY);
 
     CT = 255;
     C = array_array_container_xor(A2, A2, &CT);
-    // xoring array with itself, getting array
-    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
-    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-    array_container_free(CAST_array(C));
+    // xoring array with itself, getting empty back
+    assert_ptr_equal(C, CONTAINER_EMPTY);
 
     CT = 255;
     C = bitset_bitset_container_xor(B2, B2, &CT);
-    // xoring bitset with itself, getting array
-    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
-    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-    array_container_free(CAST_array(C));
+    // xoring bitset with itself, getting empty back
+    assert_ptr_equal(C, CONTAINER_EMPTY);
 
     array_bitset_container_andnot(A1, B2, AM);
     assert_int_equal(cm, array_container_cardinality(AM));
@@ -401,11 +395,9 @@ DEFINE_TEST(array_bitset_ixor_test) {
 
     C = A1;
     CT = ARRAY_CONTAINER_TYPE;
-    // xoring something with itself, getting array
+    // xoring something with itself, getting empty back
     array_bitset_container_ixor(&C, &CT, B1);
-    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
-    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-    array_container_free(CAST_array(C));
+    assert_ptr_equal(C, CONTAINER_EMPTY);
 
     C = B1mod;
     CT = BITSET_CONTAINER_TYPE;
@@ -602,23 +594,17 @@ DEFINE_TEST(run_xor_test) {
 
     CT = 255;
     C = run_bitset_container_xor(R1, B1, &CT);
-    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
-    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-    array_container_free(CAST_array(C));
+    assert_ptr_equal(C, CONTAINER_EMPTY);
 
     CT = 255;
     C = array_run_container_xor(A1, R1, &CT);
-    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
-    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-    array_container_free(CAST_array(C));
+    assert_ptr_equal(C, CONTAINER_EMPTY);
 
     // both run coding and array coding have same serialized size for
     // empty
     CT = 255;
     C = run_run_container_xor(R1, R1, &CT);
-    assert_int_equal(RUN_CONTAINER_TYPE, CT);
-    assert_int_equal(0, run_container_cardinality(CAST_run(C)));
-    run_container_free(CAST_run(C));
+    assert_ptr_equal(C, CONTAINER_EMPTY);
 
     CT = 255;
     C = run_bitset_container_xor(R1, B3, &CT);
@@ -990,46 +976,30 @@ DEFINE_TEST(run_ixor_test) {
     C = run_container_clone(R1);
     CT = RUN_CONTAINER_TYPE;
     run_bitset_container_ixor(&C, &CT, B1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
-    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-    array_container_free(CAST_array(C));
-
+    assert_ptr_equal(C, CONTAINER_EMPTY);
     
     C = bitset_container_create();
     CT = BITSET_CONTAINER_TYPE;
     bitset_container_copy(B1, CAST_bitset(C));
     bitset_run_container_ixor(&C, &CT, R1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
-    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-    array_container_free(CAST_array(C));
+    assert_ptr_equal(C, CONTAINER_EMPTY);
 
     C = array_container_clone(A1);
     CT = ARRAY_CONTAINER_TYPE;
     array_run_container_ixor(&C, &CT, R1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
-    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-    array_container_free(CAST_array(C));
+    assert_ptr_equal(C, CONTAINER_EMPTY);
 
     C = run_container_clone(R1);
     CT = RUN_CONTAINER_TYPE;
     run_array_container_ixor(&C, &CT, A1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
-    assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-    array_container_free(CAST_array(C));
+    assert_ptr_equal(C, CONTAINER_EMPTY);
  
     // both run coding and array coding have same serialized size for
     // empty
     C = run_container_clone(R1);
     CT = RUN_CONTAINER_TYPE;
     run_run_container_ixor(&C, &CT, R1);
-    assert_int_not_equal(BITSET_CONTAINER_TYPE, CT);
-    if (CT == RUN_CONTAINER_TYPE) {
-        assert_int_equal(0, run_container_cardinality(CAST_run(C)));
-        run_container_free(CAST_run(C));
-    } else {
-        assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-        array_container_free(CAST_array(C));
-    }
+    assert_ptr_equal(C, CONTAINER_EMPTY);
 
     C = run_container_clone(R1);
     CT = RUN_CONTAINER_TYPE;

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -19,7 +19,7 @@
     using namespace roaring::internal;
 #endif
 
-#include "test.h"
+#include "test.inc"
 
 
 //#define UNVERBOSE_MIXED_CONTAINER

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -249,7 +249,6 @@ DEFINE_TEST(array_bitset_run_lazy_xor_test) {
     array_container_t* AX = array_container_create();
     bitset_container_t* B1 = bitset_container_create();
     bitset_container_t* B2 = bitset_container_create();
-    bitset_container_t* B2copy = bitset_container_create();
     bitset_container_t* BX = bitset_container_create();
     run_container_t* R1 = run_container_create();
     run_container_t* R2 = run_container_create();
@@ -266,7 +265,6 @@ DEFINE_TEST(array_bitset_run_lazy_xor_test) {
     for (int x = 0; x < (1 << 16); x += 62) {
         array_container_add(A2, x);
         bitset_container_set(B2, x);
-        bitset_container_set(B2copy, x);
         run_container_add(R2, x);
     }
 
@@ -280,38 +278,53 @@ DEFINE_TEST(array_bitset_run_lazy_xor_test) {
     // we interleave O and I on purpose (to trigger bugs!)
     int cx = array_container_cardinality(AX);  // expected xor
 
-    array_bitset_container_lazy_xor(A1, B2, BX);
-    assert_int_equal(BITSET_UNKNOWN_CARDINALITY,
-                     bitset_container_cardinality(BX));
-    assert_int_equal(cx, bitset_container_compute_cardinality(BX));
+    uint8_t CT;
+    container_t *C;
 
-    array_bitset_container_lazy_xor(A1, B2, B2);  // result onto B2, allowed
+    CT = 255;
+    C = array_bitset_container_lazy_xor(A1, B2, &CT);
+    assert(CT == BITSET_CONTAINER_TYPE);
     assert_int_equal(BITSET_UNKNOWN_CARDINALITY,
-                     bitset_container_cardinality(B2));
-    assert_int_equal(cx, bitset_container_compute_cardinality(B2));
-    bitset_container_copy(B2copy, B2);
+                     bitset_container_cardinality(CAST_bitset(C)));
+    assert_int_equal(cx, bitset_container_compute_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
 
-    run_bitset_container_lazy_xor(R1, B2, BX);
+    CT = 255;
+    C = array_bitset_container_lazy_xor(A1, B2, &CT);
+    assert(CT == BITSET_CONTAINER_TYPE);
     assert_int_equal(BITSET_UNKNOWN_CARDINALITY,
-                     bitset_container_cardinality(BX));
-    assert_int_equal(cx, bitset_container_compute_cardinality(BX));
+                     bitset_container_cardinality(CAST_bitset(C)));
+    assert_int_equal(cx, bitset_container_compute_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
 
-    run_bitset_container_lazy_xor(
-        R1, B2, B2);  // result onto B2 : not sure it's allowed
+    CT = 255;
+    C = run_bitset_container_lazy_xor(R1, B2, &CT);
+    assert(CT == BITSET_CONTAINER_TYPE);
     assert_int_equal(BITSET_UNKNOWN_CARDINALITY,
-                     bitset_container_cardinality(B2));
-    assert_int_equal(cx, bitset_container_compute_cardinality(B2));
-    bitset_container_copy(B2copy, B2);
+                     bitset_container_cardinality(CAST_bitset(C)));
+    assert_int_equal(cx, bitset_container_compute_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
 
-    container_t *ans = 0;
-    assert_true(array_array_container_lazy_xor(A1, A2, &ans));
+    CT = 255;
+    C = run_bitset_container_lazy_xor(R1, B2, &CT);
+    assert(CT == BITSET_CONTAINER_TYPE);
     assert_int_equal(BITSET_UNKNOWN_CARDINALITY,
-                     bitset_container_cardinality(CAST_bitset(ans)));
-    assert_int_equal(cx, bitset_container_compute_cardinality(CAST_bitset(ans)));
-    bitset_container_free(CAST_bitset(ans));
+                     bitset_container_cardinality(CAST_bitset(C)));
+    assert_int_equal(cx, bitset_container_compute_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
 
-    array_run_container_lazy_xor(A1, R2, RX);  // destroys content of RX
-    assert_int_equal(cx, run_container_cardinality(RX));
+    CT = 255;
+    C = array_array_container_lazy_xor(A1, A2, &CT);
+    assert(CT == BITSET_CONTAINER_TYPE);
+    assert_int_equal(BITSET_UNKNOWN_CARDINALITY,
+                     bitset_container_cardinality(CAST_bitset(C)));
+    assert_int_equal(cx, bitset_container_compute_cardinality(CAST_bitset(C)));
+    bitset_container_free(CAST_bitset(C));
+
+    C = array_run_container_lazy_xor(A1, R2, &CT);
+    assert(CT == RUN_CONTAINER_TYPE);
+    assert_int_equal(cx, run_container_cardinality(CAST_run(C)));
+    run_container_free(CAST_run(C));
 
     array_container_free(A1);
     array_container_free(A2);
@@ -319,7 +332,6 @@ DEFINE_TEST(array_bitset_run_lazy_xor_test) {
 
     bitset_container_free(B1);
     bitset_container_free(B2);
-    bitset_container_free(B2copy);
     bitset_container_free(BX);
 
     run_container_free(R1);

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -120,46 +120,53 @@ DEFINE_TEST(array_bitset_and_or_xor_andnot_test) {
     array_bitset_container_union(A2, B1, BO);
     assert_int_equal(co, bitset_container_cardinality(BO));
 
-    container_t* C = NULL;
+    uint8_t CT;
+    container_t *C;
 
-    assert_true(array_bitset_container_xor(A1, B2, &C));
+    CT = 255;
+    C = array_bitset_container_xor(A1, B2, &CT);
+    assert_int_equal(CT, BITSET_CONTAINER_TYPE);
     assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
-
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
-    assert_true(array_bitset_container_xor(A2, B1, &C));
+
+    CT = 255;
+    C = array_bitset_container_xor(A2, B1, &CT);
+    assert_int_equal(CT, BITSET_CONTAINER_TYPE);
     assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
-
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
-    assert_true(array_array_container_xor(A2, A1, &C));
+
+    CT = 255;
+    C = array_array_container_xor(A2, A1, &CT);
+    assert_int_equal(CT, BITSET_CONTAINER_TYPE);
     assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
-
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
-    assert_true(bitset_bitset_container_xor(B2, B1, &C));
+
+    CT = 255;
+    C = bitset_bitset_container_xor(B2, B1, &CT);
+    assert_int_equal(CT, BITSET_CONTAINER_TYPE);
     assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
-
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
+
+    CT = 255;
+    C = array_bitset_container_xor(A2, B2, &CT);
     // xoring something with itself, getting array
-    assert_false(array_bitset_container_xor(A2, B2, &C));
+    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
     assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-
     array_container_free(CAST_array(C));
-    C = NULL;
+
+    CT = 255;
+    C = array_array_container_xor(A2, A2, &CT);
     // xoring array with itself, getting array
-    assert_false(array_array_container_xor(A2, A2, &C));
+    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
     assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-
     array_container_free(CAST_array(C));
-    C = NULL;
+
+    CT = 255;
+    C = bitset_bitset_container_xor(B2, B2, &CT);
     // xoring bitset with itself, getting array
-    assert_false(bitset_bitset_container_xor(B2, B2, &C));
+    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
     assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-
     array_container_free(CAST_array(C));
-    C = NULL;
 
     array_bitset_container_andnot(A1, B2, AM);
     assert_int_equal(cm, array_container_cardinality(AM));
@@ -231,7 +238,7 @@ DEFINE_TEST(array_bitset_and_or_xor_andnot_test) {
     bitset_container_free(BX);
     bitset_container_free(BM);
     bitset_container_free(BM1);
-    // bitset_container_free(CAST_bitset(C));
+    // bitset_container_free(C);
 }
 
 // all xor routines with lazy option
@@ -359,37 +366,49 @@ DEFINE_TEST(array_bitset_ixor_test) {
 
     int cx = array_container_cardinality(AX);  // expected xor
 
-    container_t* C = NULL;
+    container_t* C;
+    uint8_t CT;
 
-    assert_true(bitset_array_container_ixor(B2, A1, &C));
+    C = B2;
+    CT = BITSET_CONTAINER_TYPE;
+    bitset_array_container_ixor(&C, &CT, A1);
+    assert_int_equal(CT, BITSET_CONTAINER_TYPE);
     assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
     // this case, result is inplace
     assert_ptr_equal(C, B2);
 
-    C = NULL;
-    assert_true(array_bitset_container_ixor(A2, B1, &C));
+    C = A2;
+    CT = ARRAY_CONTAINER_TYPE;
+    array_bitset_container_ixor(&C, &CT, B1);
+    assert_int_equal(CT, BITSET_CONTAINER_TYPE);
     assert_int_equal(cx, bitset_container_cardinality(CAST_bitset(C)));
     assert_ptr_not_equal(C, A2);  // nb A2 is destroyed
     // don't test a case where result can fit in the array
     // until this is implemented...at that point, make sure
-
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
+
+    C = A1;
+    CT = ARRAY_CONTAINER_TYPE;
     // xoring something with itself, getting array
-    assert_false(array_bitset_container_ixor(A1, B1, &C));
+    array_bitset_container_ixor(&C, &CT, B1);
+    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
     assert_int_equal(0, array_container_cardinality(CAST_array(C)));
-
     array_container_free(CAST_array(C));
-    C = NULL;
 
+    C = B1mod;
+    CT = BITSET_CONTAINER_TYPE;
     // B1mod and B1copy differ in position 2 only
-    assert_false(bitset_bitset_container_ixor(B1mod, B1copy, &C));
+    bitset_bitset_container_ixor(&C, &CT, B1copy);
+    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
     assert_int_equal(1, array_container_cardinality(CAST_array(C)));
-
     array_container_free(CAST_array(C));
-    C = NULL;
-    assert_false(array_array_container_ixor(A1mod, A1copy, &C));
+
+    C = A1mod;
+    CT = ARRAY_CONTAINER_TYPE;
+    array_array_container_ixor(&C, &CT, A1copy);
+    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
     assert_int_equal(1, array_container_cardinality(CAST_array(C)));
+    array_container_free(CAST_array(C));
 
     // array_container_free(A1); // disposed already
     //    array_container_free(A2); // has been disposed already
@@ -400,7 +419,6 @@ DEFINE_TEST(array_bitset_ixor_test) {
     bitset_container_free(B1copy);
     bitset_container_free(B2);
     bitset_container_free(BX);
-    array_container_free(CAST_array(C));
 }
 
 DEFINE_TEST(array_bitset_iandnot_test) {
@@ -567,95 +585,100 @@ DEFINE_TEST(run_xor_test) {
 
     int cx12 = array_container_cardinality(AX);  // expected xor for ?1 and ?2
 
-    container_t* C = NULL;
+    container_t* C;
+    uint8_t CT;
 
-    assert_false(run_bitset_container_xor(R1, B1, &C));
+    CT = 255;
+    C = run_bitset_container_xor(R1, B1, &CT);
+    assert_int_equal(CT, ARRAY_CONTAINER_TYPE);
     assert_int_equal(0, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     array_run_container_xor(A1, R1, &C));
+    CT = 255;
+    C = array_run_container_xor(A1, R1, &CT);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(0, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
     // both run coding and array coding have same serialized size for
     // empty
-    assert_int_equal(RUN_CONTAINER_TYPE,
-                     run_run_container_xor(R1, R1, &C));
+    CT = 255;
+    C = run_run_container_xor(R1, R1, &CT);
+    assert_int_equal(RUN_CONTAINER_TYPE, CT);
     assert_int_equal(0, run_container_cardinality(CAST_run(C)));
     run_container_free(CAST_run(C));
-    C = NULL;
 
-    assert_false(run_bitset_container_xor(R1, B3, &C));
+    CT = 255;
+    C = run_bitset_container_xor(R1, B3, &CT);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     array_run_container_xor(A3, R1, &C));
+    CT = 255;
+    C = array_run_container_xor(A3, R1, &CT);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     run_run_container_xor(R1, R3, &C));
+    CT = 255;
+    C = run_run_container_xor(R1, R3, &CT);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    assert_true(run_bitset_container_xor(R1, B2, &C));
+    CT = 255;
+    C = run_bitset_container_xor(R1, B2, &CT);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    assert_int_equal(BITSET_CONTAINER_TYPE,
-                     array_run_container_xor(A2, R1, &C));
+    CT = 255;
+    C = array_run_container_xor(A2, R1, &CT);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
     array_container_t* A_small = array_container_create();
     for (int i = 1000; i < 1010; ++i) array_container_add(A_small, i);
 
-    assert_int_equal(RUN_CONTAINER_TYPE,
-                     array_run_container_xor(A_small, R2, &C));
-    assert_int_equal(0x98bd,
-                     run_container_cardinality(CAST_run(C)));
+    CT = 255;
+    C = array_run_container_xor(A_small, R2, &CT);
+    assert_int_equal(RUN_CONTAINER_TYPE, CT);
+    assert_int_equal(0x98bd, run_container_cardinality(CAST_run(C)));
     run_container_free(CAST_run(C));
-    C = NULL;
 
-    assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_run_container_xor(R1, R2, &C));
+    array_container_free(A_small);
+
+    CT = 255;
+    C = run_run_container_xor(R1, R2, &CT);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    assert_true(run_bitset_container_xor(R4, B3, &C));
+    CT = 255;
+    C = run_bitset_container_xor(R4, B3, &CT);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     int card_3_4 = bitset_container_cardinality(CAST_bitset(C));
-    // assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
+    // assert_int_equal(card_3_4, bitset_container_cardinality(C));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    assert_int_equal(BITSET_CONTAINER_TYPE,
-                     array_run_container_xor(A3, R4, &C));
+    CT = 255;
+    C = array_run_container_xor(A3, R4, &CT);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     // if this fails, either this bitset is wrong or the previous one...
     assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_run_container_xor(R4, R3, &C));
+    CT = 255;
+    C = run_run_container_xor(R4, R3, &CT);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
     array_container_free(A1);
     array_container_free(A2);
     array_container_free(A3);
     array_container_free(AX);
-    array_container_free(A_small);
 
     bitset_container_free(B1);
     bitset_container_free(B2);
@@ -949,152 +972,162 @@ DEFINE_TEST(run_ixor_test) {
 
     int cx12 = array_container_cardinality(AX);  // expected xor for ?1 and ?2
 
-    container_t* C = NULL;
+    uint8_t CT;
+    container_t *C;
 
-    run_container_t* temp_r = run_container_clone(R1);
-    assert_false(run_bitset_container_ixor(temp_r, B1, &C));
+    C = run_container_clone(R1);
+    CT = RUN_CONTAINER_TYPE;
+    run_bitset_container_ixor(&C, &CT, B1);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(0, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    bitset_container_t* temp_b = bitset_container_create();
-    bitset_container_copy(B1, temp_b);
-    assert_false(bitset_run_container_ixor(temp_b, R1, &C));
+    
+    C = bitset_container_create();
+    CT = BITSET_CONTAINER_TYPE;
+    bitset_container_copy(B1, CAST_bitset(C));
+    bitset_run_container_ixor(&C, &CT, R1);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(0, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    array_container_t* temp_a = array_container_clone(A1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     array_run_container_ixor(temp_a, R1, &C));
+    C = array_container_clone(A1);
+    CT = ARRAY_CONTAINER_TYPE;
+    array_run_container_ixor(&C, &CT, R1);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(0, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    temp_r = run_container_clone(R1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     run_array_container_ixor(temp_r, A1, &C));
+    C = run_container_clone(R1);
+    CT = RUN_CONTAINER_TYPE;
+    run_array_container_ixor(&C, &CT, A1);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(0, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
-
+ 
     // both run coding and array coding have same serialized size for
     // empty
-    temp_r = run_container_clone(R1);
-    int ret_type = run_run_container_ixor(temp_r, R1, &C);
-    assert_int_not_equal(BITSET_CONTAINER_TYPE, ret_type);
-    if (ret_type == RUN_CONTAINER_TYPE) {
+    C = run_container_clone(R1);
+    CT = RUN_CONTAINER_TYPE;
+    run_run_container_ixor(&C, &CT, R1);
+    assert_int_not_equal(BITSET_CONTAINER_TYPE, CT);
+    if (CT == RUN_CONTAINER_TYPE) {
         assert_int_equal(0, run_container_cardinality(CAST_run(C)));
         run_container_free(CAST_run(C));
     } else {
         assert_int_equal(0, array_container_cardinality(CAST_array(C)));
         array_container_free(CAST_array(C));
     }
-    C = NULL;
 
-    temp_r = run_container_clone(R1);
-    assert_false(run_bitset_container_ixor(temp_r, B3, &C));
+    C = run_container_clone(R1);
+    CT = RUN_CONTAINER_TYPE;
+    run_bitset_container_ixor(&C, &CT, B3);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    temp_a = array_container_clone(A3);
-    assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     array_run_container_ixor(temp_a, R1, &C));
+    C = array_container_clone(A3);
+    CT = ARRAY_CONTAINER_TYPE;
+    array_run_container_ixor(&C, &CT, R1);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    temp_b = bitset_container_create();
-    bitset_container_copy(B1, temp_b);
-    assert_false(bitset_run_container_ixor(temp_b, R3, &C));
+    C = bitset_container_create();
+    CT = BITSET_CONTAINER_TYPE;
+    bitset_container_copy(B1, CAST_bitset(C));
+    bitset_run_container_ixor(&C, &CT, R3);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    temp_r = run_container_clone(R3);
-    assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     run_array_container_ixor(temp_r, A1, &C));
+    C = run_container_clone(R3);
+    CT = RUN_CONTAINER_TYPE;
+    run_array_container_ixor(&C, &CT, A1);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    temp_r = run_container_clone(R1);
-    assert_int_equal(ARRAY_CONTAINER_TYPE,
-                     run_run_container_ixor(temp_r, R3, &C));
+    C = run_container_clone(R1);
+    CT = RUN_CONTAINER_TYPE;
+    run_run_container_ixor(&C, &CT, R3);
+    assert_int_equal(ARRAY_CONTAINER_TYPE, CT);
     assert_int_equal(2000, array_container_cardinality(CAST_array(C)));
     array_container_free(CAST_array(C));
-    C = NULL;
 
-    temp_r = run_container_clone(R1);
-    assert_true(run_bitset_container_ixor(temp_r, B2, &C));
+    C = run_container_clone(R1);
+    CT = RUN_CONTAINER_TYPE;
+    run_bitset_container_ixor(&C, &CT, B2);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    temp_a = array_container_clone(A2);
-    assert_int_equal(BITSET_CONTAINER_TYPE,
-                     array_run_container_ixor(temp_a, R1, &C));
+    C = array_container_clone(A2);
+    CT = ARRAY_CONTAINER_TYPE;
+    array_run_container_ixor(&C, &CT, R1);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    temp_b = bitset_container_create();
-    bitset_container_copy(B1, temp_b);
-    assert_true(bitset_run_container_ixor(temp_b, R2, &C));
+    C = bitset_container_create();
+    CT = BITSET_CONTAINER_TYPE;
+    bitset_container_copy(B1, CAST_bitset(C));
+    bitset_run_container_ixor(&C, &CT, R2);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    temp_r = run_container_clone(R1);
-    assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_array_container_ixor(temp_r, A2, &C));
+    C = run_container_clone(R1);
+    CT = RUN_CONTAINER_TYPE;
+    run_array_container_ixor(&C, &CT, A2);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    temp_r = run_container_clone(R1);
-    assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_run_container_ixor(temp_r, R2, &C));
+    C = run_container_clone(R1);
+    CT = RUN_CONTAINER_TYPE;
+    run_run_container_ixor(&C, &CT, R2);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(cx12, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    temp_r = run_container_clone(R4);
-    assert_true(run_bitset_container_ixor(temp_r, B3, &C));
+    C = run_container_clone(R4);
+    CT = RUN_CONTAINER_TYPE;
+    run_bitset_container_ixor(&C, &CT, B3);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     int card_3_4 = bitset_container_cardinality(CAST_bitset(C));
     // assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    temp_a = array_container_clone(A3);
-    assert_int_equal(BITSET_CONTAINER_TYPE,
-                     array_run_container_ixor(temp_a, R4, &C));
+    C = array_container_clone(A3);
+    CT = ARRAY_CONTAINER_TYPE;
+    array_run_container_ixor(&C, &CT, R4);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     // if this fails, either this bitset is wrong or the previous one...
     assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    temp_b = bitset_container_create();
-    bitset_container_copy(B3, temp_b);
-    assert_true(bitset_run_container_ixor(temp_b, R4, &C));
+    C = bitset_container_create();
+    CT = BITSET_CONTAINER_TYPE;
+    bitset_container_copy(B3, CAST_bitset(C));
+    bitset_run_container_ixor(&C, &CT, R4);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    temp_r = run_container_clone(R3);
-    assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_array_container_ixor(temp_r, A4, &C));
+    C = run_container_clone(R3);
+    CT = RUN_CONTAINER_TYPE;
+    run_array_container_ixor(&C, &CT, A4);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
-    temp_r = run_container_clone(R4);
-    assert_int_equal(BITSET_CONTAINER_TYPE,
-                     run_run_container_ixor(temp_r, R3, &C));
+    C = run_container_clone(R4);
+    CT = RUN_CONTAINER_TYPE;
+    run_run_container_ixor(&C, &CT, R3);
+    assert_int_equal(BITSET_CONTAINER_TYPE, CT);
     assert_int_equal(card_3_4, bitset_container_cardinality(CAST_bitset(C)));
     bitset_container_free(CAST_bitset(C));
-    C = NULL;
 
     array_container_free(A1);
     array_container_free(A2);

--- a/tests/robust_deserialization_unit.c
+++ b/tests/robust_deserialization_unit.c
@@ -12,7 +12,7 @@
 
 #include "config.h"
 
-#include "test.h"
+#include "test.inc"
 
 
 long filesize(FILE* fp) {

--- a/tests/run_container_unit.c
+++ b/tests/run_container_unit.c
@@ -13,7 +13,7 @@
     using namespace roaring::internal;
 #endif
 
-#include "test.h"
+#include "test.inc"
 
 
 DEFINE_TEST(printf_test) {

--- a/tests/test.inc
+++ b/tests/test.inc
@@ -1,9 +1,12 @@
 //
-// This test.h file is included by all the unit tests.
+// This test.inc file is included by all the unit tests.
 //
 // It contains helpers for working with the cmocka unit tests.  Since that is
 // a third party file, putting common macros and functions here is better
 // than changing it.
+//
+// It is an `.inc` file instead of a `.h` file because it can contain static
+// data declarations (e.g. for the random number generator state)
 //
 
 #include <setjmp.h>
@@ -54,3 +57,16 @@
 #else
     #define DEFINE_TEST(name)   void name()
 #endif
+
+
+// Depending on a system-specific random number generator would lead to
+// different outcomes for tests involving randomness, which makes for difficult
+// debugging when a remote build encounters a failure that you don't get
+// to happen locally.
+//
+static unsigned int seed = 123456789;
+static const int OUR_RAND_MAX = (1 << 30) - 1;
+inline static unsigned int our_rand() {
+    seed = (1103515245 * seed + 12345);
+    return seed & OUR_RAND_MAX;
+}

--- a/tests/test.inc
+++ b/tests/test.inc
@@ -64,9 +64,21 @@
 // debugging when a remote build encounters a failure that you don't get
 // to happen locally.
 //
-static unsigned int seed = 123456789;
-static const int OUR_RAND_MAX = (1 << 30) - 1;
-inline static unsigned int our_rand() {
-    seed = (1103515245 * seed + 12345);
-    return seed & OUR_RAND_MAX;
+// http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.43.3639
+// http://www.iro.umontreal.ca/~simardr/rng/lfsr113.c
+//
+#define OUR_RAND_MAX UINT32_MAX
+uint32_t our_rand(void)  // lfsr113_Bits()
+{
+   static uint32_t z1 = 12345, z2 = 12345, z3 = 12345, z4 = 12345;
+   uint32_t b;
+   b  = ((z1 << 6) ^ z1) >> 13;
+   z1 = ((z1 & 4294967294U) << 18) ^ b;
+   b  = ((z2 << 2) ^ z2) >> 27; 
+   z2 = ((z2 & 4294967288U) << 2) ^ b;
+   b  = ((z3 << 13) ^ z3) >> 21;
+   z3 = ((z3 & 4294967280U) << 7) ^ b;
+   b  = ((z4 << 3) ^ z4) >> 12;
+   z4 = ((z4 & 4294967168U) << 13) ^ b;
+   return (z1 ^ z2 ^ z3 ^ z4);
 }

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -14,16 +14,8 @@
     using namespace roaring::internal;
 #endif
 
-#include "test.h"
+#include "test.inc"
 
-
-static unsigned int seed = 123456789;
-static const int OUR_RAND_MAX = (1 << 30) - 1;
-inline static unsigned int our_rand() {  // we do not want to depend on a system-specific
-                                // random number generator
-    seed = (1103515245 * seed + 12345);
-    return seed & OUR_RAND_MAX;
-}
 
 static inline uint32_t minimum_uint32(uint32_t a, uint32_t b) {
     return (a < b) ? a : b;

--- a/tests/util_unit.c
+++ b/tests/util_unit.c
@@ -14,7 +14,7 @@
     using namespace roaring::internal;
 #endif
 
-#include "test.h"
+#include "test.inc"
 
 
 DEFINE_TEST(setandextract_uint16) {


### PR DESCRIPTION
This is a prototype that picks one operator to work with...to see about bubbling up the necessary information to report errors ( as discussed in #174 ) and tries to make some other improvements in the process.

Truly getting to a point where out of memory can be handled gracefully will require work and stress testing--but this tries to put things on that path.

Part of the goal is to streamline the dispatching to be more regular--so that the subdispatch matches the interface of the higher-level dispatch.  This reduces the amount of transformation that has to be done.

For instance: there were boolean return codes which had to be interpreted by callers as a container type.  This gives the subdispatch the place to write the container type if it changes--and it can leave it as-is if not.  <strike>Ultimately this might be imagined as updating the container and the type in the container array directly...without needing separate code to update it after the dispatch returns.</strike> **(done)**

**Stylistic Notes**

Writing out the full word "container" is less necessary when it's in the type (`container_t *c` is better than `void *container`), and most of the functions redundantly have container in their name anyway.

Out of the abbreviations for container classes (`array/run`, `arr/run`, `ac/rc`) this favors `c` for generic containers and `ac`/`rc`/`bc` for specific ones.  This communicates while being brief, and `ac->array` looks better than `array->array` or `arr->array`, with the A.C. reinforcing the concept that it is an "Array *Container*".

<strike>The bitset container's inner words array would be better called `words`, as having it be called "array" is a bit of a speedbump when working with containers where one is an "array container" and one is a "bitset container".</strike> [merged in a separate PR](https://github.com/RoaringBitmap/CRoaring/pull/269)

When there are two inputs they are numbered and labeled by their type, since **ac1** and **rc2** offers strictly more information than **src1** and **src2**.