### PR TITLE
Fix sanitizer crash

### DIFF
--- a/src/containers/mixed_negation.c
+++ b/src/containers/mixed_negation.c
@@ -32,6 +32,10 @@ void array_container_negation(const array_container_t *src,
     uint64_t card = UINT64_C(1 << 16);
     bitset_container_set_all(dst);
 
+    if (src->cardinality == 0) {
+        return;
+    }
+
     dst->cardinality = (int32_t)bitset_clear_list(dst->words, card, src->array,
                                                   (uint64_t)src->cardinality);
 }


### PR DESCRIPTION
The address sanitizer bans arithmetic on `NULL` pointers. Calling `bitset_clear_list` with such an input performs an addition to compare between start and end. Even tho the code is correct (it's used only as the end condition of an iteration), the sanitizer causes a crash.