### PR TITLE
Use ISO 8601 UTC dates as amalgamation timestamps

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -5,7 +5,7 @@
 ########################################################################
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-timestamp=$(date)  # capture to label files with their generation time
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")  # capture to label files with their generation time
 
 function newline {
     echo ""


### PR DESCRIPTION
At the moment, amalgamation generation date is locale-dependent and can't be reliably parsed by external tools.

0.7.2
// Created by amalgamation.sh on Ven  4 nov 2022 11:02:44 EDT

0.6.0
// Created by amalgamation.sh on Wed 20 Jul 2022 16:25:25 EDT


I suggest using ISO 8601 UTC dates instead as an internationally understood universal format

`date -u +"%Y-%m-%dT%H:%M:%SZ"`
// Created by amalgamation.sh on 2022-11-08T08:02:56Z
