### PR TITLE
including roaring.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ int main() {
 #include <iostream>
 
 #include "roaring.hh"
+#include "roaring.c"
 
 using namespace roaring;
 


### PR DESCRIPTION
ld gives error on compilation if `#include "roaring.c"` is not added while writing cpp code.