### PR TITLE
fix compiling error "implicit-function-declaration" for function printf

### DIFF
--- a/benchmarks/add_benchmark.c
+++ b/benchmarks/add_benchmark.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include <roaring/roaring.h>
 #include <math.h>
+#include <stdio.h>
 #include "benchmark.h"
 #include "random.h"
 


### PR DESCRIPTION
Seeing error in building the project on macos with below clang version: 

_Apple clang version 12.0.0 (clang-1200.0.32.27)_
_Target: x86_64-apple-darwin19.6.0_
_Thread model: posix_
_InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin_

I think quick fix is to include stdio.h where `printf` is declared. There should be no negative impact to do so.
So send this tiny PR.
