### PR TITLE
Let us test installation.

### DIFF
--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -15,9 +15,10 @@ jobs:
     steps: 
       - uses: actions/checkout@v2
       - name: Build and Test
-        run: |
           mkdir build
           cd build
-          cmake  ..
+          cmake -DCMAKE_INSTALL_PREFIX:PATH=destination ..
           cmake --build . 
           ctest . --output-on-failure
+          cmake --install . 
+          cd ../tests/installation/find && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=../../../build/destination .. &&  cmake --build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,11 @@ SET(ROARING_DISABLE_NATIVE ON) # ARM platforms may not like -march=native
 endif()
 
 option(ROARING_BUILD_STATIC "Build a static library" ON)
+if(BUILD_SHARED_LIBS)
+  MESSAGE( STATUS "BUILD_SHARED_LIBS: " ${BUILD_SHARED_LIBS})
+  MESSAGE( STATUS "Building a shared library by request. ")
+  set(ROARING_BUILD_STATIC OFF)
+endif()
 option(ROARING_LINK_STATIC "Link executables (tests, benchmarks) statically" OFF)
 option(ROARING_BUILD_LTO "Build library with Link Time Optimization" OFF)
 option(ROARING_BUILD_C_AS_CPP "Build library C files using C++ compilation" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ SET(ROARING_DISABLE_AVX ON) # for ARM processors, there is no hope of having AVX
 SET(ROARING_DISABLE_NATIVE ON) # ARM platforms may not like -march=native
 endif()
 
-option(ROARING_BUILD_STATIC "Build a static library" OFF) # turning it on disables the production of a dynamic library
+option(ROARING_BUILD_STATIC "Build a static library" ON)
 option(ROARING_LINK_STATIC "Link executables (tests, benchmarks) statically" OFF)
 option(ROARING_BUILD_LTO "Build library with Link Time Optimization" OFF)
 option(ROARING_BUILD_C_AS_CPP "Build library C files using C++ compilation" OFF)

--- a/tests/installation/find/CMakeLists.txt
+++ b/tests/installation/find/CMakeLists.txt
@@ -1,0 +1,42 @@
+
+cmake_minimum_required(VERSION 3.15)
+
+project(test_roaring_install VERSION 0.1.0 LANGUAGES CXX C)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+find_package(roaring REQUIRED)
+
+file(WRITE main.cpp "
+#include <iostream>
+#include \"roaring/roaring.hh\"
+int main() {
+  roaring::Roaring r1;
+  for (uint32_t i = 100; i < 1000; i++) {
+    r1.add(i);
+  }
+  std::cout << \"cardinality = \" << r1.cardinality() << std::endl;
+  return 0;
+}")
+
+add_executable(repro main.cpp)
+target_link_libraries(repro PUBLIC roaring::roaring)
+
+file(WRITE main.c "
+#include <stdio.h>
+#include \"roaring/roaring.h\"
+int main() {
+  roaring_bitmap_t *r1 = roaring_bitmap_create();
+  for (uint32_t i = 100; i < 1000; i++) roaring_bitmap_add(r1, i);
+  printf(\"cardinality = %d\\n\", (int) roaring_bitmap_get_cardinality(r1));
+  roaring_bitmap_free(r1);
+  return 0;
+}")
+
+add_executable(reproc main.c)
+target_link_libraries(reproc PUBLIC roaring::roaring)


### PR DESCRIPTION
This adds a simple CMake install and test routine. It also moves us to static by default.

Fixes https://github.com/RoaringBitmap/CRoaring/issues/243