### PR TITLE
Fixes issue 288.

### DIFF
--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -114,7 +114,8 @@ void ra_init(roaring_array_t *new_ra) {
 bool ra_overwrite(const roaring_array_t *source, roaring_array_t *dest,
                   bool copy_on_write) {
     ra_clear_containers(dest);  // we are going to overwrite them
-    if (source->size == 0) {  // Note: can't call memcpy(NULL), even w/size 0
+    if (source->size == 0) {  // Note: can't call memcpy(NULL), even w/size
+        dest->size = 0; // <--- This is important.
         return true;  // output was just cleared, so they match
     }
     if (dest->allocation_size < source->size) {

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -165,6 +165,20 @@ DEFINE_TEST(issue208b) {
     roaring_bitmap_free(r);
 }
 
+DEFINE_TEST(issue288) {
+    roaring_bitmap_t *r1 = roaring_bitmap_create();
+    roaring_bitmap_t *r2 = roaring_bitmap_create();
+    assert_true(roaring_bitmap_get_cardinality(r1) == 0);
+    assert_true(roaring_bitmap_get_cardinality(r2) == 0);
+
+    roaring_bitmap_add(r1, 42);
+    assert_true(roaring_bitmap_get_cardinality(r1) == 1);
+    roaring_bitmap_overwrite(r1, r2);
+    assert_true(roaring_bitmap_get_cardinality(r1) == 0);
+    assert_true(roaring_bitmap_get_cardinality(r2) == 0);
+    roaring_bitmap_free(r1);
+    roaring_bitmap_free(r2);
+}
 
 DEFINE_TEST(can_copy_empty_true) {
   can_copy_empty(true);
@@ -4139,6 +4153,7 @@ int main() {
     tellmeall();
 
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(issue288),
         cmocka_unit_test(issue245),
         cmocka_unit_test(issue208),
         cmocka_unit_test(issue208b),


### PR DESCRIPTION
Basically, when overwriting a bitmap with an empty source, a contributor has recently added a fast path. The fast path would just free the containers, but it would not adjust the container count, leaving a broken state.

Fixes https://github.com/RoaringBitmap/CRoaring/issues/288