### PR TITLE
[WIP] Add SSE and AVX-512 support

### DIFF
--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -64,177 +64,20 @@ bitset_container_t *bitset_container_clone(const bitset_container_t *src);
 void bitset_container_set_range(bitset_container_t *bitset, uint32_t begin,
                                 uint32_t end);
 
-static inline void _scalar_bitset_container_set(bitset_container_t* bitset, uint16_t pos) {
-    const uint64_t old_word = bitset->words[pos >> 6];
-    const int index = pos & 63;
-    const uint64_t new_word = old_word | (UINT64_C(1) << index);
-    bitset->cardinality += (uint32_t)((old_word ^ new_word) >> index);
-    bitset->words[pos >> 6] = new_word;
-}
-
-static inline void _scalar_bitset_container_unset(bitset_container_t* bitset, uint16_t pos) {
-    const uint64_t old_word = bitset->words[pos >> 6];
-    const int index = pos & 63;
-    const uint64_t new_word = old_word & (~(UINT64_C(1) << index));
-    bitset->cardinality -= (uint32_t)((old_word ^ new_word) >> index);
-    bitset->words[pos >> 6] = new_word;
-}
-
-static inline bool _scalar_bitset_container_add(bitset_container_t* bitset, uint16_t pos) {
-    const uint64_t old_word = bitset->words[pos >> 6];
-    const int index = pos & 63;
-    const uint64_t new_word = old_word | (UINT64_C(1) << index);
-    const uint64_t increment = (old_word ^ new_word) >> index;
-    bitset->cardinality += (uint32_t)increment;
-    bitset->words[pos >> 6] = new_word;
-    return increment > 0;
-}
-
-static inline bool _scalar_bitset_container_remove(bitset_container_t* bitset, uint16_t pos) {
-    const uint64_t old_word = bitset->words[pos >> 6];
-    const int index = pos & 63;
-    const uint64_t new_word = old_word & (~(UINT64_C(1) << index));
-    const uint64_t increment = (old_word ^ new_word) >> index;
-    bitset->cardinality -= (uint32_t)increment;
-    bitset->words[pos >> 6] = new_word;
-    return increment > 0;
-}
-
-static inline bool _scalar_bitset_container_get(const bitset_container_t* bitset, uint16_t pos) {
-    const uint64_t word = bitset->words[pos >> 6];
-    return (word >> (pos & 63)) & 1;
-}
-
-#if defined(CROARING_ASMBITMANIPOPTIMIZATION)
-
-static inline void _asm_bitset_container_set(bitset_container_t* bitset, uint16_t pos) {
-    uint64_t shift = 6;
-    uint64_t offset;
-    uint64_t p = pos;
-    ASM_SHIFT_RIGHT(p, shift, offset);
-    uint64_t load = bitset->words[offset];
-    ASM_SET_BIT_INC_WAS_CLEAR(load, p, bitset->cardinality);
-    bitset->words[offset] = load;
-}
-
-static inline void _asm_bitset_container_unset(bitset_container_t* bitset, uint16_t pos) {
-    uint64_t shift = 6;
-    uint64_t offset;
-    uint64_t p = pos;
-    ASM_SHIFT_RIGHT(p, shift, offset);
-    uint64_t load = bitset->words[offset];
-    ASM_CLEAR_BIT_DEC_WAS_SET(load, p, bitset->cardinality);
-    bitset->words[offset] = load;
-}
-
-static inline bool _asm_bitset_container_add(bitset_container_t* bitset, uint16_t pos) {
-    uint64_t shift = 6;
-    uint64_t offset;
-    uint64_t p = pos;
-    ASM_SHIFT_RIGHT(p, shift, offset);
-    uint64_t load = bitset->words[offset];
-    // could be possibly slightly further optimized
-    const int32_t oldcard = bitset->cardinality;
-    ASM_SET_BIT_INC_WAS_CLEAR(load, p, bitset->cardinality);
-    bitset->words[offset] = load;
-    return bitset->cardinality - oldcard;
-}
-
-static inline bool _asm_bitset_container_remove(bitset_container_t* bitset, uint16_t pos) {
-    uint64_t shift = 6;
-    uint64_t offset;
-    uint64_t p = pos;
-    ASM_SHIFT_RIGHT(p, shift, offset);
-    uint64_t load = bitset->words[offset];
-    // could be possibly slightly further optimized
-    const int32_t oldcard = bitset->cardinality;
-    ASM_CLEAR_BIT_DEC_WAS_SET(load, p, bitset->cardinality);
-    bitset->words[offset] = load;
-    return oldcard - bitset->cardinality;
-}
-
-static inline bool _asm_bitset_container_get(const bitset_container_t* bitset, uint16_t pos) {
-    uint64_t word = bitset->words[pos >> 6];
-    const uint64_t p = pos;
-    ASM_INPLACESHIFT_RIGHT(word, p);
-    return word & 1;
-}
-
-inline void bitset_container_set(bitset_container_t* bitset, uint16_t pos) {
-    if (croaring_bmi2()) {
-        _asm_bitset_container_set(bitset, pos);
-    } else {
-        _scalar_bitset_container_set(bitset, pos);
-    }
-}
+void bitset_container_set(bitset_container_t* bitset, uint16_t pos);
 
 /* Unset the ith bit.  */
