### PR TITLE
Improve efficiency of outer map operations for Roaring64Map

### DIFF
--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -309,16 +309,58 @@ public:
     }
 
     /**
-     * Compute the intersection between the current bitmap and the provided
-     * bitmap, writing the result in the current bitmap. The provided bitmap
-     * is not modified.
+     * Compute the intersection of the current bitmap and the provided bitmap,
+     * writing the result in the current bitmap. The provided bitmap is not
+     * modified.
      */
-    Roaring64Map &operator&=(const Roaring64Map &r) {
-        for (auto &map_entry : roarings) {
-            if (r.roarings.count(map_entry.first) == 1)
-                map_entry.second &= r.roarings.at(map_entry.first);
-            else
-                map_entry.second = Roaring();
+    Roaring64Map &operator&=(const Roaring64Map &other) {
+        if (this == &other) {
+            // ANDing *this with itself is a no-op.
+            return *this;
+        }
+
+        // Logic table summarizing what to do when a given outer key is
+        // present vs. absent from self and other.
+        //
+        // self     other    (self & other)  work to do
+        // --------------------------------------------
+        // absent   absent   empty           None
+        // absent   present  empty           None
+        // present  absent   empty           Erase self
+        // present  present  empty or not    Intersect self with other, but
+        //                                   erase self if result is empty.
+        //
+        // Because there is only work to do when a key is present in 'self', the
+        // main for loop iterates over entries in 'self'.
+
+        decltype(roarings.begin()) self_next;
+        for (auto self_iter = roarings.begin(); self_iter != roarings.end();
+             self_iter = self_next) {
+            // Do the 'next' operation now, so we don't have to worry about
+            // invalidation of self_iter down below with the 'erase' operation.
+            self_next = std::next(self_iter);
+
+            auto self_key = self_iter->first;
+            auto &self_bitmap = self_iter->second;
+
+            auto other_iter = other.roarings.find(self_key);
+            if (other_iter == other.roarings.end()) {
+                // 'other' doesn't have self_key. In the logic table above,
+                // this reflects the case (self.present & other.absent).
+                // So, erase self.
+                roarings.erase(self_iter);
+                continue;
+            }
+
+            // Both sides have self_key. In the logic table above, this reflects
+            // the case (self.present & other.present). So, intersect self with
+            // other.
+            const auto &other_bitmap = other_iter->second;
+            self_bitmap &= other_bitmap;
+            if (self_bitmap.isEmpty()) {
+                // ...but if intersection is empty, remove it altogether.
+                roarings.erase(self_iter);
+            }
         }
         return *this;
     }
@@ -328,44 +370,177 @@ public:
      * bitmap, writing the result in the current bitmap. The provided bitmap
      * is not modified.
      */
-    Roaring64Map &operator-=(const Roaring64Map &r) {
-        for (auto &map_entry : roarings) {
-            if (r.roarings.count(map_entry.first) == 1)
-                map_entry.second -= r.roarings.at(map_entry.first);
+    Roaring64Map &operator-=(const Roaring64Map &other) {
+        if (this == &other) {
+            // Subtracting *this from itself results in the empty map.
+            roarings.clear();
+            return *this;
+        }
+
+        // Logic table summarizing what to do when a given outer key is
+        // present vs. absent from self and other.
+        //
+        // self     other    (self - other)  work to do
+        // --------------------------------------------
+        // absent   absent   empty           None
+        // absent   present  empty           None
+        // present  absent   unchanged       None
+        // present  present  empty or not    Subtract other from self, but
+        //                                   erase self if result is empty
+        //
+        // Because there is only work to do when a key is present in both 'self'
+        // and 'other', the main while loop ping-pongs back and forth until it
+        // finds the next key that is the same on both sides.
+
+        auto self_iter = roarings.begin();
+        auto other_iter = other.roarings.cbegin();
+
+        while (self_iter != roarings.end() &&
+               other_iter != other.roarings.cend()) {
+            auto self_key = self_iter->first;
+            auto other_key = other_iter->first;
+            if (self_key < other_key) {
+                // Because self_key is < other_key, advance self_iter to the
+                // first point where self_key >= other_key (or end).
+                self_iter = roarings.lower_bound(other_key);
+                continue;
+            }
+
+            if (self_key > other_key) {
+                // Because self_key is > other_key, advance other_iter to the
+                // first point where other_key >= self_key (or end).
+                other_iter = other.roarings.lower_bound(self_key);
+                continue;
+            }
+
+            // Both sides have self_key. In the logic table above, this reflects
+            // the case (self.present & other.present). So subtract other from
+            // self.
+            auto &self_bitmap = self_iter->second;
+            const auto &other_bitmap = other_iter->second;
+            self_bitmap -= other_bitmap;
+
+            if (self_bitmap.isEmpty()) {
+                // ...but if subtraction is empty, remove it altogether.
+                self_iter = roarings.erase(self_iter);
+            } else {
+                ++self_iter;
+            }
+            ++other_iter;
         }
         return *this;
     }
 
     /**
-     * Compute the union between the current bitmap and the provided bitmap,
+     * Compute the union of the current bitmap and the provided bitmap,
      * writing the result in the current bitmap. The provided bitmap is not
      * modified.
      *
      * See also the fastunion function to aggregate many bitmaps more quickly.
      */
-    Roaring64Map &operator|=(const Roaring64Map &r) {
-        for (const auto &map_entry : r.roarings) {
-            if (roarings.count(map_entry.first) == 0) {
-                roarings[map_entry.first] = map_entry.second;
-                roarings[map_entry.first].setCopyOnWrite(copyOnWrite);
-            } else
-                roarings[map_entry.first] |= map_entry.second;
+    Roaring64Map &operator|=(const Roaring64Map &other) {
+        if (this == &other) {
+            // ORing *this with itself is a no-op.
+            return *this;
+        }
+
+        // Logic table summarizing what to do when a given outer key is
+        // present vs. absent from self and other.
+        //
+        // self     other    (self | other)  work to do
+        // --------------------------------------------
+        // absent   absent   empty           None
+        // absent   present  not empty       Copy other to self and set flags
+        // present  absent   unchanged       None
+        // present  present  not empty       self |= other
+        //
+        // Because there is only work to do when a key is present in 'other',
+        // the main for loop iterates over entries in 'other'.
+
+        for (const auto &other_entry : other.roarings) {
+            const auto &other_bitmap = other_entry.second;
+
+            // Try to insert other_bitmap into self at other_key. We take
+            // advantage of the fact that std::map::insert will not overwrite an
+            // existing entry.
+            auto insert_result = roarings.insert(other_entry);
+            auto self_iter = insert_result.first;
+            auto insert_happened = insert_result.second;
+            auto &self_bitmap = self_iter->second;
+
+            if (insert_happened) {
+                // Key was not present in self, so insert was performed above.
+                // In the logic table above, this reflects the case
+                // (self.absent | other.present). Because the copy has already
+                // happened, thanks to the 'insert' operation above, we just
+                // need to set the copyOnWrite flag.
+                self_bitmap.setCopyOnWrite(copyOnWrite);
+                continue;
+            }
+
+            // Both sides have self_key, and the insert was not performed. In
+            // the logic table above, this reflects the case
+            // (self.present & other.present). So OR other into self.
+            self_bitmap |= other_bitmap;
         }
         return *this;
     }
 
     /**
-     * Compute the symmetric union between the current bitmap and the provided
-     * bitmap, writing the result in the current bitmap. The provided bitmap
-     * is not modified.
+     * Compute the XOR of the current bitmap and the provided bitmap, writing
+     * the result in the current bitmap. The provided bitmap is not modified.
      */
-    Roaring64Map &operator^=(const Roaring64Map &r) {
-        for (const auto &map_entry : r.roarings) {
-            if (roarings.count(map_entry.first) == 0) {
-                roarings[map_entry.first] = map_entry.second;
-                roarings[map_entry.first].setCopyOnWrite(copyOnWrite);
-            } else
-                roarings[map_entry.first] ^= map_entry.second;
+    Roaring64Map &operator^=(const Roaring64Map &other) {
+        if (this == &other) {
+            // XORing *this with itself results in the empty map.
+            roarings.clear();
+            return *this;
+        }
+
+        // Logic table summarizing what to do when a given outer key is
+        // present vs. absent from self and other.
+        //
+        // self     other    (self ^ other)  work to do
+        // --------------------------------------------
+        // absent   absent   empty           None
+        // absent   present  non-empty       Copy other to self and set flags
+        // present  absent   unchanged       None
+        // present  present  empty or not    XOR other into self, but erase self
+        //                                   if result is empty.
+        //
+        // Because there is only work to do when a key is present in 'other',
+        // the main for loop iterates over entries in 'other'.
+
+        for (const auto &other_entry : other.roarings) {
+            const auto &other_bitmap = other_entry.second;
+
+            // Try to insert other_bitmap into self at other_key. We take
+            // advantage of the fact that std::map::insert will not overwrite an
+            // existing entry.
+            auto insert_result = roarings.insert(other_entry);
+            auto self_iter = insert_result.first;
+            auto insert_happened = insert_result.second;
+            auto &self_bitmap = self_iter->second;
+
+            if (insert_happened) {
+                // Key was not present in self, so insert was performed above.
+                // In the logic table above, this reflects the case
+                // (self.absent | other.present). Because the copy has already
+                // happened, thanks to the 'insert' operation above, we just
+                // need to set the copyOnWrite flag.
+                self_bitmap.setCopyOnWrite(copyOnWrite);
+                continue;
+            }
+
+            // Both sides have self_key, and the insert was not performed. In
+            // the logic table above, this reflects the case
+            // (self.present ^ other.present). So XOR other into self.
+            self_bitmap ^= other_bitmap;
+
+            if (self_bitmap.isEmpty()) {
+                // ...but if intersection is empty, remove it altogether.
+                roarings.erase(self_iter);
+            }
         }
         return *this;
     }

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -525,7 +525,7 @@ public:
             if (insert_happened) {
                 // Key was not present in self, so insert was performed above.
                 // In the logic table above, this reflects the case
-                // (self.absent | other.present). Because the copy has already
+                // (self.absent ^ other.present). Because the copy has already
                 // happened, thanks to the 'insert' operation above, we just
                 // need to set the copyOnWrite flag.
                 self_bitmap.setCopyOnWrite(copyOnWrite);

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -832,7 +832,7 @@ DEFINE_TEST(test_cpp_remove_range_64) {
 }
 
 std::pair<doublechecked::Roaring64Map, doublechecked::Roaring64Map>
-    makeTwoBigRoaring64Maps() {
+    make_two_big_roaring64_maps() {
     // Insert a large number of pseudorandom numbers into two sets.
     const uint32_t randomSeed = 0xdeadbeef;
     const size_t numValues = 1000000;  // 1 million
@@ -883,40 +883,40 @@ std::pair<doublechecked::Roaring64Map, doublechecked::Roaring64Map>
 }
 
 DEFINE_TEST(test_cpp_union_64) {
-    auto twoMaps = makeTwoBigRoaring64Maps();
+    auto two_maps = make_two_big_roaring64_maps();
 
-    auto &lhs = twoMaps.first;
-    const auto &rhs = twoMaps.second;
+    auto &lhs = two_maps.first;
+    const auto &rhs = two_maps.second;
 
     lhs |= rhs;
     assert_true(lhs.does_std_set_match_roaring());
 }
 
 DEFINE_TEST(test_cpp_intersect_64) {
-    auto twoMaps = makeTwoBigRoaring64Maps();
+    auto two_maps = make_two_big_roaring64_maps();
 
-    auto &lhs = twoMaps.first;
-    const auto &rhs = twoMaps.second;
+    auto &lhs = two_maps.first;
+    const auto &rhs = two_maps.second;
 
     lhs &= rhs;
     assert_true(lhs.does_std_set_match_roaring());
 }
 
 DEFINE_TEST(test_cpp_difference_64) {
-    auto twoMaps = makeTwoBigRoaring64Maps();
+    auto two_maps = make_two_big_roaring64_maps();
 
-    auto &lhs = twoMaps.first;
-    const auto &rhs = twoMaps.second;
+    auto &lhs = two_maps.first;
+    const auto &rhs = two_maps.second;
 
     lhs -= rhs;
     assert_true(lhs.does_std_set_match_roaring());
 }
 
 DEFINE_TEST(test_cpp_xor_64) {
-    auto twoMaps = makeTwoBigRoaring64Maps();
+    auto two_maps = make_two_big_roaring64_maps();
 
-    auto &lhs = twoMaps.first;
-    const auto &rhs = twoMaps.second;
+    auto &lhs = two_maps.first;
+    const auto &rhs = two_maps.second;
 
     lhs ^= rhs;
     assert_true(lhs.does_std_set_match_roaring());

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <random>
 #include <vector>
 
 
@@ -24,6 +25,8 @@ using roaring::Roaring;  // the C++ wrapper class
 
 #include "roaring64map.hh"
 using roaring::Roaring64Map;  // C++ class extended for 64-bit numbers
+
+#include "roaring64map_checked.hh"
 
 #include "test.h"
 
@@ -828,6 +831,97 @@ DEFINE_TEST(test_cpp_remove_range_64) {
     }
 }
 
+std::pair<doublechecked::Roaring64Map, doublechecked::Roaring64Map>
+    makeTwoBigRoaring64Maps() {
+    // Insert a large number of pseudorandom numbers into two sets.
+    const uint32_t randomSeed = 0xdeadbeef;
+    const size_t numValues = 1000000;  // 1 million
+
+    doublechecked::Roaring64Map roaring1;
+    doublechecked::Roaring64Map roaring2;
+
+    std::default_random_engine engine(randomSeed);
+    std::uniform_int_distribution<uint64_t> rng;
+
+    for (size_t i = 0; i < numValues; ++i) {
+        auto value = rng(engine);
+        auto choice = rng(engine) % 4;
+        switch (choice) {
+            case 0: {
+                // Value is added only to set 1.
+                roaring1.add(value);
+                break;
+            }
+
+            case 1: {
+                // Value is added only to set 2.
+                roaring2.add(value);
+                break;
+            }
+
+            case 2: {
+                // Value is added to both sets.
+                roaring1.add(value);
+                roaring2.add(value);
+                break;
+            }
+
+            case 3: {
+                // Value is added to set 1, and a slightly different value
+                // is added to set 2. This makes it likely that they are in
+                // the same "outer" bin, but at a different "inner" position.
+                roaring1.add(value);
+                roaring2.add(value + 1);
+                break;
+            }
+
+            default:
+                assert_true(false);
+        }
+    }
+    return std::make_pair(std::move(roaring1), std::move(roaring2));
+}
+
+DEFINE_TEST(test_cpp_union_64) {
+    auto twoMaps = makeTwoBigRoaring64Maps();
+
+    auto &lhs = twoMaps.first;
+    const auto &rhs = twoMaps.second;
+
+    lhs |= rhs;
+    assert_true(lhs.does_std_set_match_roaring());
+}
+
+DEFINE_TEST(test_cpp_intersect_64) {
+    auto twoMaps = makeTwoBigRoaring64Maps();
+
+    auto &lhs = twoMaps.first;
+    const auto &rhs = twoMaps.second;
+
+    lhs &= rhs;
+    assert_true(lhs.does_std_set_match_roaring());
+}
+
+DEFINE_TEST(test_cpp_difference_64) {
+    auto twoMaps = makeTwoBigRoaring64Maps();
+
+    auto &lhs = twoMaps.first;
+    const auto &rhs = twoMaps.second;
+
+    lhs -= rhs;
+    assert_true(lhs.does_std_set_match_roaring());
+}
+
+DEFINE_TEST(test_cpp_xor_64) {
+    auto twoMaps = makeTwoBigRoaring64Maps();
+
+    auto &lhs = twoMaps.first;
+    const auto &rhs = twoMaps.second;
+
+    lhs ^= rhs;
+    assert_true(lhs.does_std_set_match_roaring());
+}
+
 DEFINE_TEST(test_cpp_clear_64) {
     Roaring64Map roaring;
 
@@ -1218,6 +1312,10 @@ int main() {
         cmocka_unit_test(test_run_compression_cpp_64_false),
         cmocka_unit_test(test_run_compression_cpp_true),
         cmocka_unit_test(test_run_compression_cpp_false),
+        cmocka_unit_test(test_cpp_union_64),
+        cmocka_unit_test(test_cpp_intersect_64),
+        cmocka_unit_test(test_cpp_difference_64),
+        cmocka_unit_test(test_cpp_xor_64),
         cmocka_unit_test(test_cpp_clear_64),
         cmocka_unit_test(test_cpp_move_64),
         cmocka_unit_test(test_roaring64_iterate_multi_roaring),


### PR DESCRIPTION
Hello,

The purpose of this PR is to slightly improve the efficiency of `Roaring64Map` in C++.

As you know `Roaring64Map` contains an "outer" `std::map`, which maps the key's high bits to individual (32-bit) Roaring maps, which in turn handle the key's low bits. The problem is that many of the methods in `Roaring64Map` probe the outer map more times than necessary. This includes high-traffic items like `add()` and `contains()`, which probe twice when they only need to probe once.

I've changed a variety of methods to do fewer probes. While I was here I also took the liberty to make a few changes:
* In `flip()`, I added what I believe to be a missing call to `setCopyOnWrite()`
* In `operator &=`,  `operator -=`, and `operator ^=`, if the 32-bit Roaring entry becomes empty, I remove it from the outer map altogether, rather than leaving an empty Roaring in that slot. I believe this is preferable (?)
* In `shrinkToFit()` I removed an instance of what I believe is undefined behavior. In the line `roarings.erase(iter++)` I believe it is theoretically possible for the increment to happen after the call to `erase` has finished (and therefore `iter` would be an invalid iterator at that point and you ought not try to increment it).  EDIT: no, this can't happen with an overloaded operator, so, forget I mentioned it. (I would still prefer to keep my change because I feel it reads better).
* In `maximum()` I changed the code to use forward iterators, but traversing in the reverse direction, rather than reverse iterators. The rationale is that map's `reverse_iterator` is significantly slower than its `forward_iterator`, because in `reverse_iterator`, the `operator *` and `operator ->` methods are not constant time because they both do a decrement operation on a temporary internal tree iterator. I can provide more detail if you're interested.

The code passes the current test suite. I'm not sure if that's sufficient or if additional tests need to be written.

