### PR TITLE
Make sure unit tests are actually called (#373)

### DIFF
--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -1675,12 +1675,12 @@ static int run_negation_range_tests_simpler(int k, int h, int start_offset,
     for (int x = 0; x < (1 << 16) - start_offset; x++) {
         int offsetx = x + start_offset;
         if (x % k == 0) {
-            int actual_runlen = runlen;
-            if (offsetx + runlen > (1 << 16))
+            int actual_runlen = runlen + 1;
+            if (offsetx + actual_runlen > (1 << 16))
                 actual_runlen = (1 << 16) - offsetx;
 
             run_container_append_first(
-                RI, MAKE_RLE16(offsetx, actual_runlen));
+                RI, MAKE_RLE16(offsetx, actual_runlen - 1));
             if (++runlen == k) runlen = h;
         }
     }
@@ -2018,6 +2018,8 @@ int main() {
         cmocka_unit_test(bitset_negation_range_test2),
         cmocka_unit_test(bitset_negation_range_inplace_test1),
         cmocka_unit_test(bitset_negation_range_inplace_test2),
+        cmocka_unit_test(run_many_negation_range_tests_simpler_notinplace),
+        cmocka_unit_test(run_many_negation_range_tests_simpler_inplace),
         cmocka_unit_test(run_negation_range_inplace_test1),
         cmocka_unit_test(run_negation_range_inplace_test2),
         cmocka_unit_test(run_negation_range_inplace_test3),

--- a/tests/robust_deserialization_unit.c
+++ b/tests/robust_deserialization_unit.c
@@ -163,15 +163,6 @@ DEFINE_TEST(test_robust_deserialize7) {
     test_deserialize(filename);
 }
 
-DEFINE_TEST(test_robust_deserialize8) {
-    char filename[1024];
-
-    strcpy(filename, TEST_DATA_DIR);
-    strcat(filename, "crashproneinput8.bin");
-
-    test_deserialize(filename);
-}
-
 int main() {
     tellmeall();
 

--- a/tests/test.h
+++ b/tests/test.h
@@ -50,7 +50,7 @@
 // rather than disabling warnings, this defines a macro to declare the tests.
 //
 #ifdef __cplusplus
-    #define DEFINE_TEST(name)   void name(void**)
+    #define DEFINE_TEST(name)   static void name(void**)
 #else
-    #define DEFINE_TEST(name)   void name()
+    #define DEFINE_TEST(name)   static void name()
 #endif

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -4253,6 +4253,7 @@ int main() {
         cmocka_unit_test(test_array_to_run),
         cmocka_unit_test(test_array_to_self),
         cmocka_unit_test(test_bitset_to_self),
+        cmocka_unit_test(test_bitset_to_run),
         cmocka_unit_test(test_conversion_to_int_array_with_runoptimize),
         cmocka_unit_test(test_run_to_self),
         cmocka_unit_test(test_remove_run_to_bitset_cow),


### PR DESCRIPTION
Change the `DEFINE_TEST` macro to define static functions: This gives warnings when test functions are never used.