-inline void bitset_container_unset(bitset_container_t* bitset, uint16_t pos) {
-    if (croaring_bmi2()) {
-        _asm_bitset_container_unset(bitset, pos);
-    } else {
-        _scalar_bitset_container_unset(bitset, pos);
-    }
-}
+void bitset_container_unset(bitset_container_t* bitset, uint16_t pos);
 
 /* Add `pos' to `bitset'. Returns true if `pos' was not present. Might be slower
  * than bitset_container_set.  */
-inline bool bitset_container_add(bitset_container_t* bitset, uint16_t pos) {
-    if (croaring_bmi2()) {
-        return _asm_bitset_container_add(bitset, pos);
-    } else {
-        return _scalar_bitset_container_add(bitset, pos);
-    }
-}
-
+bool bitset_container_add(bitset_container_t* bitset, uint16_t pos);
 /* Remove `pos' from `bitset'. Returns true if `pos' was present.  Might be
  * slower than bitset_container_unset.  */
-inline bool bitset_container_remove(bitset_container_t* bitset, uint16_t pos) {
-    if (croaring_bmi2()) {
-        return _asm_bitset_container_remove(bitset, pos);
-    } else {
-        return _scalar_bitset_container_remove(bitset, pos);
-    }
-}
+bool bitset_container_remove(bitset_container_t* bitset, uint16_t pos);
 
 /* Get the value of the ith bit.  */
