### PR TITLE
Rename bitset words array "array" => "words"

### DIFF
--- a/benchmarks/bitset_container_benchmark.c
+++ b/benchmarks/bitset_container_benchmark.c
@@ -18,7 +18,7 @@ void bitset_cache_flush(bitset_container_t* B) {
         computecacheline();  // 64 bytes per cache line
     for (int32_t k = 0; k < BITSET_CONTAINER_SIZE_IN_WORDS;
          k += CACHELINESIZE / (int32_t)sizeof(uint64_t)) {
-        __builtin_ia32_clflush(B->array + k);
+        __builtin_ia32_clflush(B->words + k);
     }
 }
 #else
@@ -37,7 +37,7 @@ void bitset_cache_prefetch(bitset_container_t* B) {
 #if !(defined(_MSC_VER) && !defined(__clang__))
     for (int32_t k = 0; k < BITSET_CONTAINER_SIZE_IN_WORDS;
          k += CACHELINESIZE / (int32_t)sizeof(uint64_t)) {
-        __builtin_prefetch(B->array + k);
+        __builtin_prefetch(B->words + k);
     }
 #endif
 }

--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -24,8 +24,9 @@ static inline void bitset_set_range(uint64_t *words, uint32_t start,
         return;
     }
     words[firstword] |= (~UINT64_C(0)) << (start % 64);
-    for (uint32_t i = firstword + 1; i < endword; i++)
+    for (uint32_t i = firstword + 1; i < endword; i++) {
         words[i] = ~UINT64_C(0);
+    }
     words[endword] |= (~UINT64_C(0)) >> ((~end + 1) % 64);
 }
 
@@ -64,14 +65,17 @@ static inline bool bitset_lenrange_empty(const uint64_t *words, uint32_t start,
         return (words[firstword] & ((~UINT64_C(0)) >> ((63 - lenminusone) % 64))
               << (start % 64)) == 0;
     }
-    if (((words[firstword] & ((~UINT64_C(0)) << (start%64)))) != 0)
+    if (((words[firstword] & ((~UINT64_C(0)) << (start%64)))) != 0) {
         return false;
-    for (uint32_t i = firstword + 1; i < endword; i++) {
-        if (words[i] != 0)
-            return false;
     }
-    if ((words[endword] & (~UINT64_C(0)) >> (((~start + 1) - lenminusone - 1) % 64)) != 0)
+    for (uint32_t i = firstword + 1; i < endword; i++) {
+        if (words[i] != 0) {
+            return false;
+        }
+    }
+    if ((words[endword] & (~UINT64_C(0)) >> (((~start + 1) - lenminusone - 1) % 64)) != 0) {
         return false;
+    }
     return true;
 }
 
@@ -105,8 +109,9 @@ static inline void bitset_flip_range(uint64_t *words, uint32_t start,
     uint32_t firstword = start / 64;
     uint32_t endword = (end - 1) / 64;
     words[firstword] ^= ~((~UINT64_C(0)) << (start % 64));
-    for (uint32_t i = firstword; i < endword; i++)
+    for (uint32_t i = firstword; i < endword; i++) {
         words[i] = ~words[i];
+    }
     words[endword] ^= ((~UINT64_C(0)) >> ((~end + 1) % 64));
 }
 
@@ -124,8 +129,9 @@ static inline void bitset_reset_range(uint64_t *words, uint32_t start,
         return;
     }
     words[firstword] &= ~((~UINT64_C(0)) << (start % 64));
-    for (uint32_t i = firstword + 1; i < endword; i++)
+    for (uint32_t i = firstword + 1; i < endword; i++) {
         words[i] = UINT64_C(0);
+    }
     words[endword] &= ~((~UINT64_C(0)) >> ((~end + 1) % 64));
 }
 

