### PR TITLE
fix memory copy in for_each

### DIFF
--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -520,7 +520,7 @@ class Roaring64Map {
      */
     void iterate(api::roaring_iterator64 iterator, void *ptr) const {
         std::for_each(roarings.begin(), roarings.cend(),
-                      [=](const std::pair<uint32_t, Roaring> &map_entry) {
+                      [=](const std::pair<const uint32_t, Roaring> &map_entry) {
                           roaring_iterate64(&map_entry.second.roaring, iterator,
                                             uint64_t(map_entry.first) << 32,
                                             ptr);
@@ -586,7 +586,7 @@ class Roaring64Map {
         buf += sizeof(uint64_t);
         std::for_each(
             roarings.cbegin(), roarings.cend(),
-            [&buf, portable](const std::pair<uint32_t, Roaring> &map_entry) {
+            [&buf, portable](const std::pair<const uint32_t, Roaring> &map_entry) {
                 // push map key
                 std::memcpy(buf, &map_entry.first, sizeof(uint32_t));
                 // ^-- Note: `*((uint32_t*)buf) = map_entry.first;` is undefined
@@ -762,7 +762,7 @@ class Roaring64Map {
                 (void *)&outer_iter_data);
             std::for_each(
                 ++map_iter, roarings.cend(),
-                [](const std::pair<uint32_t, Roaring> &map_entry) {
+                [](const std::pair<const uint32_t, Roaring> &map_entry) {
                     map_entry.second.iterate(
                         [](uint32_t low_bits, void *high_bits) -> bool {
                             std::printf(",%llu",
@@ -804,7 +804,7 @@ class Roaring64Map {
             std::for_each(
                 ++map_iter, roarings.cend(),
                 [&outer_iter_data](
-                    const std::pair<uint32_t, Roaring> &map_entry) {
+                    const std::pair<const uint32_t, Roaring> &map_entry) {
                     outer_iter_data.high_bits = map_entry.first;
                     map_entry.second.iterate(
                         [](uint32_t low_bits, void *inner_iter_data) -> bool {


### PR DESCRIPTION
for_each std::pair<int, Roaring> will generate a extra memory copy
https://github.com/apache/incubator-doris/issues/5855