-inline bool bitset_container_get(const bitset_container_t* bitset, uint16_t pos) {
-    if (croaring_bmi2()) {
-        return _asm_bitset_container_get(bitset, pos);
-    } else {
-        return _scalar_bitset_container_get(bitset, pos);
-    }
-}
-
-#else
-
-inline void bitset_container_set(bitset_container_t* bitset, uint16_t pos) {
-    _scalar_bitset_container_set(bitset, pos);
-}
-
-/* Unset the ith bit.  */
-inline void bitset_container_unset(bitset_container_t* bitset, uint16_t pos) {
-    _scalar_bitset_container_unset(bitset, pos);
-}
-
-/* Add `pos' to `bitset'. Returns true if `pos' was not present. Might be slower
- * than bitset_container_set.  */
-inline bool bitset_container_add(bitset_container_t* bitset, uint16_t pos) {
-    return _scalar_bitset_container_add(bitset, pos);
-}
-
-/* Remove `pos' from `bitset'. Returns true if `pos' was present.  Might be
- * slower than bitset_container_unset.  */
-inline bool bitset_container_remove(bitset_container_t* bitset, uint16_t pos) {
-    return _scalar_bitset_container_remove(bitset, pos);
-}
-
-/* Get the value of the ith bit.  */
-inline bool bitset_container_get(const bitset_container_t* bitset, uint16_t pos) {
-    return _scalar_bitset_container_get(bitset, pos);
-}
-
-#endif
+bool bitset_container_get(const bitset_container_t* bitset, uint16_t pos);
 
 /*
 * Check if all bits are set in a range of positions from pos_start (included) to

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -64,7 +64,7 @@ bitset_container_t *bitset_container_clone(const bitset_container_t *src);
 void bitset_container_set_range(bitset_container_t *bitset, uint32_t begin,
                                 uint32_t end);
 
-#if defined(CROARING_ASMBITMANIPOPTIMIZATION) && defined(__AVX2__)
+#if defined(CROARING_ASMBITMANIPOPTIMIZATION) && defined(__BMI2__)
 /* Set the ith bit.  */
 static inline void bitset_container_set(bitset_container_t *bitset,
                                         uint16_t pos) {

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -64,10 +64,50 @@ bitset_container_t *bitset_container_clone(const bitset_container_t *src);
 void bitset_container_set_range(bitset_container_t *bitset, uint32_t begin,
                                 uint32_t end);
 
-#if defined(CROARING_ASMBITMANIPOPTIMIZATION) && defined(__BMI2__)
-/* Set the ith bit.  */
-static inline void bitset_container_set(bitset_container_t *bitset,
-                                        uint16_t pos) {
+static inline void _scalar_bitset_container_set(bitset_container_t* bitset, uint16_t pos) {
+    const uint64_t old_word = bitset->words[pos >> 6];
+    const int index = pos & 63;
+    const uint64_t new_word = old_word | (UINT64_C(1) << index);
+    bitset->cardinality += (uint32_t)((old_word ^ new_word) >> index);
+    bitset->words[pos >> 6] = new_word;
+}
+
+static inline void _scalar_bitset_container_unset(bitset_container_t* bitset, uint16_t pos) {
+    const uint64_t old_word = bitset->words[pos >> 6];
+    const int index = pos & 63;
+    const uint64_t new_word = old_word & (~(UINT64_C(1) << index));
+    bitset->cardinality -= (uint32_t)((old_word ^ new_word) >> index);
+    bitset->words[pos >> 6] = new_word;
+}
+
+static inline bool _scalar_bitset_container_add(bitset_container_t* bitset, uint16_t pos) {
+    const uint64_t old_word = bitset->words[pos >> 6];
+    const int index = pos & 63;
+    const uint64_t new_word = old_word | (UINT64_C(1) << index);
+    const uint64_t increment = (old_word ^ new_word) >> index;
+    bitset->cardinality += (uint32_t)increment;
+    bitset->words[pos >> 6] = new_word;
+    return increment > 0;
+}
+
+static inline bool _scalar_bitset_container_remove(bitset_container_t* bitset, uint16_t pos) {
+    const uint64_t old_word = bitset->words[pos >> 6];
+    const int index = pos & 63;
+    const uint64_t new_word = old_word & (~(UINT64_C(1) << index));
+    const uint64_t increment = (old_word ^ new_word) >> index;
+    bitset->cardinality -= (uint32_t)increment;
+    bitset->words[pos >> 6] = new_word;
+    return increment > 0;
+}
+
+static inline bool _scalar_bitset_container_get(const bitset_container_t* bitset, uint16_t pos) {
+    const uint64_t word = bitset->words[pos >> 6];
+    return (word >> (pos & 63)) & 1;
+}
+
+#if defined(CROARING_ASMBITMANIPOPTIMIZATION)
+
+static inline void _asm_bitset_container_set(bitset_container_t* bitset, uint16_t pos) {
     uint64_t shift = 6;
     uint64_t offset;
     uint64_t p = pos;
@@ -77,9 +117,7 @@ static inline void bitset_container_set(bitset_container_t *bitset,
     bitset->words[offset] = load;
 }
 
-/* Unset the ith bit.  */
-static inline void bitset_container_unset(bitset_container_t *bitset,
-                                          uint16_t pos) {
+static inline void _asm_bitset_container_unset(bitset_container_t* bitset, uint16_t pos) {
     uint64_t shift = 6;
     uint64_t offset;
     uint64_t p = pos;
@@ -89,10 +127,7 @@ static inline void bitset_container_unset(bitset_container_t *bitset,
     bitset->words[offset] = load;
 }
 
-/* Add `pos' to `bitset'. Returns true if `pos' was not present. Might be slower
- * than bitset_container_set.  */
-static inline bool bitset_container_add(bitset_container_t *bitset,
-                                        uint16_t pos) {
+static inline bool _asm_bitset_container_add(bitset_container_t* bitset, uint16_t pos) {
     uint64_t shift = 6;
     uint64_t offset;
     uint64_t p = pos;
@@ -105,10 +140,7 @@ static inline bool bitset_container_add(bitset_container_t *bitset,
     return bitset->cardinality - oldcard;
 }
 
-/* Remove `pos' from `bitset'. Returns true if `pos' was present.  Might be
- * slower than bitset_container_unset.  */
-static inline bool bitset_container_remove(bitset_container_t *bitset,
-                                           uint16_t pos) {
+static inline bool _asm_bitset_container_remove(bitset_container_t* bitset, uint16_t pos) {
     uint64_t shift = 6;
     uint64_t offset;
     uint64_t p = pos;
@@ -121,68 +153,85 @@ static inline bool bitset_container_remove(bitset_container_t *bitset,
     return oldcard - bitset->cardinality;
 }
 
-/* Get the value of the ith bit.  */
-inline bool bitset_container_get(const bitset_container_t *bitset,
-                                 uint16_t pos) {
+static inline bool _asm_bitset_container_get(const bitset_container_t* bitset, uint16_t pos) {
     uint64_t word = bitset->words[pos >> 6];
     const uint64_t p = pos;
     ASM_INPLACESHIFT_RIGHT(word, p);
     return word & 1;
 }
 
-#else
-
-/* Set the ith bit.  */
-static inline void bitset_container_set(bitset_container_t *bitset,
-                                        uint16_t pos) {
-    const uint64_t old_word = bitset->words[pos >> 6];
-    const int index = pos & 63;
-    const uint64_t new_word = old_word | (UINT64_C(1) << index);
-    bitset->cardinality += (uint32_t)((old_word ^ new_word) >> index);
-    bitset->words[pos >> 6] = new_word;
+inline void bitset_container_set(bitset_container_t* bitset, uint16_t pos) {
+    if (croaring_bmi2()) {
+        _asm_bitset_container_set(bitset, pos);
+    } else {
+        _scalar_bitset_container_set(bitset, pos);
+    }
 }
 
 /* Unset the ith bit.  */
-static inline void bitset_container_unset(bitset_container_t *bitset,
-                                          uint16_t pos) {
-    const uint64_t old_word = bitset->words[pos >> 6];
-    const int index = pos & 63;
-    const uint64_t new_word = old_word & (~(UINT64_C(1) << index));
-    bitset->cardinality -= (uint32_t)((old_word ^ new_word) >> index);
-    bitset->words[pos >> 6] = new_word;
+inline void bitset_container_unset(bitset_container_t* bitset, uint16_t pos) {
+    if (croaring_bmi2()) {
+        _asm_bitset_container_unset(bitset, pos);
+    } else {
+        _scalar_bitset_container_unset(bitset, pos);
+    }
 }
 
 /* Add `pos' to `bitset'. Returns true if `pos' was not present. Might be slower
  * than bitset_container_set.  */
-static inline bool bitset_container_add(bitset_container_t *bitset,
-                                        uint16_t pos) {
-    const uint64_t old_word = bitset->words[pos >> 6];
-    const int index = pos & 63;
-    const uint64_t new_word = old_word | (UINT64_C(1) << index);
-    const uint64_t increment = (old_word ^ new_word) >> index;
-    bitset->cardinality += (uint32_t)increment;
-    bitset->words[pos >> 6] = new_word;
-    return increment > 0;
+inline bool bitset_container_add(bitset_container_t* bitset, uint16_t pos) {
+    if (croaring_bmi2()) {
+        return _asm_bitset_container_add(bitset, pos);
+    } else {
+        return _scalar_bitset_container_add(bitset, pos);
+    }
 }
 
 /* Remove `pos' from `bitset'. Returns true if `pos' was present.  Might be
  * slower than bitset_container_unset.  */
-static inline bool bitset_container_remove(bitset_container_t *bitset,
-                                           uint16_t pos) {
-    const uint64_t old_word = bitset->words[pos >> 6];
-    const int index = pos & 63;
-    const uint64_t new_word = old_word & (~(UINT64_C(1) << index));
-    const uint64_t increment = (old_word ^ new_word) >> index;
-    bitset->cardinality -= (uint32_t)increment;
-    bitset->words[pos >> 6] = new_word;
-    return increment > 0;
+inline bool bitset_container_remove(bitset_container_t* bitset, uint16_t pos) {
+    if (croaring_bmi2()) {
+        return _asm_bitset_container_remove(bitset, pos);
+    } else {
+        return _scalar_bitset_container_remove(bitset, pos);
+    }
 }
 
 /* Get the value of the ith bit.  */
-inline bool bitset_container_get(const bitset_container_t *bitset,
-                                 uint16_t pos) {
-    const uint64_t word = bitset->words[pos >> 6];
-    return (word >> (pos & 63)) & 1;
+inline bool bitset_container_get(const bitset_container_t* bitset, uint16_t pos) {
+    if (croaring_bmi2()) {
+        return _asm_bitset_container_get(bitset, pos);
+    } else {
+        return _scalar_bitset_container_get(bitset, pos);
+    }
+}
+
+#else
+
+inline void bitset_container_set(bitset_container_t* bitset, uint16_t pos) {
+    _scalar_bitset_container_set(bitset, pos);
+}
+
+/* Unset the ith bit.  */
+inline void bitset_container_unset(bitset_container_t* bitset, uint16_t pos) {
+    _scalar_bitset_container_unset(bitset, pos);
+}
+
+/* Add `pos' to `bitset'. Returns true if `pos' was not present. Might be slower
+ * than bitset_container_set.  */
+inline bool bitset_container_add(bitset_container_t* bitset, uint16_t pos) {
+    return _scalar_bitset_container_add(bitset, pos);
+}
+
+/* Remove `pos' from `bitset'. Returns true if `pos' was present.  Might be
+ * slower than bitset_container_unset.  */
+inline bool bitset_container_remove(bitset_container_t* bitset, uint16_t pos) {
+    return _scalar_bitset_container_remove(bitset, pos);
+}
+
+/* Get the value of the ith bit.  */
+inline bool bitset_container_get(const bitset_container_t* bitset, uint16_t pos) {
+    return _scalar_bitset_container_get(bitset, pos);
 }
 
 #endif

--- a/include/roaring/isadetection.h
+++ b/include/roaring/isadetection.h
@@ -231,7 +231,7 @@ static inline bool croaring_sse42() {
 }
 #endif
 
-#ifndef CROARING_ASMBITMANIPOPTIMIZATION
+#ifdef ROARING_DISABLE_BMI
 static inline bool croaring_bmi2() {
   return false;
 }

--- a/include/roaring/isadetection.h
+++ b/include/roaring/isadetection.h
@@ -217,6 +217,33 @@ static inline bool croaring_avx2() {
 }
 #endif
 
+#ifdef ROARING_DISABLE_SSE
+static inline bool croaring_sse42() {
+  return false;
+}
+#elif defined(__SSE4_2__)
+static inline bool croaring_sse42() {
+  return true;
+}
+#else
+static inline bool croaring_sse42() {
+  return  (croaring_detect_supported_architectures() & CROARING_SSE42) == CROARING_SSE42;
+}
+#endif
+
+#ifndef CROARING_ASMBITMANIPOPTIMIZATION
+static inline bool croaring_bmi2() {
+  return false;
+}
+#elif defined(__BMI2__)
+static inline bool croaring_bmi2() {
+  return true;
+}
+#else
+static inline bool croaring_bmi2() {
+  return  (croaring_detect_supported_architectures() & CROARING_BMI2) == CROARING_BMI2;
+}
+#endif
 
 #else // defined(__x86_64__) || defined(_M_AMD64) // x64
 

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -316,6 +316,7 @@ static inline int hamming(uint64_t x) {
 #endif
 
 #define CROARING_TARGET_AVX2 CROARING_TARGET_REGION("avx2,bmi,pclmul,lzcnt")
+#define CROARING_TARGET_SSE42 CROARING_TARGET_REGION("sse4.2,bmi,pclmul,lzcnt")
 
 #ifdef __AVX2__
 // No need for runtime dispatching.

--- a/include/roaring/utilasm.h
+++ b/include/roaring/utilasm.h
@@ -15,7 +15,6 @@ extern "C" { namespace roaring {
 #if defined(CROARING_INLINE_ASM)
 #define CROARING_ASMBITMANIPOPTIMIZATION  // optimization flag
 
-#if defined(__BMI2__)
 #define ASM_SHIFT_RIGHT(srcReg, bitsReg, destReg) \
     __asm volatile("shrx %1, %2, %0"              \
                    : "=r"(destReg)                \
@@ -70,8 +69,7 @@ extern "C" { namespace roaring {
         "r"(testBit)   /* read only */     \
         )
 
-#endif // defined(__BMI2__)
-#endif // defined(CROARING_INLINE_ASM)
+#endif
 
 #ifdef __cplusplus
 } }  // extern "C" { namespace roaring {

--- a/include/roaring/utilasm.h
+++ b/include/roaring/utilasm.h
@@ -15,6 +15,7 @@ extern "C" { namespace roaring {
 #if defined(CROARING_INLINE_ASM)
 #define CROARING_ASMBITMANIPOPTIMIZATION  // optimization flag
 
+#if defined(__BMI2__)
 #define ASM_SHIFT_RIGHT(srcReg, bitsReg, destReg) \
     __asm volatile("shrx %1, %2, %0"              \
                    : "=r"(destReg)                \
@@ -69,7 +70,8 @@ extern "C" { namespace roaring {
         "r"(testBit)   /* read only */     \
         )
 
-#endif
+#endif // defined(__BMI2__)
+#endif // defined(CROARING_INLINE_ASM)
 
 #ifdef __cplusplus
 } }  // extern "C" { namespace roaring {

--- a/src/array_util.c
+++ b/src/array_util.c
@@ -1861,7 +1861,7 @@ size_t union_uint32_card(const uint32_t *set_1, size_t size_1,
 size_t fast_union_uint16(const uint16_t *set_1, size_t size_1, const uint16_t *set_2,
                     size_t size_2, uint16_t *buffer) {
 #ifdef CROARING_IS_X64
-    if( croaring_avx2() ) {
+    if( croaring_sse42() ) {
         // compute union with smallest array first
       if (size_1 < size_2) {
         return union_vector16(set_1, (uint32_t)size_1,

--- a/src/array_util.c
+++ b/src/array_util.c
@@ -367,7 +367,7 @@ static const uint8_t shuffle_mask16[] = {
  * From Schlegel et al., Fast Sorted-Set Intersection using SIMD Instructions
  * Optimized by D. Lemire on May 3rd 2013
  */
-CROARING_TARGET_AVX2
+CROARING_TARGET_SSE42
 int32_t intersect_vector16(const uint16_t *__restrict__ A, size_t s_a,
                            const uint16_t *__restrict__ B, size_t s_b,
                            uint16_t *C) {
@@ -446,7 +446,7 @@ int32_t intersect_vector16(const uint16_t *__restrict__ A, size_t s_a,
 }
 CROARING_UNTARGET_REGION
 
-CROARING_TARGET_AVX2
+CROARING_TARGET_SSE42
 int32_t intersect_vector16_cardinality(const uint16_t *__restrict__ A,
                                        size_t s_a,
                                        const uint16_t *__restrict__ B,
@@ -518,7 +518,7 @@ int32_t intersect_vector16_cardinality(const uint16_t *__restrict__ A,
 }
 CROARING_UNTARGET_REGION
 
-CROARING_TARGET_AVX2
+CROARING_TARGET_SSE42
 /////////
 // Warning:
 // This function may not be safe if A == C or B == C.
@@ -662,7 +662,6 @@ int32_t difference_vector16(const uint16_t *__restrict__ A, size_t s_a,
 }
 CROARING_UNTARGET_REGION
 #endif  // CROARING_IS_X64
-
 
 
 /**
@@ -1527,7 +1526,7 @@ static int uint16_compare(const void *a, const void *b) {
     return (*(uint16_t *)a - *(uint16_t *)b);
 }
 
-CROARING_TARGET_AVX2
+CROARING_TARGET_SSE42
 // a one-pass SSE union algorithm
 // This function may not be safe if array1 == output or array2 == output.
 uint32_t union_vector16(const uint16_t *__restrict__ array1, uint32_t length1,
@@ -1652,7 +1651,8 @@ static inline uint32_t unique_xor(uint16_t *out, uint32_t len) {
     }
     return pos;
 }
-CROARING_TARGET_AVX2
+
+CROARING_TARGET_SSE42
 // a one-pass SSE xor algorithm
 uint32_t xor_vector16(const uint16_t *__restrict__ array1, uint32_t length1,
                       const uint16_t *__restrict__ array2, uint32_t length2,
@@ -1757,6 +1757,7 @@ uint32_t xor_vector16(const uint16_t *__restrict__ array1, uint32_t length1,
     return len;
 }
 CROARING_UNTARGET_REGION
+
 /**
  * End of SIMD 16-bit XOR code
  */
@@ -1861,7 +1862,7 @@ size_t union_uint32_card(const uint32_t *set_1, size_t size_1,
 size_t fast_union_uint16(const uint16_t *set_1, size_t size_1, const uint16_t *set_2,
                     size_t size_2, uint16_t *buffer) {
 #ifdef CROARING_IS_X64
-    if( croaring_sse42() ) {
+    if(croaring_sse42()) {
         // compute union with smallest array first
       if (size_1 < size_2) {
         return union_vector16(set_1, (uint32_t)size_1,

--- a/src/bitset_util.c
+++ b/src/bitset_util.c
@@ -737,7 +737,7 @@ size_t bitset_extract_setbits_uint16(const uint64_t *words, size_t length,
     return outpos;
 }
 
-#if defined(CROARING_ASMBITMANIPOPTIMIZATION) && defined(CROARING_IS_X64) && defined(__BMI2__)
+#if defined(CROARING_ASMBITMANIPOPTIMIZATION) && defined(CROARING_IS_X64)
 
 static inline uint64_t _asm_bitset_set_list_withcard(uint64_t *words, uint64_t card,
                                   const uint16_t *list, uint64_t length) {

--- a/src/bitset_util.c
+++ b/src/bitset_util.c
@@ -737,7 +737,7 @@ size_t bitset_extract_setbits_uint16(const uint64_t *words, size_t length,
     return outpos;
 }
 
-#if defined(CROARING_ASMBITMANIPOPTIMIZATION) && defined(CROARING_IS_X64)
+#if defined(CROARING_ASMBITMANIPOPTIMIZATION) && defined(CROARING_IS_X64) && defined(__BMI2__)
 
 static inline uint64_t _asm_bitset_set_list_withcard(uint64_t *words, uint64_t card,
                                   const uint16_t *list, uint64_t length) {
@@ -895,7 +895,7 @@ static inline void _scalar_bitset_set_list(uint64_t *words, const uint16_t *list
 
 uint64_t bitset_clear_list(uint64_t *words, uint64_t card, const uint16_t *list,
                            uint64_t length) {
-    if( croaring_avx2() ) {
+    if( croaring_bmi2() ) {
         return _asm_bitset_clear_list(words, card, list, length);
     } else {
         return _scalar_bitset_clear_list(words, card, list, length);
@@ -904,7 +904,7 @@ uint64_t bitset_clear_list(uint64_t *words, uint64_t card, const uint16_t *list,
 
 uint64_t bitset_set_list_withcard(uint64_t *words, uint64_t card,
                                   const uint16_t *list, uint64_t length) {
-    if( croaring_avx2() ) {
+    if( croaring_bmi2() ) {
         return _asm_bitset_set_list_withcard(words, card, list, length);
     } else {
         return _scalar_bitset_set_list_withcard(words, card, list, length);
@@ -912,7 +912,7 @@ uint64_t bitset_set_list_withcard(uint64_t *words, uint64_t card,
 }
 
 void bitset_set_list(uint64_t *words, const uint16_t *list, uint64_t length) {
-    if( croaring_avx2() ) {
+    if( croaring_bmi2() ) {
         _asm_bitset_set_list(words, list, length);
     } else {
         _scalar_bitset_set_list(words, list, length);

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -218,7 +218,7 @@ void array_container_andnot(const array_container_t *array_1,
     if (out->capacity < array_1->cardinality)
         array_container_grow(out, array_1->cardinality, false);
 #ifdef CROARING_IS_X64
-    if(( croaring_avx2() ) && (out != array_1) && (out != array_2)) {
+    if(( croaring_sse42() ) && (out != array_1) && (out != array_2)) {
       out->cardinality =
           difference_vector16(array_1->array, array_1->cardinality,
                             array_2->array, array_2->cardinality, out->array);
@@ -249,7 +249,7 @@ void array_container_xor(const array_container_t *array_1,
     }
 
 #ifdef CROARING_IS_X64
-    if( croaring_avx2() ) {
+    if( croaring_sse42() ) {
       out->cardinality =
         xor_vector16(array_1->array, array_1->cardinality, array_2->array,
                      array_2->cardinality, out->array);
@@ -298,7 +298,7 @@ void array_container_intersection(const array_container_t *array1,
             array2->array, card_2, array1->array, card_1, out->array);
     } else {
 #ifdef CROARING_IS_X64
-       if( croaring_avx2() ) {
+       if( croaring_sse42() ) {
         out->cardinality = intersect_vector16(
             array1->array, card_1, array2->array, card_2, out->array);
        } else {
@@ -326,7 +326,7 @@ int array_container_intersection_cardinality(const array_container_t *array1,
                                                    array1->array, card_1);
     } else {
 #ifdef CROARING_IS_X64
-    if( croaring_avx2() ) {
+    if( croaring_sse42() ) {
         return intersect_vector16_cardinality(array1->array, card_1,
                                               array2->array, card_2);
     } else {

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -217,8 +217,9 @@ void array_container_andnot(const array_container_t *array_1,
                             array_container_t *out) {
     if (out->capacity < array_1->cardinality)
         array_container_grow(out, array_1->cardinality, false);
-#ifdef CROARING_IS_X64
-    if(( croaring_sse42() ) && (out != array_1) && (out != array_2)) {
+// Somehow difference_vector16 doesn't work on macOS+llvm13
+#if defined(CROARING_IS_X64) && false
+    if(croaring_sse42() && (out != array_1) && (out != array_2)) {
       out->cardinality =
           difference_vector16(array_1->array, array_1->cardinality,
                             array_2->array, array_2->cardinality, out->array);
@@ -247,8 +248,8 @@ void array_container_xor(const array_container_t *array_1,
     if (out->capacity < max_cardinality) {
         array_container_grow(out, max_cardinality, false);
     }
-
-#ifdef CROARING_IS_X64
+// Somehow xor_vector16 doesn't work on macOS+llvm13
+#if defined(CROARING_IS_X64) && false
     if( croaring_sse42() ) {
       out->cardinality =
         xor_vector16(array_1->array, array_1->cardinality, array_2->array,

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -217,9 +217,8 @@ void array_container_andnot(const array_container_t *array_1,
                             array_container_t *out) {
     if (out->capacity < array_1->cardinality)
         array_container_grow(out, array_1->cardinality, false);
-// Somehow difference_vector16 doesn't work on macOS+llvm13
-#if defined(CROARING_IS_X64) && false
-    if(croaring_sse42() && (out != array_1) && (out != array_2)) {
+#if defined(CROARING_IS_X64)
+    if(croaring_avx2() && (out != array_1) && (out != array_2)) {
       out->cardinality =
           difference_vector16(array_1->array, array_1->cardinality,
                             array_2->array, array_2->cardinality, out->array);
@@ -248,9 +247,8 @@ void array_container_xor(const array_container_t *array_1,
     if (out->capacity < max_cardinality) {
         array_container_grow(out, max_cardinality, false);
     }
-// Somehow xor_vector16 doesn't work on macOS+llvm13
-#if defined(CROARING_IS_X64) && false
-    if( croaring_sse42() ) {
+#if defined(CROARING_IS_X64)
+    if( croaring_avx2() ) {
       out->cardinality =
         xor_vector16(array_1->array, array_1->cardinality, array_2->array,
                      array_2->cardinality, out->array);

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -218,7 +218,7 @@ void array_container_andnot(const array_container_t *array_1,
     if (out->capacity < array_1->cardinality)
         array_container_grow(out, array_1->cardinality, false);
 #if defined(CROARING_IS_X64)
-    if(croaring_avx2() && (out != array_1) && (out != array_2)) {
+    if(croaring_sse42() && (out != array_1) && (out != array_2)) {
       out->cardinality =
           difference_vector16(array_1->array, array_1->cardinality,
                             array_2->array, array_2->cardinality, out->array);
@@ -248,7 +248,7 @@ void array_container_xor(const array_container_t *array_1,
         array_container_grow(out, max_cardinality, false);
     }
 #if defined(CROARING_IS_X64)
-    if( croaring_avx2() ) {
+    if( croaring_sse42() ) {
       out->cardinality =
         xor_vector16(array_1->array, array_1->cardinality, array_2->array,
                      array_2->cardinality, out->array);


### PR DESCRIPTION
For issue #391 

Instead of using `croaring_avx2()` to switch on and off all vectorizing optimizations, add `croaring_sse42()` and `croaring_bmi2()` to specify what support a funciton actually needs. This enables old CPUs to use at least some of the optimizations.

[WIP] Add vectorized functions using AVX-512 instructions for better performance.
[WIP] Add vectorized functions using old SSE instructions to enable old machines that don't support AVX to use vectorized instructions.