### PR TITLE
r => roaring_bitmap_t, ra => roaring_array_t, cleanups

### DIFF
--- a/benchmarks/real_bitmaps_benchmark.c
+++ b/benchmarks/real_bitmaps_benchmark.c
@@ -158,9 +158,9 @@ int main(int argc, char **argv) {
     size_t total_count = 0;
     RDTSC_START(cycles_start);
     for (size_t i = 0; i < count; ++i) {
-        roaring_bitmap_t *ra = bitmaps[i];
+        roaring_bitmap_t *r = bitmaps[i];
         roaring_uint32_iterator_t j;
-        roaring_init_iterator(ra, &j);
+        roaring_init_iterator(r, &j);
         while (j.has_value) {
             total_count++;
             roaring_advance_uint32_iterator(&j);

--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -147,7 +147,7 @@ int array_container_to_uint32_array(void *vout, const array_container_t *cont,
                                     uint32_t base);
 
 /* Compute the number of runs */
-int32_t array_container_number_of_runs(const array_container_t *a);
+int32_t array_container_number_of_runs(const array_container_t *ac);
 
 /*
  * Print this container using printf (useful for debugging).

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -397,7 +397,8 @@ int bitset_container_andnot_nocard(const bitset_container_t *src_1,
  * The out pointer should point to enough memory (the cardinality times 32
  * bits).
  */
-int bitset_container_to_uint32_array(void *out, const bitset_container_t *cont,
+int bitset_container_to_uint32_array(uint32_t *out,
+                                     const bitset_container_t *bc,
                                      uint32_t base);
 
 /*

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -423,7 +423,7 @@ static inline int32_t bitset_container_serialized_size_in_bytes(void) {
 /**
  * Return the the number of runs.
  */
-int bitset_container_number_of_runs(bitset_container_t *b);
+int bitset_container_number_of_runs(bitset_container_t *bc);
 
 bool bitset_container_iterate(const bitset_container_t *cont, uint32_t base,
                               roaring_iterator iterator, void *ptr);

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -94,10 +94,9 @@ static inline const container_t *container_unwrap_shared(
     const container_t *candidate_shared_container, uint8_t *type
 ){
     if (*type == SHARED_CONTAINER_TYPE) {
-        *type =
-            ((const shared_container_t *)candidate_shared_container)->typecode;
+        *type = const_CAST_shared(candidate_shared_container)->typecode;
         assert(*type != SHARED_CONTAINER_TYPE);
-        return ((const shared_container_t *)candidate_shared_container)->container;
+        return const_CAST_shared(candidate_shared_container)->container;
     } else {
         return candidate_shared_container;
     }
@@ -122,7 +121,7 @@ static inline uint8_t get_container_type(
     const container_t *c, uint8_t type
 ){
     if (type == SHARED_CONTAINER_TYPE) {
-        return ((const shared_container_t *)c)->typecode;
+        return const_CAST_shared(c)->typecode;
     } else {
         return type;
     }
@@ -211,7 +210,7 @@ static inline const char *get_full_container_name(
         case RUN_CONTAINER_TYPE:
             return container_names[2];
         case SHARED_CONTAINER_TYPE:
-            switch (((const shared_container_t *)c)->typecode) {
+            switch (const_CAST_shared(c)->typecode) {
                 case BITSET_CONTAINER_TYPE:
                     return shared_container_names[0];
                 case ARRAY_CONTAINER_TYPE:
@@ -2349,7 +2348,7 @@ static inline container_t *container_add_range(
             }
         }
         case RUN_CONTAINER_TYPE: {
-            run_container_t *run = (run_container_t *) c;
+            run_container_t *run = CAST_run(c);
 
             int32_t nruns_greater = rle16_count_greater(run->runs, run->n_runs, max);
             int32_t nruns_less = rle16_count_less(run->runs, run->n_runs - nruns_greater, min);
@@ -2423,7 +2422,7 @@ static inline container_t *container_remove_range(
             }
         }
         case RUN_CONTAINER_TYPE: {
-            run_container_t *run = (run_container_t *) c;
+            run_container_t *run = CAST_run(c);
 
             if (run->n_runs == 0) {
                 return NULL;

--- a/include/roaring/containers/convert.h
+++ b/include/roaring/containers/convert.h
@@ -35,7 +35,7 @@ run_container_t *run_container_from_array(const array_container_t *c);
 /* convert a run into either an array or a bitset
  * might free the container. This does not free the input run container. */
 container_t *convert_to_bitset_or_array_container(
-        run_container_t *r, int32_t card,
+        run_container_t *rc, int32_t card,
         uint8_t *resulttype);
 
 /* convert containers to and from runcontainers, as is most space efficient.

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -1,6 +1,6 @@
 /*
-An implementation of Roaring Bitmaps in C.
-*/
+ * An implementation of Roaring Bitmaps in C.
+ */
 
 #ifndef ROARING_H
 #define ROARING_H
@@ -65,16 +65,18 @@ roaring_bitmap_t *roaring_bitmap_of_ptr(size_t n_args, const uint32_t *vals);
 
 /*
  * Whether you want to use copy-on-write.
- * Saves memory and avoids copies but needs more care in a threaded context.
+ * Saves memory and avoids copies, but needs more care in a threaded context.
  * Most users should ignore this flag.
- * Note: if you do turn this flag to 'true', enabling COW,
- * then ensure that you do so for all of your bitmaps since
- * interactions between bitmaps with and without COW is unsafe.
+ *
+ * Note: If you do turn this flag to 'true', enabling COW, then ensure that you
+ * do so for all of your bitmaps, since interactions between bitmaps with and
+ * without COW is unsafe.
  */
 static inline bool roaring_bitmap_get_copy_on_write(const roaring_bitmap_t* r) {
     return r->high_low_container.flags & ROARING_FLAG_COW;
 }
-static inline void roaring_bitmap_set_copy_on_write(roaring_bitmap_t* r, bool cow) {
+static inline void roaring_bitmap_set_copy_on_write(roaring_bitmap_t* r,
+                                                    bool cow) {
     if (cow) {
         r->high_low_container.flags |= ROARING_FLAG_COW;
     } else {
@@ -85,7 +87,7 @@ static inline void roaring_bitmap_set_copy_on_write(roaring_bitmap_t* r, bool co
 /**
  * Describe the inner structure of the bitmap.
  */
-void roaring_bitmap_printf_describe(const roaring_bitmap_t *ra);
+void roaring_bitmap_printf_describe(const roaring_bitmap_t *r);
 
 /**
  * Creates a new bitmap from a list of uint32_t integers
@@ -93,172 +95,152 @@ void roaring_bitmap_printf_describe(const roaring_bitmap_t *ra);
 roaring_bitmap_t *roaring_bitmap_of(size_t n, ...);
 
 /**
- * Copies a  bitmap. This does memory allocation. The caller is responsible for
- * memory management.
- *
+ * Copies a bitmap (this does memory allocation).
+ * The caller is responsible for memory management.
  */
 roaring_bitmap_t *roaring_bitmap_copy(const roaring_bitmap_t *r);
 
-
 /**
- * Copies a  bitmap from src to dest. It is assumed that the pointer dest
+ * Copies a bitmap from src to dest. It is assumed that the pointer dest
  * is to an already allocated bitmap. The content of the dest bitmap is
  * freed/deleted.
  *
  * It might be preferable and simpler to call roaring_bitmap_copy except
  * that roaring_bitmap_overwrite can save on memory allocations.
- *
  */
 bool roaring_bitmap_overwrite(roaring_bitmap_t *dest,
-                                     const roaring_bitmap_t *src);
+                              const roaring_bitmap_t *src);
 
 /**
  * Print the content of the bitmap.
  */
-void roaring_bitmap_printf(const roaring_bitmap_t *ra);
+void roaring_bitmap_printf(const roaring_bitmap_t *r);
 
 /**
  * Computes the intersection between two bitmaps and returns new bitmap. The
- * caller is
- * responsible for memory management.
- *
+ * caller is responsible for memory management.
  */
-roaring_bitmap_t *roaring_bitmap_and(const roaring_bitmap_t *x1,
-                                     const roaring_bitmap_t *x2);
+roaring_bitmap_t *roaring_bitmap_and(const roaring_bitmap_t *r1,
+                                     const roaring_bitmap_t *r2);
 
 /**
  * Computes the size of the intersection between two bitmaps.
- *
  */
-uint64_t roaring_bitmap_and_cardinality(const roaring_bitmap_t *x1,
-                                        const roaring_bitmap_t *x2);
-
+uint64_t roaring_bitmap_and_cardinality(const roaring_bitmap_t *r1,
+                                        const roaring_bitmap_t *r2);
 
 /**
  * Check whether two bitmaps intersect.
- *
  */
-bool roaring_bitmap_intersect(const roaring_bitmap_t *x1,
-                                     const roaring_bitmap_t *x2);
+bool roaring_bitmap_intersect(const roaring_bitmap_t *r1,
+                              const roaring_bitmap_t *r2);
 
 /**
  * Computes the Jaccard index between two bitmaps. (Also known as the Tanimoto
- * distance,
- * or the Jaccard similarity coefficient)
+ * distance, or the Jaccard similarity coefficient)
  *
  * The Jaccard index is undefined if both bitmaps are empty.
- *
  */
-double roaring_bitmap_jaccard_index(const roaring_bitmap_t *x1,
-                                    const roaring_bitmap_t *x2);
+double roaring_bitmap_jaccard_index(const roaring_bitmap_t *r1,
+                                    const roaring_bitmap_t *r2);
 
 /**
  * Computes the size of the union between two bitmaps.
- *
  */
-uint64_t roaring_bitmap_or_cardinality(const roaring_bitmap_t *x1,
-                                       const roaring_bitmap_t *x2);
+uint64_t roaring_bitmap_or_cardinality(const roaring_bitmap_t *r1,
+                                       const roaring_bitmap_t *r2);
 
 /**
  * Computes the size of the difference (andnot) between two bitmaps.
- *
  */
-uint64_t roaring_bitmap_andnot_cardinality(const roaring_bitmap_t *x1,
-                                           const roaring_bitmap_t *x2);
+uint64_t roaring_bitmap_andnot_cardinality(const roaring_bitmap_t *r1,
+                                           const roaring_bitmap_t *r2);
 
 /**
- * Computes the size of the symmetric difference (andnot) between two bitmaps.
- *
+ * Computes the size of the symmetric difference (xor) between two bitmaps.
  */
-uint64_t roaring_bitmap_xor_cardinality(const roaring_bitmap_t *x1,
-                                        const roaring_bitmap_t *x2);
+uint64_t roaring_bitmap_xor_cardinality(const roaring_bitmap_t *r1,
+                                        const roaring_bitmap_t *r2);
 
 /**
- * Inplace version modifies x1, x1 == x2 is allowed
+ * Inplace version of `roaring_bitmap_and()`, modifies r1
+ * r1 == r2 is allowed
  */
-void roaring_bitmap_and_inplace(roaring_bitmap_t *x1,
-                                const roaring_bitmap_t *x2);
+void roaring_bitmap_and_inplace(roaring_bitmap_t *r1,
+                                const roaring_bitmap_t *r2);
 
 /**
  * Computes the union between two bitmaps and returns new bitmap. The caller is
  * responsible for memory management.
  */
-roaring_bitmap_t *roaring_bitmap_or(const roaring_bitmap_t *x1,
-                                    const roaring_bitmap_t *x2);
+roaring_bitmap_t *roaring_bitmap_or(const roaring_bitmap_t *r1,
+                                    const roaring_bitmap_t *r2);
 
 /**
- * Inplace version of roaring_bitmap_or, modifies x1. TDOO: decide whether x1 ==
- *x2 ok
- *
+ * Inplace version of `roaring_bitmap_or(), modifies r1.
+ * TODO: decide whether r1 == r2 ok
  */
-void roaring_bitmap_or_inplace(roaring_bitmap_t *x1,
-                               const roaring_bitmap_t *x2);
+void roaring_bitmap_or_inplace(roaring_bitmap_t *r1,
+                               const roaring_bitmap_t *r2);
 
 /**
- * Compute the union of 'number' bitmaps. See also roaring_bitmap_or_many_heap.
- * Caller is responsible for freeing the
- * result.
- *
+ * Compute the union of 'number' bitmaps.
+ * Caller is responsible for freeing the result.
+ * See also `roaring_bitmap_or_many_heap()`
  */
 roaring_bitmap_t *roaring_bitmap_or_many(size_t number,
-                                         const roaring_bitmap_t **x);
+                                         const roaring_bitmap_t **rs);
 
 /**
- * Compute the union of 'number' bitmaps using a heap. This can
- * sometimes be faster than roaring_bitmap_or_many which uses
- * a naive algorithm. Caller is responsible for freeing the
- * result.
- *
+ * Compute the union of 'number' bitmaps using a heap. This can sometimes be
+ * faster than `roaring_bitmap_or_many() which uses a naive algorithm.
+ * Caller is responsible for freeing the result.
  */
 roaring_bitmap_t *roaring_bitmap_or_many_heap(uint32_t number,
-                                              const roaring_bitmap_t **x);
+                                              const roaring_bitmap_t **rs);
 
 /**
  * Computes the symmetric difference (xor) between two bitmaps
  * and returns new bitmap. The caller is responsible for memory management.
  */
-roaring_bitmap_t *roaring_bitmap_xor(const roaring_bitmap_t *x1,
-                                     const roaring_bitmap_t *x2);
+roaring_bitmap_t *roaring_bitmap_xor(const roaring_bitmap_t *r1,
+                                     const roaring_bitmap_t *r2);
 
 /**
- * Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
- *
+ * Inplace version of roaring_bitmap_xor, modifies r1, r1 != r2.
  */
-void roaring_bitmap_xor_inplace(roaring_bitmap_t *x1,
-                                const roaring_bitmap_t *x2);
+void roaring_bitmap_xor_inplace(roaring_bitmap_t *r1,
+                                const roaring_bitmap_t *r2);
 
 /**
  * Compute the xor of 'number' bitmaps.
- * Caller is responsible for freeing the
- * result.
- *
+ * Caller is responsible for freeing the result.
  */
 roaring_bitmap_t *roaring_bitmap_xor_many(size_t number,
-                                          const roaring_bitmap_t **x);
+                                          const roaring_bitmap_t **rs);
 
 /**
- * Computes the  difference (andnot) between two bitmaps
- * and returns new bitmap. The caller is responsible for memory management.
+ * Computes the difference (andnot) between two bitmaps and returns new bitmap.
+ * Caller is responsible for freeing the result.
  */
-roaring_bitmap_t *roaring_bitmap_andnot(const roaring_bitmap_t *x1,
-                                        const roaring_bitmap_t *x2);
+roaring_bitmap_t *roaring_bitmap_andnot(const roaring_bitmap_t *r1,
+                                        const roaring_bitmap_t *r2);
 
 /**
- * Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
- *
+ * Inplace version of roaring_bitmap_andnot, modifies r1, r1 != r2.
  */
-void roaring_bitmap_andnot_inplace(roaring_bitmap_t *x1,
-                                   const roaring_bitmap_t *x2);
+void roaring_bitmap_andnot_inplace(roaring_bitmap_t *r1,
+                                   const roaring_bitmap_t *r2);
 
 /**
  * TODO: consider implementing:
- * Compute the xor of 'number' bitmaps using a heap. This can
- * sometimes be faster than roaring_bitmap_xor_many which uses
- * a naive algorithm. Caller is responsible for freeing the
- * result.
+ *
+ * "Compute the xor of 'number' bitmaps using a heap. This can sometimes be
+ *  faster than roaring_bitmap_xor_many which uses a naive algorithm. Caller is
+ *  responsible for freeing the result.""
  *
  * roaring_bitmap_t *roaring_bitmap_xor_many_heap(uint32_t number,
- *                                              const roaring_bitmap_t **x);
+ *                                                const roaring_bitmap_t **rs);
  */
 
 /**
@@ -268,53 +250,60 @@ void roaring_bitmap_free(const roaring_bitmap_t *r);
 
 /**
  * Add value n_args from pointer vals, faster than repeatedly calling
- * roaring_bitmap_add
- *
+ * `roaring_bitmap_add()`
  */
 void roaring_bitmap_add_many(roaring_bitmap_t *r, size_t n_args,
                              const uint32_t *vals);
 
 /**
  * Add value x
- *
  */
 void roaring_bitmap_add(roaring_bitmap_t *r, uint32_t x);
 
 /**
  * Add value x
- * Returns true if a new value was added, false if the value was already existing.
+ * Returns true if a new value was added, false if the value already existed.
  */
 bool roaring_bitmap_add_checked(roaring_bitmap_t *r, uint32_t x);
 
 /**
  * Add all values in range [min, max]
  */
-void roaring_bitmap_add_range_closed(roaring_bitmap_t *ra, uint32_t min, uint32_t max);
+void roaring_bitmap_add_range_closed(roaring_bitmap_t *r,
+                                     uint32_t min, uint32_t max);
 
 /**
  * Add all values in range [min, max)
  */
-static inline void roaring_bitmap_add_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
-  if(max == min) return;
-  roaring_bitmap_add_range_closed(ra, (uint32_t)min, (uint32_t)(max - 1));
+static inline void roaring_bitmap_add_range(roaring_bitmap_t *r,
+                                            uint64_t min, uint64_t max) {
+    if(max == min) return;
+    roaring_bitmap_add_range_closed(r, (uint32_t)min, (uint32_t)(max - 1));
 }
 
 /**
  * Remove value x
- *
  */
 void roaring_bitmap_remove(roaring_bitmap_t *r, uint32_t x);
 
-/** Remove all values in range [min, max] */
-void roaring_bitmap_remove_range_closed(roaring_bitmap_t *ra, uint32_t min, uint32_t max);
+/**
+ * Remove all values in range [min, max]
+ */
+void roaring_bitmap_remove_range_closed(roaring_bitmap_t *r,
+                                        uint32_t min, uint32_t max);
 
-/** Remove all values in range [min, max) */
-static inline void roaring_bitmap_remove_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max) {
+/**
+ * Remove all values in range [min, max)
+ */
+static inline void roaring_bitmap_remove_range(roaring_bitmap_t *r,
+                                               uint64_t min, uint64_t max) {
     if(max == min) return;
-    roaring_bitmap_remove_range_closed(ra, (uint32_t)min, (uint32_t)(max - 1));
+    roaring_bitmap_remove_range_closed(r, (uint32_t)min, (uint32_t)(max - 1));
 }
 
-/** Remove multiple values */
+/**
+ * Remove multiple values
+ */
 void roaring_bitmap_remove_many(roaring_bitmap_t *r, size_t n_args,
                                 const uint32_t *vals);
 
@@ -330,151 +319,160 @@ bool roaring_bitmap_remove_checked(roaring_bitmap_t *r, uint32_t x);
 bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val);
 
 /**
- * Check whether a range of values from range_start (included) to range_end (excluded) is present
+ * Check whether a range of values from range_start (included)
+ * to range_end (excluded) is present
  */
-bool roaring_bitmap_contains_range(const roaring_bitmap_t *r, uint64_t range_start, uint64_t range_end);
+bool roaring_bitmap_contains_range(const roaring_bitmap_t *r,
+                                   uint64_t range_start,
+                                   uint64_t range_end);
 
 /**
  * Get the cardinality of the bitmap (number of elements).
  */
-uint64_t roaring_bitmap_get_cardinality(const roaring_bitmap_t *ra);
+uint64_t roaring_bitmap_get_cardinality(const roaring_bitmap_t *r);
 
 /**
  * Returns the number of elements in the range [range_start, range_end).
  */
-uint64_t roaring_bitmap_range_cardinality(const roaring_bitmap_t *ra,
-                                          uint64_t range_start, uint64_t range_end);
+uint64_t roaring_bitmap_range_cardinality(const roaring_bitmap_t *r,
+                                          uint64_t range_start,
+                                          uint64_t range_end);
 
 /**
 * Returns true if the bitmap is empty (cardinality is zero).
 */
-bool roaring_bitmap_is_empty(const roaring_bitmap_t *ra);
+bool roaring_bitmap_is_empty(const roaring_bitmap_t *r);
 
 
 /**
  * Empties the bitmap.  It will have no auxiliary allocations (so if the bitmap
  * was initialized in client memory via roaring_bitmap_init(), then a call to
- * roaring_bitmap_clear() would be enough to "free" it) 
+ * roaring_bitmap_clear() would be enough to "free" it)
  */
-void roaring_bitmap_clear(roaring_bitmap_t *ra);
+void roaring_bitmap_clear(roaring_bitmap_t *r);
 
 /**
- * Convert the bitmap to an array. Write the output to "ans",
- * caller is responsible to ensure that there is enough memory
- * allocated
- * (e.g., ans = malloc(roaring_bitmap_get_cardinality(mybitmap)
- *   * sizeof(uint32_t))
+ * Convert the bitmap to an array, output in `ans`,
+ *
+ * Caller is responsible to ensure that there is enough memory allocated, e.g.
+ *
+ *     ans = malloc(roaring_bitmap_get_cardinality(bitmap) * sizeof(uint32_t));
  */
-void roaring_bitmap_to_uint32_array(const roaring_bitmap_t *ra, uint32_t *ans);
+void roaring_bitmap_to_uint32_array(const roaring_bitmap_t *r, uint32_t *ans);
 
 
 /**
- * Convert the bitmap to an array from "offset" by "limit". Write the output to "ans".
- * so, you can get data in paging.
- * caller is responsible to ensure that there is enough memory
- * allocated
- * (e.g., ans = malloc(roaring_bitmap_get_cardinality(limit)
- *   * sizeof(uint32_t))
+ * Convert the bitmap to an array from `offset` by `limit`, output in `ans`.
+ *
+ * Caller is responsible to ensure that there is enough memory allocated, e.g.
+ *
+ *     ans = malloc(roaring_bitmap_get_cardinality(limit) * sizeof(uint32_t));
+ *
  * Return false in case of failure (e.g., insufficient memory)
  */
-bool roaring_bitmap_range_uint32_array(const roaring_bitmap_t *ra, size_t offset, size_t limit, uint32_t *ans);
+bool roaring_bitmap_range_uint32_array(const roaring_bitmap_t *r,
+                                       size_t offset, size_t limit,
+                                       uint32_t *ans);
 
 /**
- *  Remove run-length encoding even when it is more space efficient
- *  return whether a change was applied
+ * Remove run-length encoding even when it is more space efficient.
+ * Return whether a change was applied.
  */
 bool roaring_bitmap_remove_run_compression(roaring_bitmap_t *r);
 
-/** convert array and bitmap containers to run containers when it is more
- * efficient;
- * also convert from run containers when more space efficient.  Returns
- * true if the result has at least one run container.
- * Additional savings might be possible by calling shrinkToFit().
+/**
+ * Convert array and bitmap containers to run containers when it is more
+ * efficient; also convert from run containers when more space efficient.
+ *
+ * Returns true if the result has at least one run container.
+ * Additional savings might be possible by calling `shrinkToFit()`.
  */
 bool roaring_bitmap_run_optimize(roaring_bitmap_t *r);
 
 /**
- * If needed, reallocate memory to shrink the memory usage. Returns
- * the number of bytes saved.
-*/
+ * If needed, reallocate memory to shrink the memory usage.
+ * Returns the number of bytes saved.
+ */
 size_t roaring_bitmap_shrink_to_fit(roaring_bitmap_t *r);
 
 /**
-* write the bitmap to an output pointer, this output buffer should refer to
-* at least roaring_bitmap_size_in_bytes(ra) allocated bytes.
-*
-* see roaring_bitmap_portable_serialize if you want a format that's compatible
-* with Java and Go implementations
-*
-* this format has the benefit of being sometimes more space efficient than
-* roaring_bitmap_portable_serialize
-* e.g., when the data is sparse.
-*
-* Returns how many bytes were written which should be
-* roaring_bitmap_size_in_bytes(ra).
-*/
-size_t roaring_bitmap_serialize(const roaring_bitmap_t *ra, char *buf);
+ * Write the bitmap to an output pointer, this output buffer should refer to
+ * at least `roaring_bitmap_size_in_bytes(r)` allocated bytes.
+ *
+ * See `roaring_bitmap_portable_serialize()` if you want a format that's
+ * compatible with Java and Go implementations.  This format can sometimes be
+ * more space efficient than the portable form, e.g. when the data is sparse.
+ *
+ * Returns how many bytes written, should be `roaring_bitmap_size_in_bytes(r)`.
+ */
+size_t roaring_bitmap_serialize(const roaring_bitmap_t *r, char *buf);
 
-/**  use with roaring_bitmap_serialize
-* see roaring_bitmap_portable_deserialize if you want a format that's
-* compatible with Java and Go implementations
-*/
+/**
+ * Use with `roaring_bitmap_serialize()`.
+ *
+ * (See `roaring_bitmap_portable_deserialize()` if you want a format that's
+ * compatible with Java and Go implementations)
+ */
 roaring_bitmap_t *roaring_bitmap_deserialize(const void *buf);
 
 /**
  * How many bytes are required to serialize this bitmap (NOT compatible
  * with Java and Go versions)
  */
-size_t roaring_bitmap_size_in_bytes(const roaring_bitmap_t *ra);
+size_t roaring_bitmap_size_in_bytes(const roaring_bitmap_t *r);
 
 /**
- * read a bitmap from a serialized version. This is meant to be compatible with
- * the Java and Go versions. See format specification at
- * https://github.com/RoaringBitmap/RoaringFormatSpec
- * In case of failure, a null pointer is returned.
+ * Read bitmap from a serialized buffer.
+ * In case of failure, NULL is returned.
+ *
  * This function is unsafe in the sense that if there is no valid serialized
- * bitmap at the pointer, then many bytes could be read, possibly causing a buffer
- * overflow. For a safer approach,
- * call roaring_bitmap_portable_deserialize_safe.
+ * bitmap at the pointer, then many bytes could be read, possibly causing a
+ * buffer overflow.  See also roaring_bitmap_portable_deserialize_safe().
+ *
+ * This is meant to be compatible with the Java and Go versions:
+ * https://github.com/RoaringBitmap/RoaringFormatSpec
  */
 roaring_bitmap_t *roaring_bitmap_portable_deserialize(const char *buf);
 
 /**
- * read a bitmap from a serialized version in a safe manner (reading up to maxbytes).
- * This is meant to be compatible with
- * the Java and Go versions. See format specification at
+ * Read bitmap from a serialized buffer safely (reading up to maxbytes).
+ * In case of failure, NULL is returned.
+ *
+ * This is meant to be compatible with the Java and Go versions:
  * https://github.com/RoaringBitmap/RoaringFormatSpec
- * In case of failure, a null pointer is returned.
  */
-roaring_bitmap_t *roaring_bitmap_portable_deserialize_safe(const char *buf, size_t maxbytes);
+roaring_bitmap_t *roaring_bitmap_portable_deserialize_safe(const char *buf,
+                                                           size_t maxbytes);
 
 /**
  * Check how many bytes would be read (up to maxbytes) at this pointer if there
  * is a bitmap, returns zero if there is no valid bitmap.
- * This is meant to be compatible with
- * the Java and Go versions. See format specification at
+ *
+ * This is meant to be compatible with the Java and Go versions:
  * https://github.com/RoaringBitmap/RoaringFormatSpec
  */
-size_t roaring_bitmap_portable_deserialize_size(const char *buf, size_t maxbytes);
-
-
-/**
- * How many bytes are required to serialize this bitmap (meant to be compatible
- * with Java and Go versions).  See format specification at
- * https://github.com/RoaringBitmap/RoaringFormatSpec
- */
-size_t roaring_bitmap_portable_size_in_bytes(const roaring_bitmap_t *ra);
+size_t roaring_bitmap_portable_deserialize_size(const char *buf,
+                                                size_t maxbytes);
 
 /**
- * write a bitmap to a char buffer.  The output buffer should refer to at least
- *  roaring_bitmap_portable_size_in_bytes(ra) bytes of allocated memory.
- * This is meant to be compatible with
- * the
- * Java and Go versions. Returns how many bytes were written which should be
- * roaring_bitmap_portable_size_in_bytes(ra).  See format specification at
+ * How many bytes are required to serialize this bitmap.
+ *
+ * This is meant to be compatible with the Java and Go versions:
  * https://github.com/RoaringBitmap/RoaringFormatSpec
  */
-size_t roaring_bitmap_portable_serialize(const roaring_bitmap_t *ra, char *buf);
+size_t roaring_bitmap_portable_size_in_bytes(const roaring_bitmap_t *r);
+
+/**
+ * Write a bitmap to a char buffer.  The output buffer should refer to at least
+ * `roaring_bitmap_portable_size_in_bytes(r)` bytes of allocated memory.
+ *
+ * Returns how many bytes were written which should match
+ * `roaring_bitmap_portable_size_in_bytes(r)`.
+ *
+ * This is meant to be compatible with the Java and Go versions:
+ * https://github.com/RoaringBitmap/RoaringFormatSpec
+ */
+size_t roaring_bitmap_portable_serialize(const roaring_bitmap_t *r, char *buf);
 
 /*
  * "Frozen" serialization format imitates memory layout of roaring_bitmap_t.
@@ -498,66 +496,63 @@ size_t roaring_bitmap_portable_serialize(const roaring_bitmap_t *ra, char *buf);
 /**
  * Returns number of bytes required to serialize bitmap using frozen format.
  */
-size_t roaring_bitmap_frozen_size_in_bytes(const roaring_bitmap_t *ra);
+size_t roaring_bitmap_frozen_size_in_bytes(const roaring_bitmap_t *r);
 
 /**
  * Serializes bitmap using frozen format.
  * Buffer size must be at least roaring_bitmap_frozen_size_in_bytes().
  */
-void roaring_bitmap_frozen_serialize(const roaring_bitmap_t *ra, char *buf);
+void roaring_bitmap_frozen_serialize(const roaring_bitmap_t *r, char *buf);
 
 /**
  * Creates constant bitmap that is a view of a given buffer.
- * Buffer must contain data previously written by roaring_bitmap_frozen_serialize(),
- * and additionally its beginning must be aligned by 32 bytes.
- * Length must be equal exactly to roaring_bitmap_frozen_size_in_bytes().
- *
- * On error, NULL is returned.
+ * Buffer data should have been written by `roaring_bitmap_frozen_serialize()`
+ * Its beginning must also be aligned by 32 bytes.
+ * Length must be equal exactly to `roaring_bitmap_frozen_size_in_bytes()`.
+ * In case of failure, NULL is returned.
  *
  * Bitmap returned by this function can be used in all readonly contexts.
  * Bitmap must be freed as usual, by calling roaring_bitmap_free().
  * Underlying buffer must not be freed or modified while it backs any bitmaps.
  */
-const roaring_bitmap_t *roaring_bitmap_frozen_view(const char *buf, size_t length);
-
+const roaring_bitmap_t *roaring_bitmap_frozen_view(const char *buf,
+                                                   size_t length);
 
 /**
  * Iterate over the bitmap elements. The function iterator is called once for
- *  all the values with ptr (can be NULL) as the second parameter of each call.
+ * all the values with ptr (can be NULL) as the second parameter of each call.
  *
- *  roaring_iterator is simply a pointer to a function that returns bool
- *  (true means that the iteration should continue while false means that it
- * should stop),
- *  and takes (uint32_t,void*) as inputs.
+ * `roaring_iterator` is simply a pointer to a function that returns bool
+ * (true means that the iteration should continue while false means that it
+ * should stop), and takes (uint32_t,void*) as inputs.
  *
- *  Returns true if the roaring_iterator returned true throughout (so that
- *  all data points were necessarily visited).
+ * Returns true if the roaring_iterator returned true throughout (so that all
+ * data points were necessarily visited).
  */
-bool roaring_iterate(const roaring_bitmap_t *ra, roaring_iterator iterator,
+bool roaring_iterate(const roaring_bitmap_t *r, roaring_iterator iterator,
                      void *ptr);
 
-bool roaring_iterate64(const roaring_bitmap_t *ra, roaring_iterator64 iterator,
+bool roaring_iterate64(const roaring_bitmap_t *r, roaring_iterator64 iterator,
                        uint64_t high_bits, void *ptr);
 
 /**
  * Return true if the two bitmaps contain the same elements.
  */
-bool roaring_bitmap_equals(const roaring_bitmap_t *ra1,
-                           const roaring_bitmap_t *ra2);
+bool roaring_bitmap_equals(const roaring_bitmap_t *r1,
+                           const roaring_bitmap_t *r2);
 
 /**
- * Return true if all the elements of ra1 are also in ra2.
+ * Return true if all the elements of r1 are also in r2.
  */
-bool roaring_bitmap_is_subset(const roaring_bitmap_t *ra1,
-                              const roaring_bitmap_t *ra2);
+bool roaring_bitmap_is_subset(const roaring_bitmap_t *r1,
+                              const roaring_bitmap_t *r2);
 
 /**
- * Return true if all the elements of ra1 are also in ra2 and ra2 is strictly
- * greater
- * than ra1.
+ * Return true if all the elements of r1 are also in r2, and r2 is strictly
+ * greater than r1.
  */
-bool roaring_bitmap_is_strict_subset(const roaring_bitmap_t *ra1,
-                                            const roaring_bitmap_t *ra2);
+bool roaring_bitmap_is_strict_subset(const roaring_bitmap_t *r1,
+                                     const roaring_bitmap_t *r2);
 
 /**
  * (For expert users who seek high performance.)
@@ -566,65 +561,66 @@ bool roaring_bitmap_is_strict_subset(const roaring_bitmap_t *ra1,
  * responsible for memory management.
  *
  * The lazy version defers some computations such as the maintenance of the
- * cardinality counts. Thus you need
- * to call roaring_bitmap_repair_after_lazy after executing "lazy" computations.
+ * cardinality counts. Thus you must call `roaring_bitmap_repair_after_lazy()`
+ * after executing "lazy" computations.
+ *
  * It is safe to repeatedly call roaring_bitmap_lazy_or_inplace on the result.
- * The bitsetconversion conversion is a flag which determines
- * whether container-container operations force a bitset conversion.
- **/
-roaring_bitmap_t *roaring_bitmap_lazy_or(const roaring_bitmap_t *x1,
-                                         const roaring_bitmap_t *x2,
+ *
+ * `bitsetconversion` is a flag which determines whether container-container
+ * operations force a bitset conversion.
+ */
+roaring_bitmap_t *roaring_bitmap_lazy_or(const roaring_bitmap_t *r1,
+                                         const roaring_bitmap_t *r2,
                                          const bool bitsetconversion);
 
 /**
  * (For expert users who seek high performance.)
- * Inplace version of roaring_bitmap_lazy_or, modifies x1
- * The bitsetconversion conversion is a flag which determines
- * whether container-container operations force a bitset conversion.
+ *
+ * Inplace version of roaring_bitmap_lazy_or, modifies r1.
+ *
+ * `bitsetconversion` is a flag which determines whether container-container
+ * operations force a bitset conversion.
  */
-void roaring_bitmap_lazy_or_inplace(roaring_bitmap_t *x1,
-                                    const roaring_bitmap_t *x2,
+void roaring_bitmap_lazy_or_inplace(roaring_bitmap_t *r1,
+                                    const roaring_bitmap_t *r2,
                                     const bool bitsetconversion);
 
 /**
  * (For expert users who seek high performance.)
  *
- * Execute maintenance operations on a bitmap created from
- * roaring_bitmap_lazy_or
- * or modified with roaring_bitmap_lazy_or_inplace.
+ * Execute maintenance on a bitmap created from `roaring_bitmap_lazy_or()`
+ * or modified with `roaring_bitmap_lazy_or_inplace()`.
  */
-void roaring_bitmap_repair_after_lazy(roaring_bitmap_t *x1);
+void roaring_bitmap_repair_after_lazy(roaring_bitmap_t *r1);
 
 /**
  * Computes the symmetric difference between two bitmaps and returns new bitmap.
- *The caller is
- * responsible for memory management.
+ * The caller is responsible for memory management.
  *
  * The lazy version defers some computations such as the maintenance of the
- * cardinality counts. Thus you need
- * to call roaring_bitmap_repair_after_lazy after executing "lazy" computations.
- * It is safe to repeatedly call roaring_bitmap_lazy_xor_inplace on the result.
+ * cardinality counts. Thus you must call `roaring_bitmap_repair_after_lazy()`
+ * after executing "lazy" computations.
  *
+ * It is safe to repeatedly call `roaring_bitmap_lazy_xor_inplace()` on
+ * the result.
  */
-roaring_bitmap_t *roaring_bitmap_lazy_xor(const roaring_bitmap_t *x1,
-                                          const roaring_bitmap_t *x2);
+roaring_bitmap_t *roaring_bitmap_lazy_xor(const roaring_bitmap_t *r1,
+                                          const roaring_bitmap_t *r2);
 
 /**
  * (For expert users who seek high performance.)
- * Inplace version of roaring_bitmap_lazy_xor, modifies x1. x1 != x2
  *
+ * Inplace version of roaring_bitmap_lazy_xor, modifies r1. r1 != r2
  */
-void roaring_bitmap_lazy_xor_inplace(roaring_bitmap_t *x1,
-                                     const roaring_bitmap_t *x2);
+void roaring_bitmap_lazy_xor_inplace(roaring_bitmap_t *r1,
+                                     const roaring_bitmap_t *r2);
 
 /**
- * compute the negation of the roaring bitmap within a specified
- * interval: [range_start, range_end). The number of negated values is
- * range_end - range_start.
+ * Compute the negation of the bitmap in the interval [range_start, range_end).
+ * The number of negated values is range_end - range_start.
  * Areas outside the range are passed through unchanged.
  */
-
-roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *x1,
+roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *r1,
                                       uint64_t range_start, uint64_t range_end);
 
 /**
@@ -633,56 +629,55 @@ roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *x1,
  * range_end - range_start.
  * Areas outside the range are passed through unchanged.
  */
-
-void roaring_bitmap_flip_inplace(roaring_bitmap_t *x1, uint64_t range_start,
+void roaring_bitmap_flip_inplace(roaring_bitmap_t *r1, uint64_t range_start,
                                  uint64_t range_end);
 
 /**
  * Selects the element at index 'rank' where the smallest element is at index 0.
  * If the size of the roaring bitmap is strictly greater than rank, then this
-   function returns true and sets element to the element of given rank.
-   Otherwise, it returns false.
+ * function returns true and sets element to the element of given rank.
+ * Otherwise, it returns false.
  */
-bool roaring_bitmap_select(const roaring_bitmap_t *ra, uint32_t rank,
+bool roaring_bitmap_select(const roaring_bitmap_t *r, uint32_t rank,
                            uint32_t *element);
-/**
-* roaring_bitmap_rank returns the number of integers that are smaller or equal
-* to x. Thus if x is the first element, this function will return 1. If
-* x is smaller than the smallest element, this function will return 0.
-*
-* The indexing convention differs between roaring_bitmap_select and
-* roaring_bitmap_rank: roaring_bitmap_select refers to the smallest value
-* as having index 0, whereas roaring_bitmap_rank returns 1 when ranking
-* the smallest value.
-*/
-uint64_t roaring_bitmap_rank(const roaring_bitmap_t *bm, uint32_t x);
 
 /**
-* roaring_bitmap_smallest returns the smallest value in the set.
-* Returns UINT32_MAX if the set is empty.
-*/
-uint32_t roaring_bitmap_minimum(const roaring_bitmap_t *bm);
+ * roaring_bitmap_rank returns the number of integers that are smaller or equal
+ * to x. Thus if x is the first element, this function will return 1. If
+ * x is smaller than the smallest element, this function will return 0.
+ *
+ * The indexing convention differs between roaring_bitmap_select and
+ * roaring_bitmap_rank: roaring_bitmap_select refers to the smallest value
+ * as having index 0, whereas roaring_bitmap_rank returns 1 when ranking
+ * the smallest value.
+ */
+uint64_t roaring_bitmap_rank(const roaring_bitmap_t *r, uint32_t x);
 
 /**
-* roaring_bitmap_smallest returns the greatest value in the set.
-* Returns 0 if the set is empty.
-*/
-uint32_t roaring_bitmap_maximum(const roaring_bitmap_t *bm);
+ * Returns the smallest value in the set, or UINT32_MAX if the set is empty.
+ */
+uint32_t roaring_bitmap_minimum(const roaring_bitmap_t *r);
 
 /**
-*  (For advanced users.)
-* Collect statistics about the bitmap, see roaring_types.h for
-* a description of roaring_statistics_t
-*/
-void roaring_bitmap_statistics(const roaring_bitmap_t *ra,
+ * Returns the greatest value in the set, or 0 if the set is empty.
+ */
+uint32_t roaring_bitmap_maximum(const roaring_bitmap_t *r);
+
+/**
+ * (For advanced users.)
+ *
+ * Collect statistics about the bitmap, see roaring_types.h for
+ * a description of roaring_statistics_t
+ */
+void roaring_bitmap_statistics(const roaring_bitmap_t *r,
                                roaring_statistics_t *stat);
 
 /*********************
 * What follows is code use to iterate through values in a roaring bitmap
 
-roaring_bitmap_t *ra =...
-roaring_uint32_iterator_t   i;
-roaring_create_iterator(ra, &i);
+roaring_bitmap_t *r =...
+roaring_uint32_iterator_t i;
+roaring_create_iterator(r, &i);
 while(i.has_value) {
   printf("value = %d\n", i.current_value);
   roaring_advance_uint32_iterator(&i);
@@ -714,61 +709,63 @@ typedef struct roaring_uint32_iterator_s {
 } roaring_uint32_iterator_t;
 
 /**
-* Initialize an iterator object that can be used to iterate through the
-* values. If there is a  value, then this iterator points to the first value
-* and it->has_value is true. The value is in it->current_value.
-*/
-void roaring_init_iterator(const roaring_bitmap_t *ra,
+ * Initialize an iterator object that can be used to iterate through the
+ * values. If there is a  value, then this iterator points to the first value
+ * and `it->has_value` is true. The value is in `it->current_value`.
+ */
+void roaring_init_iterator(const roaring_bitmap_t *r,
                            roaring_uint32_iterator_t *newit);
 
 /**
-* Initialize an iterator object that can be used to iterate through the
-* values. If there is a value, then this iterator points to the last value
-* and it->has_value is true. The value is in it->current_value.
-*/
-void roaring_init_iterator_last(const roaring_bitmap_t *ra,
+ * Initialize an iterator object that can be used to iterate through the
+ * values. If there is a value, then this iterator points to the last value
+ * and `it->has_value` is true. The value is in `it->current_value`.
+ */
+void roaring_init_iterator_last(const roaring_bitmap_t *r,
                                 roaring_uint32_iterator_t *newit);
 
 /**
-* Create an iterator object that can be used to iterate through the
-* values. Caller is responsible for calling roaring_free_iterator.
-* The iterator is initialized. If there is a  value, then this iterator
-* points to the first value and it->has_value is true.
-* The value is in it->current_value.
-*
-* This function calls roaring_init_iterator.
-*/
-roaring_uint32_iterator_t *roaring_create_iterator(const roaring_bitmap_t *ra);
+ * Create an iterator object that can be used to iterate through the values.
+ * Caller is responsible for calling `roaring_free_iterator()`.
+ *
+ * The iterator is initialized (this function calls `roaring_init_iterator()`)
+ * If there is a value, then this iterator points to the first value and
+ * `it->has_value` is true.  The value is in `it->current_value`.
+ */
+roaring_uint32_iterator_t *roaring_create_iterator(const roaring_bitmap_t *r);
 
 /**
-* Advance the iterator. If there is a new value, then it->has_value is true.
-* The new value is in it->current_value. Values are traversed in increasing
-* orders. For convenience, returns it->has_value.
+* Advance the iterator. If there is a new value, then `it->has_value` is true.
+* The new value is in `it->current_value`. Values are traversed in increasing
+* orders. For convenience, returns `it->has_value`.
 */
 bool roaring_advance_uint32_iterator(roaring_uint32_iterator_t *it);
 
 /**
-* Decrement the iterator. If there is a new value, then it->has_value is true.
-* The new value is in it->current_value. Values are traversed in decreasing
-* orders. For convenience, returns it->has_value.
+* Decrement the iterator. If there's a new value, then `it->has_value` is true.
+* The new value is in `it->current_value`. Values are traversed in decreasing
+* order. For convenience, returns `it->has_value`.
 */
 bool roaring_previous_uint32_iterator(roaring_uint32_iterator_t *it);
 
 /**
-* Move the iterator to the first value >= val. If there is a such a value, then it->has_value is true.
-* The new value is in it->current_value. For convenience, returns it->has_value.
-*/
-bool roaring_move_uint32_iterator_equalorlarger(roaring_uint32_iterator_t *it, uint32_t val) ;
+ * Move the iterator to the first value >= `val`. If there is a such a value,
+ * then `it->has_value` is true. The new value is in `it->current_value`.
+ * For convenience, returns `it->has_value`.
+ */
+bool roaring_move_uint32_iterator_equalorlarger(roaring_uint32_iterator_t *it,
+                                                uint32_t val);
+
 /**
-* Creates a copy of an iterator.
-* Caller must free it.
-*/
+ * Creates a copy of an iterator.
+ * Caller must free it.
+ */
 roaring_uint32_iterator_t *roaring_copy_uint32_iterator(
     const roaring_uint32_iterator_t *it);
 
 /**
-* Free memory following roaring_create_iterator
-*/
+ * Free memory following `roaring_create_iterator()`
+ */
 void roaring_free_uint32_iterator(roaring_uint32_iterator_t *it);
 
 /*
@@ -781,7 +778,8 @@ void roaring_free_uint32_iterator(roaring_uint32_iterator_t *it);
  *  - first value is copied from ${it}->current_value
  *  - after function returns, iterator is positioned at the next element
  */
-uint32_t roaring_read_uint32_iterator(roaring_uint32_iterator_t *it, uint32_t* buf, uint32_t count);
+uint32_t roaring_read_uint32_iterator(roaring_uint32_iterator_t *it,
+                                      uint32_t* buf, uint32_t count);
 
 #ifdef __cplusplus
 } } }  // extern "C" { namespace roaring { namespace api {
@@ -798,7 +796,7 @@ uint32_t roaring_read_uint32_iterator(roaring_uint32_iterator_t *it, uint32_t* b
      * BUT when `roaring.hh` is included instead, it sets this flag.  That way
      * explicit namespacing must be used to get the C functions.
      *
-     * This is outside the include guard so that if you include BOTH headers, 
+     * This is outside the include guard so that if you include BOTH headers,
      * the order won't matter; you still get the global definitions.
      */
     #if !defined(ROARING_API_NOT_IN_GLOBAL_NAMESPACE)

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -371,11 +371,11 @@ void array_container_printf_as_uint32_array(const array_container_t *v,
 }
 
 /* Compute the number of runs */
-int32_t array_container_number_of_runs(const array_container_t *a) {
+int32_t array_container_number_of_runs(const array_container_t *ac) {
     // Can SIMD work here?
     int32_t nr_runs = 0;
     int32_t prev = -2;
-    for (const uint16_t *p = a->array; p != a->array + a->cardinality; ++p) {
+    for (const uint16_t *p = ac->array; p != ac->array + ac->cardinality; ++p) {
         if (*p != prev + 1) nr_runs++;
         prev = *p;
     }

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -505,13 +505,13 @@ void bitset_container_printf_as_uint32_array(const bitset_container_t * v, uint3
 
 
 // TODO: use the fast lower bound, also
-int bitset_container_number_of_runs(bitset_container_t *b) {
+int bitset_container_number_of_runs(bitset_container_t *bc) {
   int num_runs = 0;
-  uint64_t next_word = b->words[0];
+  uint64_t next_word = bc->words[0];
 
   for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS-1; ++i) {
     uint64_t word = next_word;
-    next_word = b->words[i+1];
+    next_word = bc->words[i+1];
     num_runs += hamming((~word) & (word << 1)) + ( (word >> 63) & ~next_word);
   }
 

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -437,14 +437,21 @@ BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
 
 
 
-int bitset_container_to_uint32_array( void *vout, const bitset_container_t *cont, uint32_t base) {
+int bitset_container_to_uint32_array(
+    uint32_t *out,
+    const bitset_container_t *bc,
+    uint32_t base
+){
 #ifdef USEAVX2FORDECODING
-	if(cont->cardinality >= 8192)// heuristic
-		return (int) bitset_extract_setbits_avx2(cont->words, BITSET_CONTAINER_SIZE_IN_WORDS, vout,cont->cardinality,base);
+	if (bc->cardinality >= 8192)  // heuristic
+		return (int) bitset_extract_setbits_avx2(bc->words,
+                BITSET_CONTAINER_SIZE_IN_WORDS, out, bc->cardinality, base);
 	else
-		return (int) bitset_extract_setbits(cont->words, BITSET_CONTAINER_SIZE_IN_WORDS, vout,base);
+		return (int) bitset_extract_setbits(bc->words,
+                BITSET_CONTAINER_SIZE_IN_WORDS, out, base);
 #else
-	return (int) bitset_extract_setbits(cont->words, BITSET_CONTAINER_SIZE_IN_WORDS, vout,base);
+	return (int) bitset_extract_setbits(bc->words,
+                BITSET_CONTAINER_SIZE_IN_WORDS, out, base);
 #endif
 }
 

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -234,16 +234,16 @@ bool bitset_run_container_iandnot(
  * to avoid advanceUntil?
  */
 
-static int run_array_array_subtract(const run_container_t *r,
+static int run_array_array_subtract(const run_container_t *rc,
                                     const array_container_t *a_in,
                                     array_container_t *a_out) {
     int out_card = 0;
     int32_t in_array_pos =
         -1;  // since advanceUntil always assumes we start the search AFTER this
 
-    for (int rlepos = 0; rlepos < r->n_runs; rlepos++) {
-        int32_t start = r->runs[rlepos].value;
-        int32_t end = start + r->runs[rlepos].length + 1;
+    for (int rlepos = 0; rlepos < rc->n_runs; rlepos++) {
+        int32_t start = rc->runs[rlepos].value;
+        int32_t end = start + rc->runs[rlepos].length + 1;
 
         in_array_pos = advanceUntil(a_in->array, in_array_pos,
                                     a_in->cardinality, (uint16_t)start);

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -16,7 +16,7 @@ extern inline bool run_container_contains(const run_container_t *run,
                                           uint16_t pos);
 extern inline int run_container_index_equalorlarger(const run_container_t *arr, uint16_t x);
 extern inline bool run_container_is_full(const run_container_t *run);
-extern inline bool run_container_nonzero_cardinality(const run_container_t *r);
+extern inline bool run_container_nonzero_cardinality(const run_container_t *rc);
 extern inline void run_container_clear(run_container_t *run);
 extern inline int32_t run_container_serialized_size_in_bytes(int32_t num_runs);
 extern inline run_container_t *run_container_create_range(uint32_t start,

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -301,8 +301,7 @@ void roaring_bitmap_printf_describe(const roaring_bitmap_t *ra) {
         if (ra->high_low_container.typecodes[i] == SHARED_CONTAINER_TYPE) {
             printf(
                 "(shared count = %" PRIu32 " )",
-                ((shared_container_t *)(ra->high_low_container.containers[i]))
-                    ->counter);
+                (CAST_shared(ra->high_low_container.containers[i]))->counter);
         }
 
         if (i + 1 < ra->high_low_container.size) printf(", ");
@@ -986,7 +985,7 @@ void roaring_bitmap_xor_inplace(roaring_bitmap_t *x1,
             container_t *c;
             if (type1 == SHARED_CONTAINER_TYPE) {
                 c = container_xor(c1, type1, c2, type2, &result_type);
-                shared_container_free((shared_container_t *)c1);  // so release
+                shared_container_free(CAST_shared(c1));  // so release
             }
             else {
                 c = container_ixor(c1, type1, c2, type2, &result_type);
@@ -1139,7 +1138,7 @@ void roaring_bitmap_andnot_inplace(roaring_bitmap_t *x1,
             container_t *c;
             if (type1 == SHARED_CONTAINER_TYPE) {
                 c = container_andnot(c1, type1, c2, type2, &result_type);
-                shared_container_free((shared_container_t *)c1);  // release
+                shared_container_free(CAST_shared(c1));  // release
             }
             else {
                 c = container_iandnot(c1, type1, c2, type2, &result_type);
@@ -1322,12 +1321,11 @@ bool roaring_bitmap_remove_run_compression(roaring_bitmap_t *r) {
         if (get_container_type(c, type_original) == RUN_CONTAINER_TYPE) {
             answer = true;
             if (type_original == SHARED_CONTAINER_TYPE) {
-                run_container_t *truec =
-                    (run_container_t *)((shared_container_t *)c)->container;
+                run_container_t *truec = CAST_run(CAST_shared(c)->container);
                 int32_t card = run_container_cardinality(truec);
                 container_t *c1 = convert_to_bitset_or_array_container(
                                         truec, card, &type_after);
-                shared_container_free((shared_container_t *)c);// will free the run container as needed
+                shared_container_free(CAST_shared(c));  // frees run as needed
                 ra_set_container_at_index(&r->high_low_container, i, c1,
                                           type_after);
 
@@ -2412,7 +2410,7 @@ void roaring_bitmap_lazy_xor_inplace(roaring_bitmap_t *x1,
             container_t *c;
             if (type1 == SHARED_CONTAINER_TYPE) {
                 c = container_lazy_xor(c1, type1, c2, type2, &result_type);
-                shared_container_free((shared_container_t *)c1);  // release
+                shared_container_free(CAST_shared(c1));  // release
             }
             else {
                 c = container_lazy_ixor(c1, type1, c2, type2, &result_type);


### PR DESCRIPTION
In experimenting with the concept for the exposure of the API roaring_bitmap_t to allocator hooks, the distinction between `roaring_bitmap_t` and `roaring_array_t` becomes important; and routines that have an `ra` need to properly cast it to an `r` to pass through.

*(Note: Given the existence of `array_container_t` it might be better to call it a `roaring_highlow_t` or similar...it's easy to get those two mixed up.)*

This is the outgrowth of trying to normalize taking `r` as the common abbreviation for roaring bitmaps, as exposed in the API.  Since it involved editing several of the comments and prototypes in `roaring.h` I went ahead and tried to tidy up the file as a whole somewhat...until it was diminishing returns to do any more.

There is no (intentional) change in functionality from these commits.