--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -33,7 +33,8 @@ static inline void bitset_set_range(uint64_t *words, uint32_t start,
 /*
  * Find the cardinality of the bitset in [begin,begin+lenminusone]
  */
-static inline int bitset_lenrange_cardinality(uint64_t *words, uint32_t start,
+static inline int bitset_lenrange_cardinality(const uint64_t *words,
+                                              uint32_t start,
                                               uint32_t lenminusone) {
     uint32_t firstword = start / 64;
     uint32_t endword = (start + lenminusone) / 64;
@@ -55,8 +56,8 @@ static inline int bitset_lenrange_cardinality(uint64_t *words, uint32_t start,
 /*
  * Check whether the cardinality of the bitset in [begin,begin+lenminusone] is 0
  */
-static inline bool bitset_lenrange_empty(uint64_t *words, uint32_t start,
-        uint32_t lenminusone) {
+static inline bool bitset_lenrange_empty(const uint64_t *words, uint32_t start,
+                                         uint32_t lenminusone) {
     uint32_t firstword = start / 64;
     uint32_t endword = (start + lenminusone) / 64;
     if (firstword == endword) {
@@ -143,8 +144,9 @@ static inline void bitset_reset_range(uint64_t *words, uint32_t start,
  *
  * This function uses AVX2 decoding.
  */
-size_t bitset_extract_setbits_avx2(uint64_t *words, size_t length, uint32_t *out,
-                                   size_t outcapacity, uint32_t base);
+size_t bitset_extract_setbits_avx2(const uint64_t *words, size_t length,
+                                   uint32_t *out, size_t outcapacity,
+                                   uint32_t base);
 
 /*
  * Given a bitset containing "length" 64-bit words, write out the position
@@ -155,8 +157,8 @@ size_t bitset_extract_setbits_avx2(uint64_t *words, size_t length, uint32_t *out
  *
  * Returns how many values were actually decoded.
  */
-size_t bitset_extract_setbits(uint64_t *words, size_t length, uint32_t *out,
-                              uint32_t base);
+size_t bitset_extract_setbits(const uint64_t *words, size_t length,
+                              uint32_t *out, uint32_t base);
 
 /*
  * Given a bitset containing "length" 64-bit words, write out the position

--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -143,7 +143,7 @@ static inline void bitset_reset_range(uint64_t *words, uint32_t start,
  *
  * This function uses AVX2 decoding.
  */
-size_t bitset_extract_setbits_avx2(uint64_t *words, size_t length, void *vout,
+size_t bitset_extract_setbits_avx2(uint64_t *words, size_t length, uint32_t *out,
                                    size_t outcapacity, uint32_t base);
 
 /*
@@ -155,7 +155,7 @@ size_t bitset_extract_setbits_avx2(uint64_t *words, size_t length, void *vout,
  *
  * Returns how many values were actually decoded.
  */
-size_t bitset_extract_setbits(uint64_t *words, size_t length, void *vout,
+size_t bitset_extract_setbits(uint64_t *words, size_t length, uint32_t *out,
                               uint32_t base);
 
 /*

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -2313,14 +2313,15 @@ static inline container_t *container_add_range(
             int32_t union_cardinality = 0;
             union_cardinality += bitset->cardinality;
             union_cardinality += max - min + 1;
-            union_cardinality -= bitset_lenrange_cardinality(bitset->array, min, max-min);
+            union_cardinality -= bitset_lenrange_cardinality(bitset->words,
+                                                             min, max-min);
 
             if (union_cardinality == INT32_C(0x10000)) {
                 *result_type = RUN_CONTAINER_TYPE;
                 return run_container_create_range(0, INT32_C(0x10000));
             } else {
                 *result_type = BITSET_CONTAINER_TYPE;
-                bitset_set_lenrange(bitset->array, min, max - min);
+                bitset_set_lenrange(bitset->words, min, max - min);
                 bitset->cardinality = union_cardinality;
                 return bitset;
             }
@@ -2342,7 +2343,7 @@ static inline container_t *container_add_range(
             } else {
                 *result_type = BITSET_CONTAINER_TYPE;
                 bitset_container_t *bitset = bitset_container_from_array(array);
-                bitset_set_lenrange(bitset->array, min, max - min);
+                bitset_set_lenrange(bitset->words, min, max - min);
                 bitset->cardinality = union_cardinality;
                 return bitset;
             }
@@ -2389,18 +2390,18 @@ static inline container_t *container_remove_range(
             bitset_container_t *bitset = CAST_bitset(c);
 
             int32_t result_cardinality = bitset->cardinality -
-                bitset_lenrange_cardinality(bitset->array, min, max-min);
+                bitset_lenrange_cardinality(bitset->words, min, max-min);
 
             if (result_cardinality == 0) {
                 return NULL;
             } else if (result_cardinality < DEFAULT_MAX_SIZE) {
                 *result_type = ARRAY_CONTAINER_TYPE;
-                bitset_reset_range(bitset->array, min, max+1);
+                bitset_reset_range(bitset->words, min, max+1);
                 bitset->cardinality = result_cardinality;
                 return array_container_from_bitset(bitset);
             } else {
                 *result_type = BITSET_CONTAINER_TYPE;
-                bitset_reset_range(bitset->array, min, max+1);
+                bitset_reset_range(bitset->words, min, max+1);
                 bitset->cardinality = result_cardinality;
                 return bitset;
             }

--- a/src/bitset_util.c
+++ b/src/bitset_util.c
@@ -554,9 +554,8 @@ static uint16_t vecDecodeTable_uint16[256][8] = {
 
 #ifdef USEAVX
 
-size_t bitset_extract_setbits_avx2(uint64_t *words, size_t length, void *vout,
+size_t bitset_extract_setbits_avx2(uint64_t *words, size_t length, uint32_t *out,
                                    size_t outcapacity, uint32_t base) {
-    uint32_t *out = (uint32_t *)vout;
     uint32_t *initout = out;
     __m256i baseVec = _mm256_set1_epi32(base - 1);
     __m256i incVec = _mm256_set1_epi32(64);
@@ -607,10 +606,9 @@ size_t bitset_extract_setbits_avx2(uint64_t *words, size_t length, void *vout,
 }
 #endif  // USEAVX
 
-size_t bitset_extract_setbits(uint64_t *words, size_t length, void *vout,
+size_t bitset_extract_setbits(uint64_t *words, size_t length, uint32_t *out,
                               uint32_t base) {
     int outpos = 0;
-    uint32_t *out = (uint32_t *)vout;
     for (size_t i = 0; i < length; ++i) {
         uint64_t w = words[i];
         while (w != 0) {

--- a/src/bitset_util.c
+++ b/src/bitset_util.c
@@ -554,8 +554,9 @@ static uint16_t vecDecodeTable_uint16[256][8] = {
 
 #ifdef USEAVX
 
-size_t bitset_extract_setbits_avx2(uint64_t *words, size_t length, uint32_t *out,
-                                   size_t outcapacity, uint32_t base) {
+size_t bitset_extract_setbits_avx2(const uint64_t *words, size_t length,
+                                   uint32_t *out, size_t outcapacity,
+                                   uint32_t base) {
     uint32_t *initout = out;
     __m256i baseVec = _mm256_set1_epi32(base - 1);
     __m256i incVec = _mm256_set1_epi32(64);
@@ -606,8 +607,8 @@ size_t bitset_extract_setbits_avx2(uint64_t *words, size_t length, uint32_t *out
 }
 #endif  // USEAVX
 
-size_t bitset_extract_setbits(uint64_t *words, size_t length, uint32_t *out,
-                              uint32_t base) {
+size_t bitset_extract_setbits(const uint64_t *words, size_t length,
+                              uint32_t *out, uint32_t base) {
     int outpos = 0;
     for (size_t i = 0; i < length; ++i) {
         uint64_t w = words[i];

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -57,7 +57,7 @@ bool bitset_array_container_andnot(
     bitset_container_t *result = bitset_container_create();
     bitset_container_copy(src_1, result);
     result->cardinality =
-        (int32_t)bitset_clear_list(result->array, (uint64_t)result->cardinality,
+        (int32_t)bitset_clear_list(result->words, (uint64_t)result->cardinality,
                                    src_2->array, (uint64_t)src_2->cardinality);
 
     // do required type conversions.
@@ -83,7 +83,7 @@ bool bitset_array_container_iandnot(
 ){
     *dst = src_1;
     src_1->cardinality =
-        (int32_t)bitset_clear_list(src_1->array, (uint64_t)src_1->cardinality,
+        (int32_t)bitset_clear_list(src_1->words, (uint64_t)src_1->cardinality,
                                    src_2->array, (uint64_t)src_2->cardinality);
 
     if (src_1->cardinality <= DEFAULT_MAX_SIZE) {
@@ -132,11 +132,11 @@ bool run_bitset_container_andnot(
 
             uint32_t start = rle.value;
             uint32_t end = start + rle.length + 1;
-            bitset_reset_range(answer->array, last_pos, start);
-            bitset_flip_range(answer->array, start, end);
+            bitset_reset_range(answer->words, last_pos, start);
+            bitset_flip_range(answer->words, start, end);
             last_pos = end;
         }
-        bitset_reset_range(answer->array, last_pos, (uint32_t)(1 << 16));
+        bitset_reset_range(answer->words, last_pos, (uint32_t)(1 << 16));
 
         answer->cardinality = bitset_container_compute_cardinality(answer);
 
@@ -184,7 +184,7 @@ bool bitset_run_container_andnot(
     bitset_container_copy(src_1, result);
     for (int32_t rlepos = 0; rlepos < src_2->n_runs; ++rlepos) {
         rle16_t rle = src_2->runs[rlepos];
-        bitset_reset_range(result->array, rle.value,
+        bitset_reset_range(result->words, rle.value,
                            rle.value + rle.length + UINT32_C(1));
     }
     result->cardinality = bitset_container_compute_cardinality(result);
@@ -213,7 +213,7 @@ bool bitset_run_container_iandnot(
 
     for (int32_t rlepos = 0; rlepos < src_2->n_runs; ++rlepos) {
         rle16_t rle = src_2->runs[rlepos];
-        bitset_reset_range(src_1->array, rle.value,
+        bitset_reset_range(src_1->words, rle.value,
                            rle.value + rle.length + UINT32_C(1));
     }
     src_1->cardinality = bitset_container_compute_cardinality(src_1);

--- a/src/containers/mixed_equal.c
+++ b/src/containers/mixed_equal.c
@@ -13,7 +13,7 @@ bool array_container_equal_bitset(const array_container_t* container1,
     }
     int32_t pos = 0;
     for (int32_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i) {
-        uint64_t w = container2->array[i];
+        uint64_t w = container2->words[i];
         while (w != 0) {
             uint64_t t = w & (~w + 1);
             uint16_t r = i * 64 + __builtin_ctzll(w);

--- a/src/containers/mixed_intersection.c
+++ b/src/containers/mixed_intersection.c
@@ -151,11 +151,11 @@ bool run_bitset_container_intersection(
         for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
             const rle16_t rle = src_1->runs[rlepos];
             uint32_t end = rle.value;
-            bitset_reset_range(src_2->array, start, end);
+            bitset_reset_range(src_2->words, start, end);
 
             start = end + rle.length + 1;
         }
-        bitset_reset_range(src_2->array, start, UINT32_C(1) << 16);
+        bitset_reset_range(src_2->words, start, UINT32_C(1) << 16);
         answer->cardinality = bitset_container_compute_cardinality(answer);
         if (src_2->cardinality > DEFAULT_MAX_SIZE) {
             return true;
@@ -180,10 +180,10 @@ bool run_bitset_container_intersection(
         for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
             const rle16_t rle = src_1->runs[rlepos];
             uint32_t end = rle.value;
-            bitset_reset_range(answer->array, start, end);
+            bitset_reset_range(answer->words, start, end);
             start = end + rle.length + 1;
         }
-        bitset_reset_range(answer->array, start, UINT32_C(1) << 16);
+        bitset_reset_range(answer->words, start, UINT32_C(1) << 16);
         answer->cardinality = bitset_container_compute_cardinality(answer);
 
         if (answer->cardinality > DEFAULT_MAX_SIZE) {
@@ -246,7 +246,7 @@ int run_bitset_container_intersection_cardinality(
     for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
         rle16_t rle = src_1->runs[rlepos];
         answer +=
-            bitset_lenrange_cardinality(src_2->array, rle.value, rle.length);
+            bitset_lenrange_cardinality(src_2->words, rle.value, rle.length);
     }
     return answer;
 }
@@ -292,7 +292,7 @@ bool run_bitset_container_intersect(const run_container_t *src_1,
 	   }
        for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
            rle16_t rle = src_1->runs[rlepos];
-           if(!bitset_lenrange_empty(src_2->array, rle.value,rle.length)) return true;
+           if(!bitset_lenrange_empty(src_2->words, rle.value,rle.length)) return true;
        }
        return false;
 }
@@ -319,7 +319,7 @@ bool bitset_bitset_container_intersection(
     if (*dst != NULL) {
         CAST_array(*dst)->cardinality = newCardinality;
         bitset_extract_intersection_setbits_uint16(
-            src_1->array, src_2->array, BITSET_CONTAINER_SIZE_IN_WORDS,
+            src_1->words, src_2->words, BITSET_CONTAINER_SIZE_IN_WORDS,
             CAST_array(*dst)->array, 0);
     }
     return false;  // not a bitset
@@ -340,7 +340,7 @@ bool bitset_bitset_container_intersection_inplace(
     if (*dst != NULL) {
         CAST_array(*dst)->cardinality = newCardinality;
         bitset_extract_intersection_setbits_uint16(
-            src_1->array, src_2->array, BITSET_CONTAINER_SIZE_IN_WORDS,
+            src_1->words, src_2->words, BITSET_CONTAINER_SIZE_IN_WORDS,
             CAST_array(*dst)->array, 0);
     }
     return false;  // not a bitset

--- a/src/containers/mixed_negation.c
+++ b/src/containers/mixed_negation.c
@@ -32,7 +32,7 @@ void array_container_negation(const array_container_t *src,
     uint64_t card = UINT64_C(1 << 16);
     bitset_container_set_all(dst);
 
-    dst->cardinality = (int32_t)bitset_clear_list(dst->array, card, src->array,
+    dst->cardinality = (int32_t)bitset_clear_list(dst->words, card, src->array,
                                                   (uint64_t)src->cardinality);
 }
 
@@ -119,7 +119,7 @@ bool array_container_negation_range(
 
     if (new_cardinality > DEFAULT_MAX_SIZE) {
         bitset_container_t *temp = bitset_container_from_array(src);
-        bitset_flip_range(temp->array, (uint32_t)range_start,
+        bitset_flip_range(temp->words, (uint32_t)range_start,
                           (uint32_t)range_end);
         temp->cardinality = new_cardinality;
         *dst = temp;
@@ -190,7 +190,7 @@ bool bitset_container_negation_range(
 
     // keep computation using bitsets as long as possible.
     bitset_container_t *t = bitset_container_clone(src);
-    bitset_flip_range(t->array, (uint32_t)range_start, (uint32_t)range_end);
+    bitset_flip_range(t->words, (uint32_t)range_start, (uint32_t)range_end);
     t->cardinality = bitset_container_compute_cardinality(t);
 
     if (t->cardinality > DEFAULT_MAX_SIZE) {
@@ -217,7 +217,7 @@ bool bitset_container_negation_range_inplace(
     const int range_start, const int range_end,
     container_t **dst
 ){
-    bitset_flip_range(src->array, (uint32_t)range_start, (uint32_t)range_end);
+    bitset_flip_range(src->words, (uint32_t)range_start, (uint32_t)range_end);
     src->cardinality = bitset_container_compute_cardinality(src);
     if (src->cardinality > DEFAULT_MAX_SIZE) {
         *dst = src;

--- a/src/containers/mixed_subset.c
+++ b/src/containers/mixed_subset.c
@@ -103,7 +103,7 @@ bool bitset_container_is_subset_run(const bitset_container_t* container1,
     int32_t i_bitset = 0, i_run = 0;
     while (i_bitset < BITSET_CONTAINER_SIZE_IN_WORDS &&
            i_run < container2->n_runs) {
-        uint64_t w = container1->array[i_bitset];
+        uint64_t w = container1->words[i_bitset];
         while (w != 0 && i_run < container2->n_runs) {
             uint32_t start = container2->runs[i_run].value;
             uint32_t stop = start + container2->runs[i_run].length;
@@ -128,7 +128,7 @@ bool bitset_container_is_subset_run(const bitset_container_t* container1,
         // terminated iterating on the run containers, check that rest of bitset
         // is empty
         for (; i_bitset < BITSET_CONTAINER_SIZE_IN_WORDS; i_bitset++) {
-            if (container1->array[i_bitset] != 0) {
+            if (container1->words[i_bitset] != 0) {
                 return false;
             }
         }

--- a/src/containers/mixed_union.c
+++ b/src/containers/mixed_union.c
@@ -22,7 +22,7 @@ void array_bitset_container_union(const array_container_t *src_1,
                                   bitset_container_t *dst) {
     if (src_2 != dst) bitset_container_copy(src_2, dst);
     dst->cardinality = (int32_t)bitset_set_list_withcard(
-        dst->array, dst->cardinality, src_1->array, src_1->cardinality);
+        dst->words, dst->cardinality, src_1->array, src_1->cardinality);
 }
 
 /* Compute the union of src_1 and src_2 and write the result to
@@ -32,7 +32,7 @@ void array_bitset_container_lazy_union(const array_container_t *src_1,
                                        const bitset_container_t *src_2,
                                        bitset_container_t *dst) {
     if (src_2 != dst) bitset_container_copy(src_2, dst);
-    bitset_set_list(dst->array, src_1->array, src_1->cardinality);
+    bitset_set_list(dst->words, src_1->array, src_1->cardinality);
     dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
 }
 
@@ -43,7 +43,7 @@ void run_bitset_container_union(const run_container_t *src_1,
     if (src_2 != dst) bitset_container_copy(src_2, dst);
     for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
         rle16_t rle = src_1->runs[rlepos];
-        bitset_set_lenrange(dst->array, rle.value, rle.length);
+        bitset_set_lenrange(dst->words, rle.value, rle.length);
     }
     dst->cardinality = bitset_container_compute_cardinality(dst);
 }
@@ -55,7 +55,7 @@ void run_bitset_container_lazy_union(const run_container_t *src_1,
     if (src_2 != dst) bitset_container_copy(src_2, dst);
     for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
         rle16_t rle = src_1->runs[rlepos];
-        bitset_set_lenrange(dst->array, rle.value, rle.length);
+        bitset_set_lenrange(dst->words, rle.value, rle.length);
     }
     dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
 }
@@ -175,9 +175,9 @@ bool array_array_container_union(
     bool returnval = true;  // expect a bitset
     if (*dst != NULL) {
         bitset_container_t *ourbitset = CAST_bitset(*dst);
-        bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
+        bitset_set_list(ourbitset->words, src_1->array, src_1->cardinality);
         ourbitset->cardinality = (int32_t)bitset_set_list_withcard(
-            ourbitset->array, src_1->cardinality, src_2->array,
+            ourbitset->words, src_1->cardinality, src_2->array,
             src_2->cardinality);
         if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {
             // need to convert!
@@ -215,9 +215,9 @@ bool array_array_container_inplace_union(
     bool returnval = true;  // expect a bitset
     if (*dst != NULL) {
         bitset_container_t *ourbitset = CAST_bitset(*dst);
-        bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
+        bitset_set_list(ourbitset->words, src_1->array, src_1->cardinality);
         ourbitset->cardinality = (int32_t)bitset_set_list_withcard(
-            ourbitset->array, src_1->cardinality, src_2->array,
+            ourbitset->words, src_1->cardinality, src_2->array,
             src_2->cardinality);
         if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {
             // need to convert!
@@ -225,7 +225,7 @@ bool array_array_container_inplace_union(
               array_container_grow(src_1, ourbitset->cardinality, false);
             }
 
-            bitset_extract_setbits_uint16(ourbitset->array, BITSET_CONTAINER_SIZE_IN_WORDS,
+            bitset_extract_setbits_uint16(ourbitset->words, BITSET_CONTAINER_SIZE_IN_WORDS,
                                   src_1->array, 0);
             src_1->cardinality =  ourbitset->cardinality;
             *dst = src_1;
@@ -255,8 +255,8 @@ bool array_array_container_lazy_union(
     bool returnval = true;  // expect a bitset
     if (*dst != NULL) {
         bitset_container_t *ourbitset = CAST_bitset(*dst);
-        bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
-        bitset_set_list(ourbitset->array, src_2->array, src_2->cardinality);
+        bitset_set_list(ourbitset->words, src_1->array, src_1->cardinality);
+        bitset_set_list(ourbitset->words, src_2->array, src_2->cardinality);
         ourbitset->cardinality = BITSET_UNKNOWN_CARDINALITY;
     }
     return returnval;
@@ -289,8 +289,8 @@ bool array_array_container_lazy_inplace_union(
     bool returnval = true;  // expect a bitset
     if (*dst != NULL) {
         bitset_container_t *ourbitset = CAST_bitset(*dst);
-        bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
-        bitset_set_list(ourbitset->array, src_2->array, src_2->cardinality);
+        bitset_set_list(ourbitset->words, src_1->array, src_1->cardinality);
+        bitset_set_list(ourbitset->words, src_2->array, src_2->cardinality);
         ourbitset->cardinality = BITSET_UNKNOWN_CARDINALITY;
     }
     return returnval;

--- a/src/containers/mixed_xor.c
+++ b/src/containers/mixed_xor.c
@@ -25,7 +25,7 @@ bool array_bitset_container_xor(
     bitset_container_t *result = bitset_container_create();
     bitset_container_copy(src_2, result);
     result->cardinality = (int32_t)bitset_flip_list_withcard(
-        result->array, result->cardinality, src_1->array, src_1->cardinality);
+        result->words, result->cardinality, src_1->array, src_1->cardinality);
 
     // do required type conversions.
     if (result->cardinality <= DEFAULT_MAX_SIZE) {
@@ -46,7 +46,7 @@ void array_bitset_container_lazy_xor(const array_container_t *src_1,
                                      const bitset_container_t *src_2,
                                      bitset_container_t *dst) {
     if (src_2 != dst) bitset_container_copy(src_2, dst);
-    bitset_flip_list(dst->array, src_1->array, src_1->cardinality);
+    bitset_flip_list(dst->words, src_1->array, src_1->cardinality);
     dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
 }
 
@@ -66,7 +66,7 @@ bool run_bitset_container_xor(
     bitset_container_copy(src_2, result);
     for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
         rle16_t rle = src_1->runs[rlepos];
-        bitset_flip_range(result->array, rle.value,
+        bitset_flip_range(result->words, rle.value,
                           rle.value + rle.length + UINT32_C(1));
     }
     result->cardinality = bitset_container_compute_cardinality(result);
@@ -91,7 +91,7 @@ void run_bitset_container_lazy_xor(const run_container_t *src_1,
     if (src_2 != dst) bitset_container_copy(src_2, dst);
     for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
         rle16_t rle = src_1->runs[rlepos];
-        bitset_flip_range(dst->array, rle.value,
+        bitset_flip_range(dst->words, rle.value,
                           rle.value + rle.length + UINT32_C(1));
     }
     dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
@@ -214,7 +214,7 @@ bool array_array_container_xor(
     bool returnval = true;  // expect a bitset
     bitset_container_t *ourbitset = CAST_bitset(*dst);
     ourbitset->cardinality = (uint32_t)bitset_flip_list_withcard(
-        ourbitset->array, src_1->cardinality, src_2->array, src_2->cardinality);
+        ourbitset->words, src_1->cardinality, src_2->array, src_2->cardinality);
     if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {
         // need to convert!
         *dst = array_container_from_bitset(ourbitset);
@@ -241,7 +241,7 @@ bool array_array_container_lazy_xor(
     bool returnval = true;  // expect a bitset (maybe, for XOR??)
     if (*dst != NULL) {
         bitset_container_t *ourbitset = CAST_bitset(*dst);
-        bitset_flip_list(ourbitset->array, src_2->array, src_2->cardinality);
+        bitset_flip_list(ourbitset->words, src_2->array, src_2->cardinality);
         ourbitset->cardinality = BITSET_UNKNOWN_CARDINALITY;
     }
     return returnval;
@@ -281,7 +281,7 @@ bool bitset_array_container_ixor(
 ){
     *dst = src_1;
     src_1->cardinality = (uint32_t)bitset_flip_list_withcard(
-        src_1->array, src_1->cardinality, src_2->array, src_2->cardinality);
+        src_1->words, src_1->cardinality, src_2->array, src_2->cardinality);
 
     if (src_1->cardinality <= DEFAULT_MAX_SIZE) {
         *dst = array_container_from_bitset(src_1);


### PR DESCRIPTION
Having the bitset container use a unique name for its words array
helps significantly in code understandability, especially when
working with a mixture of array containers and bitset containers.
There is no useful polymorphism from the shared name to be lost.

This also standardizes the parameter name for extracted words
arrays passed to `words` as well (variants were `array`, `bitmap`
and `bitset`).

Some const-correctness and excising of void*/casts included.