### PR TITLE
Avoid Temporaries in isEmpty

### DIFF
--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -403,7 +403,7 @@ public:
      */
     bool isEmpty() const {
         return std::all_of(roarings.cbegin(), roarings.cend(),
-                           [](const std::pair<const uint32_t, Roaring> &map_entry) {
+                           [](const std::pair<const uint32_t, const Roaring> &map_entry) {
                                return map_entry.second.isEmpty();
                            });
     }


### PR DESCRIPTION
The following function:

```c++
    /**
     * Returns true if the bitmap is empty (cardinality is zero).
     */
    bool isEmpty() const {
        return std::all_of(roarings.cbegin(), roarings.cend(),
                           [](const std::pair<const uint32_t, Roaring>
&map_entry) {
                               return map_entry.second.isEmpty();
                           });
    }
```

creates temporaries via implicit conversion.  This is because
the map entries from this location are of type:

```c++
const std::pair<const uint32_t, const Roaring>

```

which cannot be bound to:

```c++
const std::pair<const uint32_t, Roaring>
```

As it would make the ``Roaring`` component of the pair mutable.

Since this is not allowed the compiler looks for a compatible conversion
using overloading rules which leads it to ``Roaring``'s copy constructor.

In other words, for every call to that lambda a temporary copy of the
roaring bitmap is fully constructed, used and then immediately
discarded.

This can be fixed by using the right type for the argument or by using
``auto`` and letting the compiler determine the type by itself.

I prefer the latter but chose the former to retain C++11 compatibility.