### PR TITLE
Fix build when compiling as CPP

### DIFF
--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2209,7 +2209,8 @@ roaring_bitmap_t *roaring_bitmap_add_offset(const roaring_bitmap_t *bm,
     int64_t k;
 
     for (int i = 0; i < length; ++i) {
-        lo = hi = lo_ptr = hi_ptr = NULL;
+        lo = hi = NULL;
+        lo_ptr = hi_ptr = NULL;
 
         k = ra_get_key_at_index(bm_ra, i)+container_offset;
         if (k >= 0 && k < (1 << 16)) {


### PR DESCRIPTION
VS2019 in C++20 conformance mode fails to build with:

```
src\roaring.c(2212,41): error C2440: '=': cannot convert from 'roaring::internal::container_t **' to 'roaring::internal::container_t *'
src\roaring.c(2212,26): message : Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
```