### PR TITLE
add_offset fixes

### DIFF
--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2181,6 +2181,8 @@ roaring_bitmap_t *roaring_bitmap_add_offset(const roaring_bitmap_t *bm,
     in_offset = (uint16_t)(offset - container_offset * (1 << 16));
 
     answer = roaring_bitmap_create();
+    roaring_bitmap_set_copy_on_write(answer, is_cow(bm));
+
     ans_ra = &answer->high_low_container;
 
     if (in_offset == 0) {

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2206,7 +2206,7 @@ roaring_bitmap_t *roaring_bitmap_add_offset(const roaring_bitmap_t *bm,
     uint8_t t;
     const container_t *c;
     container_t *lo, *hi, **lo_ptr, **hi_ptr;
-    int k;
+    int64_t k;
 
     for (int i = 0; i < length; ++i) {
         lo = hi = lo_ptr = hi_ptr = NULL;
@@ -2233,8 +2233,6 @@ roaring_bitmap_t *roaring_bitmap_add_offset(const roaring_bitmap_t *bm,
             ra_append(ans_ra, k+1, hi, t);
         }
     }
-
-    // TODO: repair after lazy
 
     return answer;
 }

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2167,8 +2167,7 @@ roaring_bitmap_t *roaring_bitmap_add_offset(const roaring_bitmap_t *bm,
                                             int64_t offset) {
     roaring_bitmap_t *answer;
     roaring_array_t *ans_ra;
-    uint64_t container_offset_64;
-    int container_offset;
+    int64_t container_offset;
     uint16_t in_offset;
 
     const roaring_array_t *bm_ra = &bm->high_low_container;
@@ -2178,9 +2177,8 @@ roaring_bitmap_t *roaring_bitmap_add_offset(const roaring_bitmap_t *bm,
         return roaring_bitmap_copy(bm);
     }
 
-    container_offset_64 = (uint64_t)offset >> 16;
-    container_offset = 0xffffffff & container_offset_64;
-    in_offset = (uint16_t)(offset - container_offset_64 * (1 << 16));
+    container_offset = offset >> 16;
+    in_offset = (uint16_t)(offset - container_offset * (1 << 16));
 
     answer = roaring_bitmap_create();
     ans_ra = &answer->high_low_container;
@@ -2189,7 +2187,7 @@ roaring_bitmap_t *roaring_bitmap_add_offset(const roaring_bitmap_t *bm,
         ans_ra = &answer->high_low_container;
 
         for (int i = 0, j = 0; i < length; ++i) {
-            int key = ra_get_key_at_index(bm_ra, i);
+            int64_t key = ra_get_key_at_index(bm_ra, i);
             key += container_offset;
 
             if (key < 0 || key >= (1 << 16)) {

--- a/tests/add_offset.c
+++ b/tests/add_offset.c
@@ -326,8 +326,9 @@ int main() {
         ROARING_ADD_OFFSET_TEST_CASE(sparse_bitmap, UINT32_MAX),
         ROARING_ADD_OFFSET_TEST_CASE(sparse_bitmap, UINT32_MAX-UINT16_MAX),
         ROARING_ADD_OFFSET_TEST_CASE(sparse_bitmap, UINT32_MAX-UINT16_MAX+1),
+        ROARING_ADD_OFFSET_TEST_CASE(sparse_bitmap, 1L << 50),
     };
-    i = 7;
+    i = 8;
     for (int64_t offset = 3; offset < 1000000; offset *= 3) {
         roaring_add_offset_test_state_t state = ROARING_ADD_OFFSET_TEST_CASE(dense_bitmap, offset);
         roaring_state[i++] = state;

--- a/tests/add_offset.c
+++ b/tests/add_offset.c
@@ -327,8 +327,9 @@ int main() {
         ROARING_ADD_OFFSET_TEST_CASE(sparse_bitmap, UINT32_MAX-UINT16_MAX),
         ROARING_ADD_OFFSET_TEST_CASE(sparse_bitmap, UINT32_MAX-UINT16_MAX+1),
         ROARING_ADD_OFFSET_TEST_CASE(sparse_bitmap, 1L << 50),
+        ROARING_ADD_OFFSET_TEST_CASE(sparse_bitmap, 281474976710657L),
     };
-    i = 8;
+    i = 9;
     for (int64_t offset = 3; offset < 1000000; offset *= 3) {
         roaring_add_offset_test_state_t state = ROARING_ADD_OFFSET_TEST_CASE(dense_bitmap, offset);
         roaring_state[i++] = state;


### PR DESCRIPTION
Reported by @Ezibenroc 

Return empty bitmaps on very large and very small offsets. Return CoW bitmaps when the input is CoW.