### PR TITLE
Improve add-type operations

### DIFF
--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -911,7 +911,7 @@ DEFINE_TEST(test_cpp_add_range_closed_combinatoric_64) {
     // 9. {3}
     // and so forth...
     //
-    // For example, in step 6 representing set {0, 2}) we set a bit somewhere
+    // For example, in step 6 (representing set {0, 2}) we set a bit somewhere
     // in slot 0 and we set another bit somehwere in slot 2. The purpose of this
     // is to make sure 'addRangeClosed' does the right thing when it encounters
     // an arbitrary mix of present and absent slots. Then we call

--- a/tests/roaring64map_checked.hh
+++ b/tests/roaring64map_checked.hh
@@ -116,9 +116,10 @@ class Roaring64Map {
         return ans;
     }
 
-    void addRange(const uint64_t x, const uint64_t y) {
-        if (x != y) {  // repeat add_range_closed() cast and bounding logic
-            addRangeClosed(x, y - 1);
+    void addRange(const uint64_t min, const uint64_t max) {
+        plain.addRange(min, max);
+        for (uint64_t val = min; val < max; ++val) {
+            check.insert(val);
         }
     }
 


### PR DESCRIPTION
1. Improve the efficiency of various "add"-style operations by reducing the number of duplicative outer map lookups.
2. Add a private helper method `lookupOrCreateInner` to reduce the number of repetitions of the `setCopyOnWrite` call.
3. Carefully document and rewrite `addRangeClosed` so it is clearer what is going on. Also, for the "middle section", where the method is creating completely full inner Roaring bitmaps, create one "the hard way" and then copy it if you need more. (Note: if there is some more efficient way to create a completely full 32 bit Roaring, please let me know)
4. Change `addMany(size_t, const uint64_t*)` to cache its last outer map lookup and perhaps save a few lookups if there is locality that can be exploited.
