### PR TITLE
Fix memory leak in add_offset test

### DIFF
--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -163,6 +163,10 @@ void bitset_container_offset(const bitset_container_t *c,
     }
 
     if (hic == NULL) {
+        // Both hic and loc can't be NULL, so bc is never NULL here
+        if (bc->cardinality == 0) {
+            bitset_container_free(bc);
+	}
         return;
     }
 

--- a/tests/add_offset.c
+++ b/tests/add_offset.c
@@ -85,11 +85,11 @@ static int teardown_container_add_offset_test(void **state_) {
         container_free(state->hi, test.type);
         state->hi = NULL;
     }
-    if (state->lo) {
+    if (state->lo_only) {
         container_free(state->lo_only, test.type);
         state->lo_only = NULL;
     }
-    if (state->hi) {
+    if (state->hi_only) {
         container_free(state->hi_only, test.type);
         state->hi_only = NULL;
     }


### PR DESCRIPTION
Checked the wrong field to free lo_only and hi_only containers.

Addresses #349 