### PR TITLE
Fix #336

### DIFF
--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -379,49 +379,42 @@ public:
         // we cannot use operator == on the map because either side may contain
         // empty Roaring Bitmaps
         auto lhs_iter = roarings.cbegin();
+        auto lhs_cend = roarings.cend();
         auto rhs_iter = r.roarings.cbegin();
-        do {
-            // if the left map has reached its end, ensure that the right map
-            // contains only empty Bitmaps
-            if (lhs_iter == roarings.cend()) {
-                while (rhs_iter != r.roarings.cend()) {
-                    if (rhs_iter->second.isEmpty()) {
-                        ++rhs_iter;
-                        continue;
-                    }
-                    return false;
-                }
-                return true;
-            }
-            // if the left map has an empty bitmap, skip it
-            if (lhs_iter->second.isEmpty()) {
+        auto rhs_cend = r.roarings.cend();
+        while (lhs_iter != lhs_cend && rhs_iter != rhs_cend) {
+            auto lhs_key = lhs_iter->first, rhs_key = rhs_iter->first;
+            const auto &lhs_map = lhs_iter->second, &rhs_map = rhs_iter->second;
+            if (lhs_map.isEmpty()) {
                 ++lhs_iter;
                 continue;
             }
-
-            do {
-                // if the right map has reached its end, ensure that the right
-                // map contains only empty Bitmaps
-                if (rhs_iter == r.roarings.cend()) {
-                    while (lhs_iter != roarings.cend()) {
-                        if (lhs_iter->second.isEmpty()) {
-                            ++lhs_iter;
-                            continue;
-                        }
-                        return false;
-                    }
-                    return true;
-                }
-                // if the right map has an empty bitmap, skip it
-                if (rhs_iter->second.isEmpty()) {
-                    ++rhs_iter;
-                    continue;
-                }
-            } while (false);
-            // if neither map has reached its end ensure elements are equal and
-            // move to the next element in both
-        } while (lhs_iter++->second == rhs_iter++->second);
-        return false;
+            if (rhs_map.isEmpty()) {
+                ++rhs_iter;
+                continue;
+            }
+            if (!(lhs_key == rhs_key)) {
+                return false;
+            }
+            if (!(lhs_map == rhs_map)) {
+                return false;
+            }
+            ++lhs_iter;
+            ++rhs_iter;
+        }
+        while (lhs_iter != lhs_cend) {
+            if (!lhs_iter->second.isEmpty()) {
+                return false;
+            }
+            ++lhs_iter;
+        }
+        while (rhs_iter != rhs_cend) {
+            if (!rhs_iter->second.isEmpty()) {
+                return false;
+            }
+            ++rhs_iter;
+        }
+        return true;
     }
 
     /**

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -176,6 +176,24 @@ DEFINE_TEST(issue316) {
     assert_true(r1 == r2);
 }
 
+DEFINE_TEST(issue_336) {
+    Roaring64Map r1, r2;
+
+    r1.add((uint64_t)0x000000000UL);
+    r1.add((uint64_t)0x100000000UL);
+    r1.add((uint64_t)0x200000000UL);
+    r1.add((uint64_t)0x300000000UL);
+
+    r1.remove((uint64_t)0x100000000UL);
+    r1.remove((uint64_t)0x200000000UL);
+
+    r2.add((uint64_t)0x000000000UL);
+    r2.add((uint64_t)0x300000000UL);
+
+    assert_true(r1 == r2);
+    assert_true(r2 == r1);
+}
+
 void test_roaring64_iterate_multi_roaring(void) {
     Roaring64Map roaring;
 
@@ -775,6 +793,7 @@ int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(issue316),
         cmocka_unit_test(test_issue304),
+        cmocka_unit_test(issue_336),
         cmocka_unit_test(serial_test),
         cmocka_unit_test(test_example_true),
         cmocka_unit_test(test_example_false),


### PR DESCRIPTION
When one of the containers under testing has two consecutive empty containers while the other one hasn't leads to the iterators in `operator==` to become out of sync.

The code itself was quite hard to follow due to nested loops, one of which didn't really loop (the function caught my attention because LGTM pointed that out). I rewrote it to be more straightforward.