### PR TITLE
Improve remove-type operations

### DIFF
--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -182,31 +182,61 @@ public:
     }
 
     /**
-     * Remove value x
+     * Removes value x.
      */
-    void remove(uint32_t x) { roarings[0].remove(x); }
-    void remove(uint64_t x) {
-        auto roaring_iter = roarings.find(highBytes(x));
-        if (roaring_iter != roarings.cend())
-            roaring_iter->second.remove(lowBytes(x));
+    void remove(uint32_t x) {
+        auto iter = roarings.begin();
+        // Since x is a uint32_t, highbytes(x) == 0. The inner bitmap we are
+        // looking for, if it exists, will be at the first slot of 'roarings'.
+        if (iter != roarings.end() && iter->first == 0) {
+            auto &bitmap = iter->second;
+            bitmap.remove(x);
+        }
     }
 
     /**
-     * Remove value x
-     * Returns true if a new value was removed, false if the value was not existing.
+     * Removes value x.
+     */
+    void remove(uint64_t x) {
+        auto iter = roarings.find(highBytes(x));
+        if (iter != roarings.end()) {
+            auto &bitmap = iter->second;
+            bitmap.remove(lowBytes(x));
+        }
+    }
+
+    /**
+     * Removes value x
+     * Returns true if a new value was removed, false if the value was not
+     * present.
      */
     bool removeChecked(uint32_t x) {
-        return roarings[0].removeChecked(x);
-    }
-    bool removeChecked(uint64_t x) {
-        auto roaring_iter = roarings.find(highBytes(x));
-        if (roaring_iter != roarings.cend())
-            return roaring_iter->second.removeChecked(lowBytes(x));
+        auto iter = roarings.begin();
+        // Since x is a uint32_t, highbytes(x) == 0. The inner bitmap we are
+        // looking for, if it exists, will be at the first slot of 'roarings'.
+        if (iter != roarings.end() && iter->first == 0) {
+            auto &bitmap = iter->second;
+            return bitmap.removeChecked(x);
+        }
         return false;
     }
 
     /**
-     * Remove all values in range [min, max)
+     * Remove value x
+     * Returns true if a new value was removed, false if the value was not
+     * present.
+     */
+    bool removeChecked(uint64_t x) {
+        auto iter = roarings.find(highBytes(x));
+        if (iter != roarings.end()) {
+            auto &bitmap = iter->second;
+            return bitmap.removeChecked(lowBytes(x));
+        }
+        return false;
+    }
+
+    /**
+     * Removes all values in the half-open interval [min, max).
      */
     void removeRange(uint64_t min, uint64_t max) {
         if (min >= max) {
@@ -216,11 +246,22 @@ public:
     }
 
     /**
-     * Remove all values in range [min, max]
+     * Removes all values in the closed interval [min, max].
      */
     void removeRangeClosed(uint32_t min, uint32_t max) {
-        return roarings[0].removeRangeClosed(min, max);
+        auto iter = roarings.begin();
+        // Since min and max are uint32_t, highbytes(min or max) == 0. The inner
+        // bitmap we are looking for, if it exists, will be at the first slot of
+        // 'roarings'.
+        if (iter != roarings.end() && iter->first == 0) {
+            auto &bitmap = iter->second;
+            bitmap.removeRangeClosed(min, max);
+        }
     }
+
+    /**
+     * Removes all values in the closed interval [min, max].
+     */
     void removeRangeClosed(uint64_t min, uint64_t max) {
         if (min > max) {
             return;
@@ -230,35 +271,70 @@ public:
         uint32_t end_high = highBytes(max);
         uint32_t end_low = lowBytes(max);
 
+        // We put std::numeric_limits<>::max in parentheses to avoid a
+        // clash with the Windows.h header under Windows.
+        const uint32_t maxUint32 = (std::numeric_limits<uint32_t>::max)();
+
+        // If the outer map is empty, end_high is less than the first key,
+        // or start_high is greater than the last key, then exit now because
+        // there is no work to do.
         if (roarings.empty() || end_high < roarings.cbegin()->first ||
             start_high > (roarings.crbegin())->first) {
             return;
         }
 
+        // If we get here, start_iter points to the first entry in the outer map
+        // with key >= start_high. Such an entry is known to exist (i.e. the
+        // iterator will not be equal to end()) because start_high <= the last
+        // key in the map (thanks to the above if statement).
         auto start_iter = roarings.lower_bound(start_high);
+        // end_iter points to the first entry in the outer map with
+        // key >= end_high, if such a key exists. Otherwise, it equals end().
         auto end_iter = roarings.lower_bound(end_high);
+
+        // Note that the 'lower_bound' method will find the start and end slots,
+        // if they exist; otherwise it will find the next-higher slots.
+        // In the case where 'start' landed on an existing slot, we need to do a
+        // partial erase of that slot, and likewise for 'end'. But all the slots
+        // in between can be fully erased. More precisely:
+        //
+        // 1. If the start point falls on an existing entry, there are two
+        //    subcases:
+        //    a. if the end point falls on that same entry, remove the closed
+        //       interval [start_low, end_low] from that entry and we are done.
+        //    b. Otherwise, remove the closed range [start_low, maxUint32] from
+        //       that entry, advance start_iter, and fall through to step 2.
+        // 2. Completely erase all slots in the half-open interval
+        //    [start_iter, end_iter)
+        // 3. If the end point falls on an existing entry, remove the closed
+        //    interval [0, end_high] from it.
+
+        // Step 1. If the start point falls on an existing entry...
         if (start_iter->first == start_high) {
+            auto &start_inner = start_iter->second;
+            // 1a. if the end point falls on that same entry...
             if (start_iter == end_iter) {
-                start_iter->second.removeRangeClosed(start_low, end_low);
+                start_inner.removeRangeClosed(start_low, end_low);
                 return;
             }
-            // we put std::numeric_limits<>::max/min in parenthesis
-            // to avoid a clash with the Windows.h header under Windows
-            start_iter->second.removeRangeClosed(
-                start_low, (std::numeric_limits<uint32_t>::max)());
-            start_iter++;
+
+            // 1b. Otherwise, remove the closed range [start_low, maxUint32]...
+            start_inner.removeRangeClosed(start_low, maxUint32);
+            ++start_iter;
         }
 
+        // 2. Completely erase all slots in the half-open interval...
         roarings.erase(start_iter, end_iter);
 
-        if (end_iter != roarings.cend() && end_iter->first == end_high) {
-            end_iter->second.removeRangeClosed(
-                (std::numeric_limits<uint32_t>::min)(), end_low);
+        // 3. If the end point falls on an existing entry...
+        if (end_iter != roarings.end() && end_iter->first == end_high) {
+            auto &end_inner = end_iter->second;
+            end_inner.removeRangeClosed(0, end_low);
         }
     }
 
     /**
-     * Clear the bitmap
+     * Clears the bitmap.
      */
     void clear() {
         roarings.clear();
@@ -1259,7 +1335,7 @@ class Roaring64MapSetBitForwardIterator {
 public:
     typedef std::forward_iterator_tag iterator_category;
     typedef uint64_t *pointer;
-    typedef uint64_t &reference_type;
+    typedef uint64_t &reference;
     typedef uint64_t value_type;
     typedef int64_t difference_type;
     typedef Roaring64MapSetBitForwardIterator type_of_iterator;

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -900,18 +900,18 @@ DEFINE_TEST(test_cpp_remove_range_64) {
     Roaring64Map r1;
     auto b5 = uint64_t(5) << 32;
 
-    auto maxUint64 = std::numeric_limits<uint64_t>::max();
+    auto uint64_max = std::numeric_limits<uint64_t>::max();
 
     r1.add(0u);  // 32-bit add
     r1.add(b5 + 1000);  // arbitrary 64 bit add
     r1.add(b5 + 1001);  // arbitrary 64 bit add
-    r1.add(maxUint64 - 1000);
-    r1.add(maxUint64);  // highest possible bit
+    r1.add(uint64_max - 1000);
+    r1.add(uint64_max);  // highest possible bit
 
     // Half-open interval: result should be the set {0, maxUint64}
-    r1.removeRange(1, maxUint64);
+    r1.removeRange(1, uint64_max);
 
-    Roaring64Map r2 = Roaring64Map::bitmapOf(2, uint64_t(0), maxUint64);
+    Roaring64Map r2 = Roaring64Map::bitmapOf(2, uint64_t(0), uint64_max);
     assert_true(r1 == r2);
 }
 

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <algorithm>
 #include <random>
 #include <vector>
 
@@ -227,6 +228,67 @@ void test_roaring64_iterate_multi_roaring(void) {
     };
     roaring.iterate(iterate_func, &iterate_count);
     assert_true(iterate_count == 2);
+}
+
+namespace {
+bool roaringEqual(const Roaring64Map &actual,
+                  std::initializer_list<uint64_t> expected) {
+    return expected.size() == actual.cardinality() &&
+           std::equal(expected.begin(), expected.end(), actual.begin());
+}
+}  // namespace
+
+DEFINE_TEST(test_roaring64_remove_32) {
+    Roaring64Map roaring;
+
+    // A specific test to make sure we don't get slots confused.
+    // Specifically, we make Roaring64Map with only one slot (namely slot 5)
+    // with values {100, 200, 300} in its inner bitmap. Then we do a 32-bit
+    // remove of 100 from slot 0. A correct implementation of 'remove' would
+    // be a no-op.
+    const uint64_t b5 = uint64_t(5) << 32;
+    Roaring64Map r;
+    r.add(b5 + 100);
+    r.add(b5 + 200);
+    r.add(b5 + 300);
+    r.remove(uint32_t(100));
+
+    // No change
+    assert_true(roaringEqual(r, {b5 + 100, b5 + 200, b5 + 300}));
+}
+
+DEFINE_TEST(test_roaring64_add_and_remove) {
+    Roaring64Map r;
+
+    const uint64_t b5 = uint64_t(5) << 32;
+
+    // 32-bit adds
+    r.add(300u);
+    r.add(200u);
+    r.add(100u);
+    assert_true(roaringEqual(r, {100, 200, 300}));
+
+    // 64-bit adds
+    r.add(uint64_t(200));  // Duplicate
+    r.add(uint64_t(400));  // New
+    r.add(b5 + 400);  // All new
+    r.add(b5 + 300);
+    r.add(b5 + 200);
+    r.add(b5 + 100);
+    assert_true(roaringEqual(r,
+        {100, 200, 300, 400, b5 + 100, b5 + 200, b5 + 300, b5 + 400}));
+
+    // 32-bit removes
+    r.remove(200u);  // Exists.
+    r.remove(500u);  // Doesn't exist
+    assert_true(roaringEqual(r,
+        {100, 300, 400, b5 + 100, b5 + 200, b5 + 300, b5 + 400}));
+
+    // 64-bit removes
+    r.remove(b5 + 100);  // Exists.
+    r.remove(b5 + 500);  // Doesn't exist
+    assert_true(roaringEqual(r,
+        {100, 300, 400, b5 + 200, b5 + 300, b5 + 400}));
 }
 
 DEFINE_TEST(test_roaring64_iterate_multi_roaring) {
@@ -736,7 +798,7 @@ DEFINE_TEST(test_cpp_add_range_64) {
     }
 }
 
-DEFINE_TEST(test_cpp_remove_range_64) {
+DEFINE_TEST(test_cpp_remove_range_closed_64) {
     {
         // 32-bit integers
         Roaring64Map r1 =
@@ -829,6 +891,28 @@ DEFINE_TEST(test_cpp_remove_range_64) {
             3, uint64_t(1) << 32, uint64_t(2) << 32, uint64_t(4) << 32);
         assert_true(r1 == r2);
     }
+}
+
+DEFINE_TEST(test_cpp_remove_range_64) {
+    // Because removeRange delegates to removeRangeClosed, we do most of the
+    // unit testing in test_cpp_remove_range_closed_64(). We just do a couple of
+    // sanity checks here.
+    Roaring64Map r1;
+    auto b5 = uint64_t(5) << 32;
+
+    auto maxUint64 = std::numeric_limits<uint64_t>::max();
+
+    r1.add(0u);  // 32-bit add
+    r1.add(b5 + 1000);  // arbitrary 64 bit add
+    r1.add(b5 + 1001);  // arbitrary 64 bit add
+    r1.add(maxUint64 - 1000);
+    r1.add(maxUint64);  // highest possible bit
+
+    // Half-open interval: result should be the set {0, maxUint64}
+    r1.removeRange(1, maxUint64);
+
+    Roaring64Map r2 = Roaring64Map::bitmapOf(2, uint64_t(0), maxUint64);
+    assert_true(r1 == r2);
 }
 
 std::pair<doublechecked::Roaring64Map, doublechecked::Roaring64Map>
@@ -1307,6 +1391,7 @@ int main() {
         cmocka_unit_test(test_cpp_add_range),
         cmocka_unit_test(test_cpp_remove_range),
         cmocka_unit_test(test_cpp_add_range_64),
+        cmocka_unit_test(test_cpp_remove_range_closed_64),
         cmocka_unit_test(test_cpp_remove_range_64),
         cmocka_unit_test(test_run_compression_cpp_64_true),
         cmocka_unit_test(test_run_compression_cpp_64_false),
@@ -1319,6 +1404,8 @@ int main() {
         cmocka_unit_test(test_cpp_clear_64),
         cmocka_unit_test(test_cpp_move_64),
         cmocka_unit_test(test_roaring64_iterate_multi_roaring),
+        cmocka_unit_test(test_roaring64_remove_32),
+        cmocka_unit_test(test_roaring64_add_and_remove),
         cmocka_unit_test(test_cpp_bidirectional_iterator_64),
         cmocka_unit_test(test_cpp_frozen),
         cmocka_unit_test(test_cpp_frozen_64),

--- a/tests/roaring64map_checked.hh
+++ b/tests/roaring64map_checked.hh
@@ -172,22 +172,39 @@ class Roaring64Map {
         return ans;
     }
 
-    void removeRange(const uint64_t x, const uint64_t y) {
-        if (x != y) {  // repeat remove_range_closed() cast and bounding logic
-            removeRangeClosed(x, y - 1);
+    void removeRange(const uint64_t min, const uint64_t max) {
+        plain.removeRange(min, max);
+        if (min < max) {
+            // Points to the first entry with key >= min, or end
+            auto start = check.lower_bound(min);
+            // Points to the first entry with key >= max, or end.
+            auto end = check.lower_bound(max);
+            // Removes the half-open interval [start, end) (i.e. does not include max).
+            check.erase(start, end);
         }
     }
 
     void removeRangeClosed(uint32_t min, uint32_t max) {
         plain.removeRangeClosed(min, max);
         if (min <= max) {
-            check.erase(check.lower_bound(min), check.upper_bound(max));
+            // Points to the first entry with key >= min, or end
+            auto start = check.lower_bound(min);
+            // Points to the first entry with key > max, or end.
+            auto end = check.upper_bound(max);
+            // Removes the half-open interval [start, end) (i.e. includes max).
+            check.erase(start, end);
         }
     }
+
     void removeRangeClosed(uint64_t min, uint64_t max) {
         plain.removeRangeClosed(min, max);
         if (min <= max) {
-            check.erase(check.lower_bound(min), check.upper_bound(max));
+            // Points to the first entry with key >= min, or end
+            auto start = check.lower_bound(min);
+            // Points to the first entry with key > max, or end.
+            auto end = check.upper_bound(max);
+            // Removes the half-open interval [start, end) (i.e. includes max).
+            check.erase(start, end);
         }
     }
 


### PR DESCRIPTION
Improve various "remove"-style operations. The majority of the changes here are adding comments, introducing temporary variables, and adding unit tests. Highlights:

The code in `remove(uint32_t)` and `removeChecked(uint32_t)` had a subtle bug (and was also slightly inefficient). The code for `remove(uint32_t)` was

```
void remove(uint32_t x) { roarings[0].remove(x); }
```
If slot 0 is present, this does the right thing. But if slot 0 is absent, this creates an empty inner bitmap and removes `x` from it, which is a no-op. This is fine so far as it goes, aside from the needless work of making an empty bitmap and leaving it lying around. The problem is that the empty bitmap left behind in slot 0 does not have its copyOnWrite flag set. Normally the code is careful to set this bit appropriately whenever it creates new inner bitmaps but it failed to do so here.

Als the iterator traits on `Roaring64MapSetBitForwardIterator` were wrong. The correct name for reference is `reference`, not `reference_type`. This matters for library functions that want to interrogate the iterator for its capabilities. (In my case `std::equal` would not compile until I made the change).  See e.g. https://en.cppreference.com/w/cpp/iterator/iterator_traits 

Also modified `doublechecked::Roaring64Map::removeRange` to directly call the underlying `plain.removeRange()` rather than `plain.removeRangeClosed()`. In my opinion it's a little cleaner to exactly call the underlying method being shadowed and not a similar method with adjusted arguments.
