### PR TITLE
Fix for issue 394.

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -43,12 +43,12 @@ $SCRIPTPATH/cpp/roaring64map.hh
 "
 
 # internal .h files => These are used in the implementation but aren't part of
-# the API.  They're all embedded at the head of the amalgamated C file, and
+# the API.  They are all embedded at the head of the amalgamated C file, and
 # need to be in this order.
 #
 ALL_PRIVATE_H="
-$SCRIPTPATH/include/roaring/isadetection.h
 $SCRIPTPATH/include/roaring/portability.h
+$SCRIPTPATH/include/roaring/isadetection.h
 $SCRIPTPATH/include/roaring/containers/perfparameters.h
 $SCRIPTPATH/include/roaring/containers/container_defs.h
 $SCRIPTPATH/include/roaring/array_util.h

--- a/include/roaring/isadetection.h
+++ b/include/roaring/isadetection.h
@@ -46,9 +46,15 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef ROARING_ISADETECTION_H
 #define ROARING_ISADETECTION_H
 
+// isadetection.h does not define any macro (except for ROARING_ISADETECTION_H).
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
+
+// We need portability.h to be included first, see
+// https://github.com/RoaringBitmap/CRoaring/issues/394
+#include <roaring/portability.h>
 #if CROARING_REGULAR_VISUAL_STUDIO
 #include <intrin.h>
 #elif defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -46,7 +46,6 @@
 #define _XOPEN_SOURCE 700
 #endif // !(defined(_XOPEN_SOURCE)) || (_XOPEN_SOURCE < 700)
 
-#include "isadetection.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>  // will provide posix_memalign with _POSIX_C_SOURCE as defined above
@@ -327,4 +326,13 @@ static inline int hamming(uint64_t x) {
 #define CROARING_UNTARGET_REGION
 #endif
 
+
+// We need portability.h to be included first,
+// but we also always want isadetection.h to be
+// included (right after).
+// See https://github.com/RoaringBitmap/CRoaring/issues/394
+// There is no scenario where we want portability.h to
+// be included, but not isadetection.h: the latter is a
+// strict requirement.
+#include <roaring/isadetection.h> // include it last!
 #endif /* INCLUDE_PORTABILITY_H_ */


### PR DESCRIPTION
As remarked by @samhames in https://github.com/RoaringBitmap/CRoaring/issues/394, we want isadetection.h to be always included *after* portability.h, never the other way around. Sadly, the amalgamated script would do it in reverse which might cause issues when building under Windows while using the amalgamated script.