### PR TITLE
Frozen support for C++

### DIFF
--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -184,7 +184,7 @@ class Roaring {
      * Destructor.  By contract, calling roaring_bitmap_clear() is enough to
      * release all auxiliary memory used by the structure.
      */
-    ~Roaring() { 
+    ~Roaring() {
         if (!(roaring.high_low_container.flags & ROARING_FLAG_FROZEN)) {
             api::roaring_bitmap_clear(&roaring);
         } else {
@@ -194,7 +194,10 @@ class Roaring {
             // container data is not freed with it. Here we derive the arena
             // pointer from the second arena allocation in
             // `roaring_bitmap_frozen_view` and free it as well.
-            roaring_bitmap_free((roaring_bitmap_t *)((char *)roaring.high_low_container.containers - sizeof(roaring_bitmap_t)));
+            roaring_bitmap_free(
+                (roaring_bitmap_t *)((char *)
+                                         roaring.high_low_container.containers -
+                                     sizeof(roaring_bitmap_t)));
         }
     }
 
@@ -541,7 +544,8 @@ class Roaring {
     }
 
     static const Roaring frozenView(const char *buf, size_t length) {
-        const roaring_bitmap_t *s = api::roaring_bitmap_frozen_view(buf, length);
+        const roaring_bitmap_t *s =
+            api::roaring_bitmap_frozen_view(buf, length);
         if (s == NULL) {
             throw std::runtime_error("failed to read frozen bitmap");
         }

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -547,7 +547,7 @@ class Roaring {
         const roaring_bitmap_t *s =
             api::roaring_bitmap_frozen_view(buf, length);
         if (s == NULL) {
-            throw std::runtime_error("failed to read frozen bitmap");
+            ROARING_TERMINATE("failed to read frozen bitmap");
         }
         Roaring r;
         r.roaring = *s;

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -708,7 +708,7 @@ class Roaring64Map {
 
         for (uint64_t lcv = 0; lcv < map_size; lcv++) {
             // pad to 32 bytes minus the metadata size
-            while(((uintptr_t)buf + metadata_size) % 32 != 0) buf++;
+            while (((uintptr_t)buf + metadata_size) % 32 != 0) buf++;
 
             // get bitmap size
             size_t len;
@@ -751,7 +751,7 @@ class Roaring64Map {
             size_t frozenSizeInBytes = map_entry.second.getFrozenSizeInBytes();
 
             // pad to 32 bytes minus the metadata size
-            while(((uintptr_t)buf + metadata_size) % 32 != 0) buf++;
+            while (((uintptr_t)buf + metadata_size) % 32 != 0) buf++;
 
             // push bitmap size
             memcpy(buf, &frozenSizeInBytes, sizeof(size_t));
@@ -777,11 +777,11 @@ class Roaring64Map {
 
         for (auto &map_entry : roarings) {
             // pad to 32 bytes minus the metadata size
-            while((ret + metadata_size) % 32 != 0) ret++;
+            while ((ret + metadata_size) % 32 != 0) ret++;
             ret += metadata_size;
 
             // frozen bitmaps must be 32-byte aligned
-            ret += map_entry.second.getFrozenSizeInBytes(); 
+            ret += map_entry.second.getFrozenSizeInBytes();
         }
         return ret;
     }

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2983,6 +2983,12 @@ roaring_bitmap_frozen_view(const char *buf, size_t length) {
     rb->high_low_container.containers =
         (container_t **)arena_alloc(&arena,
                                     sizeof(container_t*) * num_containers);
+    // Ensure offset of high_low_container.containers is known distance used in
+    // C++ wrapper. sizeof(roaring_bitmap_t) is used as it is the size of the
+    // only allocation that precedes high_low_container.containers. If this is
+    // changed (new allocation or changed order), this offset will also need to
+    // be changed in the C++ wrapper.
+    assert(rb == (roaring_bitmap_t *)((char *)rb->high_low_container.containers - sizeof(roaring_bitmap_t)));
     for (int32_t i = 0; i < num_containers; i++) {
         switch (typecodes[i]) {
             case BITSET_CONTAINER_TYPE: {

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2988,7 +2988,9 @@ roaring_bitmap_frozen_view(const char *buf, size_t length) {
     // only allocation that precedes high_low_container.containers. If this is
     // changed (new allocation or changed order), this offset will also need to
     // be changed in the C++ wrapper.
-    assert(rb == (roaring_bitmap_t *)((char *)rb->high_low_container.containers - sizeof(roaring_bitmap_t)));
+    assert(rb ==
+           (roaring_bitmap_t *)((char *)rb->high_low_container.containers -
+                                sizeof(roaring_bitmap_t)));
     for (int32_t i = 0; i < num_containers; i++) {
         switch (typecodes[i]) {
             case BITSET_CONTAINER_TYPE: {

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -676,7 +676,7 @@ DEFINE_TEST(test_cpp_frozen) {
     }
 #endif
 
-    free(buf);
+    roaring_bitmap_aligned_free(buf);
 }
 
 DEFINE_TEST(test_cpp_frozen_64) {
@@ -711,7 +711,7 @@ DEFINE_TEST(test_cpp_frozen_64) {
     const Roaring64Map r2 = Roaring64Map::frozenView(buf);
     assert_true(r1 == r2);
 
-    free(buf);
+    roaring_bitmap_aligned_free(buf);
 }
 
 int main() {

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -667,12 +667,14 @@ DEFINE_TEST(test_cpp_frozen) {
     const Roaring r2 = Roaring::frozenView(buf, num_bytes);
     assert_true(r1 == r2);
 
+#if ROARING_EXCEPTIONS
     // try viewing a misaligned/invalid buffer
     try {
         Roaring::frozenView(buf + 1, num_bytes - 1);
         assert(false);
     } catch (...) {
     }
+#endif
 
     free(buf);
 }

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -693,7 +693,7 @@ DEFINE_TEST(test_cpp_frozen_64) {
     r1.add((uint64_t)234294967296ull);
     r1.add((uint64_t)195839473298ull);
     r1.add((uint64_t)14000000000000000100ull);
-    for(uint64_t i = s*10 + 100; i < s*13 - 100; i++) {
+    for (uint64_t i = s * 10 + 100; i < s * 13 - 100; i++) {
         r1.add(i);
     }
     // r1.addRange(s * 10 + 100, s * 13 - 100);
@@ -734,7 +734,7 @@ int main() {
 		cmocka_unit_test(test_cpp_move_64),
 		cmocka_unit_test(test_roaring64_iterate_multi_roaring),
 		cmocka_unit_test(test_cpp_bidirectional_iterator_64),
-        cmocka_unit_test(test_cpp_frozen),
+		cmocka_unit_test(test_cpp_frozen),
 		cmocka_unit_test(test_cpp_frozen_64)};
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
This implements support for frozen bitmaps in C++ 32- and 64-bit.

32-bit support is fairly trivial, adding a `static` function that yields `const Roaring` objects using the underlying C implementation. There is new logic added to the destructor to account for freeing the memory arena.

64-bit was more complicated, requiring some additional metadata and padding to concatenate each `Roaring` object while maintaining the required 32-byte alignment.

---

For example, take the following C++ 64-bit bitmap...

```cpp
Roaring64Map r;
r.add((uint64_t)5);
r.add((uint64_t)1ull);
r.add((uint64_t)2ull);
r.add((uint64_t)234294967296ull);
r.add((uint64_t)195839473298ull);
r.add((uint64_t)14000000000000000100ull);
```

Below is the hex dump of the 64-bit bitmap serialized in the frozen format containing 4 32-bit bitmaps. The format begins with a header which contains the number of 32-bit bitmaps serialized therein. Then before each frozen 32-bit bitmap, there is a padding space to ensure the bitmap data is aligned to 32 bytes, the data size in bytes, and the 32-bit key of the bitmap.

```
           0 1  2 3  4 5  6 7  8 9  a b  c d  e f  symbol
========= ==== ==== ==== ==== ==== ==== ==== ====  ================
00000000: 0400 0000 0000 0000 ac01 ad01 ae01 af01  HHHHHHHHPPPPPPPP
00000010: b001 b101 0f00 0000 0000 0000 0000 0000  PPPPSSSSSSSSKKKK
00000020: 0100 0200 0500 0000 0200 02c6 b500 0001  BBBBBBBBBBBBBBBP
00000030: c001 c101 0b00 0000 0000 0000 2d00 0000  PPPPSSSSSSSSKKKK
00000040: 9236 f198 0000 02c6 b500 0001 ce01 cf01  BBBBBBBBBBBPPPPP
00000050: d001 d101 0b00 0000 0000 0000 3600 0000  PPPPSSSSSSSSKKKK
00000060: 007c 118d 0000 02c6 b500 0001 de01 df01  BBBBBBBBBBBPPPPP
00000070: e001 e101 0b00 0000 0000 0000 d3fd 49c2  PPPPSSSSSSSSKKKK
00000080: 6400 7827 0000 02c6 b500 00              BBBBBBBBBBB
```

| Start | End  | Bytes | Symbol | Description |
|-------|------|-------|--------|---|
||||| **64-bit bitmap header** |
|  0x00 | 0x07 |     8 |      H | Number of 32-bit bitmaps serialized |
||||| **First 32-bit bitmap** |
|  0x08 | 0x13 |    12 |      P | Padding |
|  0x14 | 0x1a |     8 |      S | Data size in bytes |
|  0x1b | 0x1f |     4 |      K | 32-bit key |
|  0x20 | 0x2e |    15 |      B | Frozen data |
||||| **Second 32-bit bitmap** |
|  0x2f | 0x33 |     5 |      P | Padding |
|  0x34 | 0x3a |     8 |      S | Data size in bytes |
|  0x3b | 0x3f |     4 |      K | 32-bit key |
|  0x40 | 0x4a |    11 |      B | Frozen data |
| ... |