### PR TITLE
Add add/removeRange to Roaring and Roaring64Map

### DIFF
--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -127,10 +127,17 @@ public:
     }
 
     /**
-     * Add all values from x (included) to y (excluded)
+     * Add all values in range [min, max)
      */
-    void addRange(const uint64_t x, const uint64_t y)  {
-        return api::roaring_bitmap_add_range(&roaring, x, y);
+    void addRange(const uint64_t min, const uint64_t max)  {
+        return api::roaring_bitmap_add_range(&roaring, min, max);
+    }
+
+    /**
+     * Add all values in range [min, max]
+     */
+    void addRangeClosed(const uint32_t min, const uint32_t max)  {
+        return api::roaring_bitmap_add_range_closed(&roaring, min, max);
     }
 
     /**
@@ -152,6 +159,20 @@ public:
      */
     bool removeChecked(uint32_t x) {
         return api::roaring_bitmap_remove_checked(&roaring, x);
+    }
+
+    /**
+     * Remove all values in range [min, max)
+     */
+    void removeRange(uint64_t min, uint64_t max) {
+        return api::roaring_bitmap_remove_range(&roaring, min, max);
+    }
+
+    /**
+     * Remove all values in range [min, max]
+     */
+    void removeRangeClosed(uint32_t min, uint32_t max) {
+        return api::roaring_bitmap_remove_range_closed(&roaring, min, max);
     }
 
     /**

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -117,6 +117,52 @@ public:
     }
 
     /**
+     * Add all values in range [min, max)
+     */
+    void addRange(uint64_t min, uint64_t max) {
+        if (min >= max) {
+            return;
+        }
+        addRangeClosed(min, max - 1);
+    }
+
+    /**
+     * Add all values in range [min, max]
+     */
+    void addRangeClosed(uint32_t min, uint32_t max) {
+        roarings[0].addRangeClosed(min, max);
+    }
+    void addRangeClosed(uint64_t min, uint64_t max) {
+        if (min > max) {
+            return;
+        }
+        uint32_t start_high = highBytes(min);
+        uint32_t start_low = lowBytes(min);
+        uint32_t end_high = highBytes(max);
+        uint32_t end_low = lowBytes(max);
+        if (start_high == end_high) {
+            roarings[start_high].addRangeClosed(start_low, end_low);
+            roarings[start_high].setCopyOnWrite(copyOnWrite);
+            return;
+        }
+        // we put std::numeric_limits<>::max/min in parenthesis to avoid a clash
+        // with the Windows.h header under Windows
+        roarings[start_high].addRangeClosed(
+            start_low, (std::numeric_limits<uint32_t>::max)());
+        roarings[start_high].setCopyOnWrite(copyOnWrite);
+        start_high++;
+        for (; start_high < end_high; ++start_high) {
+            roarings[start_high].addRangeClosed(
+                (std::numeric_limits<uint32_t>::min)(),
+                (std::numeric_limits<uint32_t>::max)());
+            roarings[start_high].setCopyOnWrite(copyOnWrite);
+        }
+        roarings[end_high].addRangeClosed(
+            (std::numeric_limits<uint32_t>::min)(), end_low);
+        roarings[end_high].setCopyOnWrite(copyOnWrite);
+    }
+
+    /**
      * Add value n_args from pointer vals
      */
     void addMany(size_t n_args, const uint32_t *vals) {
@@ -154,6 +200,58 @@ public:
         if (roaring_iter != roarings.cend())
             return roaring_iter->second.removeChecked(lowBytes(x));
         return false;
+    }
+
+    /**
+     * Remove all values in range [min, max)
+     */
+    void removeRange(uint64_t min, uint64_t max) {
+        if (min >= max) {
+            return;
+        }
+        return removeRangeClosed(min, max - 1);
+    }
+
+    /**
+     * Remove all values in range [min, max]
+     */
+    void removeRangeClosed(uint32_t min, uint32_t max) {
+        return roarings[0].removeRangeClosed(min, max);
+    }
+    void removeRangeClosed(uint64_t min, uint64_t max) {
+        if (min > max) {
+            return;
+        }
+        uint32_t start_high = highBytes(min);
+        uint32_t start_low = lowBytes(min);
+        uint32_t end_high = highBytes(max);
+        uint32_t end_low = lowBytes(max);
+
+        if (roarings.empty() || end_high < roarings.cbegin()->first ||
+            start_high > (roarings.crbegin())->first) {
+            return;
+        }
+
+        auto start_iter = roarings.lower_bound(start_high);
+        auto end_iter = roarings.lower_bound(end_high);
+        if (start_iter->first == start_high) {
+            if (start_iter == end_iter) {
+                start_iter->second.removeRangeClosed(start_low, end_low);
+                return;
+            }
+            // we put std::numeric_limits<>::max/min in parenthesis
+            // to avoid a clash with the Windows.h header under Windows
+            start_iter->second.removeRangeClosed(
+                start_low, (std::numeric_limits<uint32_t>::max)());
+            start_iter++;
+        }
+
+        roarings.erase(start_iter, end_iter);
+
+        if (end_iter != roarings.cend() && end_iter->first == end_high) {
+            end_iter->second.removeRangeClosed(
+                (std::numeric_limits<uint32_t>::min)(), end_low);
+        }
     }
 
     /**

--- a/tests/cpp_random_unit.cpp
+++ b/tests/cpp_random_unit.cpp
@@ -57,7 +57,7 @@ Roaring make_random_bitset() {
     Roaring r;
     int num_ops = rand() % 100;
     for (int i = 0; i < num_ops; ++i) {
-        switch (rand() % 4) {
+        switch (rand() % 5) {
           case 0:
             r.add(gravity);
             break;
@@ -68,11 +68,16 @@ Roaring make_random_bitset() {
             break; }
 
           case 2: {
+            uint32_t start = gravity + (rand() % 10) - 5;
+            r.removeRange(start, start + rand() % 5);
+            break; }
+
+          case 3: {
             uint32_t start = gravity + (rand() % 50) - 25;
             r.flip(start, rand() % 50);
             break; }
 
-          case 3: {  // tests remove(), select(), rank()
+          case 4: {  // tests remove(), select(), rank()
             uint32_t card = r.cardinality();
             if (card != 0) {
                 uint32_t rnk = rand() % card;

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -10,6 +10,7 @@
 #include <time.h>
 #include <iostream>
 #include <roaring/misc/configreport.h>
+#include <vector>
 
 #include <roaring/roaring.h>  // access to pure C exported API for testing
 
@@ -602,6 +603,215 @@ DEFINE_TEST(test_cpp_add_remove_checked_64) {
     assert_true(roaring.isEmpty());
 }
 
+DEFINE_TEST(test_cpp_add_range) {
+    std::vector<std::pair<uint64_t, uint64_t>> ranges = {
+      {1, 5},
+      {1, 1},
+      {2, 1},
+    };
+    for (const auto &range : ranges) {
+        uint64_t min = range.first;
+        uint64_t max = range.second;
+        Roaring r1;
+        r1.addRangeClosed(min, max);
+        Roaring r2;
+        for (uint64_t v = min; v <= max; ++v) {
+            r2.add(v);
+        }
+        assert_true(r1 == r2);
+    }
+}
+
+DEFINE_TEST(test_cpp_remove_range) {
+    {
+        // min < r1.minimum, max > r1.maximum
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 4);
+        r1.removeRangeClosed(0, 5);
+        assert_true(r1.isEmpty());
+    }
+    {
+        // min < r1.minimum, max < r1.maximum, max does not exactly match an
+        // element
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 4);
+        r1.removeRangeClosed(0, 3);
+        Roaring r2 = Roaring::bitmapOf(1, 4);
+        assert_true(r1 == r2);
+    }
+    {
+        // min < r1.minimum, max < r1.maximum, max exactly matches an element
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 4);
+        r1.removeRangeClosed(0, 2);
+        Roaring r2 = Roaring::bitmapOf(1, 4);
+        assert_true(r1 == r2);
+    }
+    {
+        // min > r1.minimum, max > r1.maximum, min does not exactly match an
+        // element
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 4);
+        r1.removeRangeClosed(3, 5);
+        Roaring r2 = Roaring::bitmapOf(2, 1, 2);
+        assert_true(r1 == r2);
+    }
+    {
+        // min > r1.minimum, max > r1.maximum, min exactly matches an element
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 4);
+        r1.removeRangeClosed(2, 5);
+        Roaring r2 = Roaring::bitmapOf(1, 1);
+        assert_true(r1 == r2);
+    }
+    {
+        // min > r1.minimum, max < r1.maximum, no elements between min and max
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 4);
+        r1.removeRangeClosed(3, 3);
+        Roaring r2 = Roaring::bitmapOf(3, 1, 2, 4);
+        assert_true(r1 == r2);
+    }
+    {
+        // max < r1.minimum
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 4);
+        r1.removeRangeClosed(0, 0);
+        Roaring r2 = Roaring::bitmapOf(3, 1, 2, 4);
+        assert_true(r1 == r2);
+    }
+    {
+        // min > r1.maximum
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 4);
+        r1.removeRangeClosed(5, 6);
+        Roaring r2 = Roaring::bitmapOf(3, 1, 2, 4);
+        assert_true(r1 == r2);
+    }
+    {
+        // min > max
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 4);
+        r1.removeRangeClosed(2, 1);
+        Roaring r2 = Roaring::bitmapOf(3, 1, 2, 4);
+        assert_true(r1 == r2);
+    }
+}
+
+DEFINE_TEST(test_cpp_add_range_64) {
+    {
+        // 32-bit integers
+        Roaring64Map r1;
+        r1.addRangeClosed(uint32_t(1), uint32_t(5));
+        Roaring64Map r2;
+        for (uint32_t v = 1; v <= 5; ++v) {
+            r2.add(v);
+        }
+        assert_true(r1 == r2);
+    }
+    std::vector<std::pair<uint64_t, uint64_t>> ranges = {
+        {uint64_t(1) << 32, (uint64_t(1) << 32) + 10},
+        {(uint64_t(1) << 32) - 10, (uint64_t(1) << 32) + 10},
+        {(uint64_t(1) << 32) + 2, (uint64_t(1) << 32) - 2}};
+    for (const auto &range : ranges) {
+        uint64_t min = range.first;
+        uint64_t max = range.second;
+        Roaring64Map r1;
+        r1.addRangeClosed(min, max);
+        Roaring64Map r2;
+        for (uint64_t v = min; v <= max; ++v) {
+            r2.add(v);
+        }
+        assert_true(r1 == r2);
+    }
+}
+
+DEFINE_TEST(test_cpp_remove_range_64) {
+    {
+        // 32-bit integers
+        Roaring64Map r1 =
+            Roaring64Map::bitmapOf(3, uint64_t(1), uint64_t(2), uint64_t(4));
+        r1.removeRangeClosed(uint32_t(2), uint32_t(3));
+        Roaring64Map r2 = Roaring64Map::bitmapOf(2, uint64_t(1), uint64_t(4));
+        assert_true(r1 == r2);
+    }
+    {
+        // min < r1.minimum, max > r1.maximum
+        Roaring64Map r1 = Roaring64Map::bitmapOf(
+            3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
+        r1.removeRangeClosed(uint64_t(0), uint64_t(5) << 32);
+        assert_true(r1.isEmpty());
+    }
+    {
+        // min < r1.minimum, max < r1.maximum, max does not exactly match an
+        // element
+        Roaring64Map r1 = Roaring64Map::bitmapOf(
+            3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
+        r1.removeRangeClosed(uint64_t(0), uint64_t(3) << 32);
+        Roaring64Map r2 = Roaring64Map::bitmapOf(1, uint64_t(4) << 32);
+        assert_true(r1 == r2);
+    }
+    {
+        // min < r1.minimum, max < r1.maximum, max exactly matches the high bits
+        // of an element
+        Roaring64Map r1 =
+            Roaring64Map::bitmapOf(4, uint64_t(1) << 32, uint64_t(2) << 32,
+                                   (uint64_t(2) << 32) + 1, uint64_t(4) << 32);
+        r1.removeRangeClosed(uint64_t(0), uint64_t(2) << 32);
+        Roaring64Map r2 = Roaring64Map::bitmapOf(2, (uint64_t(2) << 32) + 1,
+                                                 uint64_t(4) << 32);
+        assert_true(r1 == r2);
+    }
+    {
+        // min > r1.minimum, max > r1.maximum, min does not exactly match an
+        // element
+        Roaring64Map r1 = Roaring64Map::bitmapOf(
+            3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
+        r1.removeRangeClosed(uint64_t(3) << 32, uint64_t(5) << 32);
+        Roaring64Map r2 =
+            Roaring64Map::bitmapOf(2, uint64_t(1) << 32, uint64_t(2) << 32);
+        assert_true(r1 == r2);
+    }
+    {
+        // min > r1.minimum, max > r1.maximum, min exactly matches the high bits
+        // of an element
+        Roaring64Map r1 =
+            Roaring64Map::bitmapOf(4, uint64_t(1) << 32, uint64_t(2) << 32,
+                                   (uint64_t(2) << 32) + 1, uint64_t(4) << 32);
+        r1.removeRangeClosed((uint64_t(2) << 32) + 1, uint64_t(5) << 32);
+        Roaring64Map r2 =
+            Roaring64Map::bitmapOf(2, uint64_t(1) << 32, uint64_t(2) << 32);
+        assert_true(r1 == r2);
+    }
+    {
+        // min > r1.minimum, max < r1.maximum, no elements between min and max
+        Roaring64Map r1 = Roaring64Map::bitmapOf(
+            3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
+        r1.removeRangeClosed(uint64_t(3) << 32, (uint64_t(3) << 32) + 1);
+        Roaring64Map r2 = Roaring64Map::bitmapOf(
+            3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
+        assert_true(r1 == r2);
+    }
+    {
+        // max < r1.minimum
+        Roaring64Map r1 = Roaring64Map::bitmapOf(
+            3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
+        r1.removeRangeClosed(uint64_t(1), uint64_t(2));
+        Roaring64Map r2 = Roaring64Map::bitmapOf(
+            3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
+        assert_true(r1 == r2);
+    }
+    {
+        // min > r1.maximum
+        Roaring64Map r1 = Roaring64Map::bitmapOf(
+            3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
+        r1.removeRangeClosed(uint64_t(5) << 32, uint64_t(6) << 32);
+        Roaring64Map r2 = Roaring64Map::bitmapOf(
+            3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
+        assert_true(r1 == r2);
+    }
+    {
+        // min > max
+        Roaring64Map r1 = Roaring64Map::bitmapOf(
+            3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
+        r1.removeRangeClosed(uint64_t(2) << 32, uint64_t(1) << 32);
+        Roaring64Map r2 = Roaring64Map::bitmapOf(
+            3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
+        assert_true(r1 == r2);
+    }
+}
+
 DEFINE_TEST(test_cpp_clear_64) {
     Roaring64Map roaring;
 
@@ -803,6 +1013,10 @@ int main() {
         cmocka_unit_test(test_example_cpp_64_false),
         cmocka_unit_test(test_cpp_add_remove_checked),
         cmocka_unit_test(test_cpp_add_remove_checked_64),
+        cmocka_unit_test(test_cpp_add_range),
+        cmocka_unit_test(test_cpp_remove_range),
+        cmocka_unit_test(test_cpp_add_range_64),
+        cmocka_unit_test(test_cpp_remove_range_64),
         cmocka_unit_test(test_run_compression_cpp_64_true),
         cmocka_unit_test(test_run_compression_cpp_64_false),
         cmocka_unit_test(test_run_compression_cpp_true),

--- a/tests/roaring_checked.hh
+++ b/tests/roaring_checked.hh
@@ -117,15 +117,17 @@ class Roaring {
         return ans;
     }
 
-    void addRange(const uint64_t x, const uint64_t y)  {
-        plain.addRange(x, y);
+    void addRange(const uint64_t x, const uint64_t y) {
         if (x != y) {  // repeat add_range_closed() cast and bounding logic
-            uint32_t min = static_cast<uint32_t>(x);
-            uint32_t max = static_cast<uint32_t>(y - 1);
-            if (min <= max) {
-                for (uint32_t val = max; val != min - 1; --val)
-                    check.insert(val);
-            }
+            addRangeClosed(x, y - 1);
+        }
+    }
+
+    void addRangeClosed(uint32_t min, uint32_t max) {
+        plain.addRangeClosed(min, max);
+        if (min <= max) {
+            for (uint32_t val = max; val != min - 1; --val)
+                check.insert(val);
         }
     }
 
@@ -146,6 +148,19 @@ class Roaring {
         assert(ans == (num_removed == 1));
         (void)num_removed;  // unused besides assert
         return ans;
+    }
+
+    void removeRange(const uint64_t x, const uint64_t y) {
+        if (x != y) {  // repeat remove_range_closed() cast and bounding logic
+            removeRangeClosed(x, y - 1);
+        }
+    }
+
+    void removeRangeClosed(uint32_t min, uint32_t max) {
+        plain.removeRangeClosed(min, max);
+        if (min <= max) {
+            check.erase(check.lower_bound(min), check.upper_bound(max));
+        }
     }
 
     uint32_t maximum() const {


### PR DESCRIPTION
These were already present in the C API, but the C++ version only had `Roaring::addRange`. `addRangeClosed` is especially useful in the case of 64-bit integers, where an open range doesn't cover all possible values.