### PR TITLE
Update flip-type operations of Roaring64Map

### DIFF
--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -99,7 +99,7 @@ public:
     }
 
     /**
-     * Construct a bitmap from a list of integer values.
+     * Construct a bitmap from a list of uint32_t values.
      */
     static Roaring bitmapOf(size_t n, ...) {
         Roaring ans;

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -345,12 +345,20 @@ public:
     }
 
     /**
-     * Compute the negation of the roaring bitmap within a specified interval.
-     * interval: [range_start, range_end).
-     * Areas outside the range are passed through unchanged.
+     * Compute the negation of the roaring bitmap within the half-open interval
+     * [range_start, range_end). Areas outside the interval are unchanged.
      */
     void flip(uint64_t range_start, uint64_t range_end) {
         api::roaring_bitmap_flip_inplace(&roaring, range_start, range_end);
+    }
+
+    /**
+     * Compute the negation of the roaring bitmap within the closed interval
+     * [range_start, range_end]. Areas outside the interval are unchanged.
+     */
+    void flipClosed(uint32_t range_start, uint32_t range_end) {
+        api::roaring_bitmap_flip_inplace(
+            &roaring, range_start, uint64_t(range_end) + 1);
     }
 
     /**

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -794,39 +794,128 @@ public:
     }
 
     /**
-     * Compute the negation of the roaring bitmap within a specified interval.
-     * areas outside the range are passed through unchanged.
+     * Computes the negation of the roaring bitmap within the half-open interval
+     * [min, max). Areas outside the interval are unchanged.
      */
-    void flip(uint64_t range_start, uint64_t range_end) {
-        if (range_start >= range_end) {
-          return;
-        }
-        uint32_t start_high = highBytes(range_start);
-        uint32_t start_low = lowBytes(range_start);
-        uint32_t end_high = highBytes(range_end);
-        uint32_t end_low = lowBytes(range_end);
-
-        if (start_high == end_high) {
-            roarings[start_high].flip(start_low, end_low);
+    void flip(uint64_t min, uint64_t max) {
+        if (min >= max) {
             return;
         }
-        // we put std::numeric_limits<>::max/min in parentheses
-        // to avoid a clash with the Windows.h header under Windows
-        // flip operates on the range [lower_bound, upper_bound)
-        const uint64_t max_upper_bound =
-            static_cast<uint64_t>((std::numeric_limits<uint32_t>::max)()) + 1;
-        roarings[start_high].flip(start_low, max_upper_bound);
-        roarings[start_high++].setCopyOnWrite(copyOnWrite);
+        flipClosed(min, max - 1);
+    }
 
-        for (; start_high <= highBytes(range_end) - 1; ++start_high) {
-            roarings[start_high].flip((std::numeric_limits<uint32_t>::min)(),
-                                      max_upper_bound);
-            roarings[start_high].setCopyOnWrite(copyOnWrite);
+    /**
+     * Computes the negation of the roaring bitmap within the closed interval
+     * [min, max]. Areas outside the interval are unchanged.
+     */
+    void flipClosed(uint32_t min, uint32_t max) {
+        auto iter = roarings.begin();
+        // Since min and max are uint32_t, highbytes(min or max) == 0. The inner
+        // bitmap we are looking for, if it exists, will be at the first slot of
+        // 'roarings'.
+        if (iter == roarings.end() || iter->first != 0) {
+            return;
+        }
+        auto &bitmap = iter->second;
+        bitmap.flipClosed(min, max);
+        eraseIfEmpty(iter);
+    }
+
+    /**
+     * Computes the negation of the roaring bitmap within the closed interval
+     * [min, max]. Areas outside the interval are unchanged.
+     */
+    void flipClosed(uint64_t min, uint64_t max) {
+        if (min > max) {
+          return;
+        }
+        uint32_t start_high = highBytes(min);
+        uint32_t start_low = lowBytes(min);
+        uint32_t end_high = highBytes(max);
+        uint32_t end_low = lowBytes(max);
+
+        // We put std::numeric_limits<>::max in parentheses to avoid a
+        // clash with the Windows.h header under Windows.
+        const uint32_t uint32_max = (std::numeric_limits<uint32_t>::max)();
+
+        // next_populated_iter points to the first entry in the outer map with
+        // key >= start_high, or end().
+        auto next_populated_iter = roarings.lower_bound(start_high);
+
+        // To simplify later logic, first ensure that every slot in the closed
+        // interval [start_high, end_high] is populated. Use uint64_t to avoid
+        // an infinite loop when end_high == uint32_max.
+        roarings_t::iterator start_iter{};  // Definitely assigned in loop.
+        for (uint64_t slot = start_high; slot <= end_high; ++slot) {
+            roarings_t::iterator slot_iter;
+            if (next_populated_iter != roarings.end() &&
+                next_populated_iter->first == slot) {
+                // 'slot' index has caught up to next_populated_iter.
+                // Note it here and advance next_populated_iter.
+                slot_iter = next_populated_iter++;
+            } else {
+                // 'slot' index has not yet caught up to next_populated_iter.
+                // Make a fresh entry {key = 'slot', value = Roaring()}, insert
+                // it just prior to next_populated_iter, and set its copy
+                // on write flag. We take pains to use emplace_hint and
+                // piecewise_construct to minimize effort.
+                slot_iter = roarings.emplace_hint(
+                    next_populated_iter,
+                    std::piecewise_construct,
+                    std::forward_as_tuple(uint32_t(slot)),
+                    std::forward_as_tuple());
+                auto &bitmap = slot_iter->second;
+                bitmap.setCopyOnWrite(copyOnWrite);
+            }
+
+            // Make a note of the iterator of the starting slot. It will be
+            // needed for the second pass.
+            if (slot == start_high) {
+                start_iter = slot_iter;
+            }
         }
 
-        roarings[start_high].flip((std::numeric_limits<uint32_t>::min)(),
-                                  end_low);
-        roarings[start_high].setCopyOnWrite(copyOnWrite);
+        // Note: start_iter is definitely assigned at this point.
+
+        // If start and end land on the same inner bitmap, then we can do the
+        // whole operation in one call.
+        if (start_high == end_high) {
+            auto &bitmap = start_iter->second;
+            bitmap.flipClosed(start_low, end_low);
+            eraseIfEmpty(start_iter);
+            return;
+        }
+
+        // Because start and end don't land on the same inner bitmap,
+        // we need to do this in multiple steps:
+        // 1. Partially flip the first bitmap in the closed interval
+        //    [start_low, maxUint32]
+        // 2. Flip intermediate bitmaps completely: [0, maxUint32]
+        // 3. Partially flip the last bitmap in the closed interval
+        //    [0, end_low]
+
+        auto num_intermediate_bitmaps = end_high - start_high - 1;
+
+        // 1. Partially flip the first bitmap...
+        {
+            auto &bitmap = start_iter->second;
+            bitmap.flipClosed(start_low, uint32_max);
+            auto temp = start_iter++;
+            eraseIfEmpty(temp);
+        }
+
+        // 2. Flip intermediate bitmaps completely...
+        for (uint32_t i = 0; i != num_intermediate_bitmaps; ++i) {
+            auto &bitmap = start_iter->second;
+            bitmap.flipClosed(0, uint32_max);
+            auto temp = start_iter++;
+            eraseIfEmpty(temp);
+        }
+
+        // 3. Partially flip the last bitmap...
+        auto &bitmap = start_iter->second;
+        bitmap.flipClosed(0, end_low);
+        eraseIfEmpty(start_iter);
     }
 
     /**

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -838,44 +838,7 @@ public:
         // clash with the Windows.h header under Windows.
         const uint32_t uint32_max = (std::numeric_limits<uint32_t>::max)();
 
-        // next_populated_iter points to the first entry in the outer map with
-        // key >= start_high, or end().
-        auto next_populated_iter = roarings.lower_bound(start_high);
-
-        // To simplify later logic, first ensure that every slot in the closed
-        // interval [start_high, end_high] is populated. Use uint64_t to avoid
-        // an infinite loop when end_high == uint32_max.
-        roarings_t::iterator start_iter{};  // Definitely assigned in loop.
-        for (uint64_t slot = start_high; slot <= end_high; ++slot) {
-            roarings_t::iterator slot_iter;
-            if (next_populated_iter != roarings.end() &&
-                next_populated_iter->first == slot) {
-                // 'slot' index has caught up to next_populated_iter.
-                // Note it here and advance next_populated_iter.
-                slot_iter = next_populated_iter++;
-            } else {
-                // 'slot' index has not yet caught up to next_populated_iter.
-                // Make a fresh entry {key = 'slot', value = Roaring()}, insert
-                // it just prior to next_populated_iter, and set its copy
-                // on write flag. We take pains to use emplace_hint and
-                // piecewise_construct to minimize effort.
-                slot_iter = roarings.emplace_hint(
-                    next_populated_iter,
-                    std::piecewise_construct,
-                    std::forward_as_tuple(uint32_t(slot)),
-                    std::forward_as_tuple());
-                auto &bitmap = slot_iter->second;
-                bitmap.setCopyOnWrite(copyOnWrite);
-            }
-
-            // Make a note of the iterator of the starting slot. It will be
-            // needed for the second pass.
-            if (slot == start_high) {
-                start_iter = slot_iter;
-            }
-        }
-
-        // Note: start_iter is definitely assigned at this point.
+        auto start_iter = ensureRangePopulated(start_high, end_high);
 
         // If start and end land on the same inner bitmap, then we can do the
         // whole operation in one call.
@@ -1411,6 +1374,53 @@ private:
         if (bitmap.isEmpty()) {
             roarings.erase(iter);
         }
+    }
+
+    /**
+     * Ensure that every key in the closed interval [start_high, end_high]
+     * refers to a Roaring bitmap rather being an empty slot. Inserts empty
+     * Roaring bitmaps if necessary. The interval must be valid and non-empty.
+     * Returns an iterator to the bitmap at start_high.
+     */
+    roarings_t::iterator ensureRangePopulated(uint32_t start_high,
+                                              uint32_t end_high) {
+        if (start_high > end_high) {
+            ROARING_TERMINATE("Logic error: start_high > end_high");
+        }
+        // next_populated_iter points to the first entry in the outer map with
+        // key >= start_high, or end().
+        auto next_populated_iter = roarings.lower_bound(start_high);
+
+        // Use uint64_t to avoid an infinite loop when end_high == uint32_max.
+        roarings_t::iterator start_iter{};  // Definitely assigned in loop.
+        for (uint64_t slot = start_high; slot <= end_high; ++slot) {
+            roarings_t::iterator slot_iter;
+            if (next_populated_iter != roarings.end() &&
+                next_populated_iter->first == slot) {
+                // 'slot' index has caught up to next_populated_iter.
+                // Note it here and advance next_populated_iter.
+                slot_iter = next_populated_iter++;
+            } else {
+                // 'slot' index has not yet caught up to next_populated_iter.
+                // Make a fresh entry {key = 'slot', value = Roaring()}, insert
+                // it just prior to next_populated_iter, and set its copy
+                // on write flag. We take pains to use emplace_hint and
+                // piecewise_construct to minimize effort.
+                slot_iter = roarings.emplace_hint(
+                    next_populated_iter, std::piecewise_construct,
+                    std::forward_as_tuple(uint32_t(slot)),
+                    std::forward_as_tuple());
+                auto &bitmap = slot_iter->second;
+                bitmap.setCopyOnWrite(copyOnWrite);
+            }
+
+            // Make a note of the iterator of the starting slot. It will be
+            // needed for the second pass.
+            if (slot == start_high) {
+                start_iter = slot_iter;
+            }
+        }
+        return start_iter;
     }
 };
 

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -801,6 +801,15 @@ public:
         if (min >= max) {
             return;
         }
+        if (max <= (uint64_t(1) << 32)) {
+            // If the interval falls completely within the first 2^32 values,
+            // delegate to the 32-bit version of flipClosed(), which is slightly
+            // faster.
+            flipClosed(uint32_t(min), uint32_t(max - 1));
+            return;
+        }
+        // Otherwise (if the interval does not fall completely within the
+        // first 2^32 values), delegate to the 64-bit version of flipClosed().
         flipClosed(min, max - 1);
     }
 

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -1415,7 +1415,7 @@ private:
             }
 
             // Make a note of the iterator of the starting slot. It will be
-            // needed for the second pass.
+            // needed for the return value.
             if (slot == start_high) {
                 start_iter = slot_iter;
             }

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -818,7 +818,7 @@ public:
                                          std::forward_as_tuple(0),
                                          std::forward_as_tuple());
             auto &bitmap = iter->second;
-            bitmap.setCopyOnWrite(true);
+            bitmap.setCopyOnWrite(copyOnWrite);
         }
         auto &bitmap = iter->second;
         bitmap.flipClosed(min, max);

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -801,15 +801,6 @@ public:
         if (min >= max) {
             return;
         }
-        if (max <= (uint64_t(1) << 32)) {
-            // If the interval falls completely within the first 2^32 values,
-            // delegate to the 32-bit version of flipClosed(), which is slightly
-            // faster.
-            flipClosed(uint32_t(min), uint32_t(max - 1));
-            return;
-        }
-        // Otherwise (if the interval does not fall completely within the
-        // first 2^32 values), delegate to the 64-bit version of flipClosed().
         flipClosed(min, max - 1);
     }
 


### PR DESCRIPTION
Executive summary:
1. Provided extra entry points for `flip` on both the 32-bit and 64-bit side to make it uniform with `addRange` and `removeRange`
2. Inspired by an idea from @Dr-Emann in https://github.com/RoaringBitmap/CRoaring/pull/397 , used `emplace_hint` to minimize map lookups. The resultant code does only *one* lookup for the whole operation; everything else is just linear iteration through the specified map range, which is cool.
3. Also `flip()` does the same "remove bitmaps if they become empty" logic that the other operations do now.
4. Added unit tests

I like how this one turned out. Kindly let me know what you think.

Some rationale on adding the entry points:

First, provides API uniformity for the end-user, which is always nice.

Second, provides uniformity for the code reader. The style of all of these is to have a couple of "easy" methods and then a longer one that does all the work. But here, the workhorse methods are  `addRangeClosed(uint64_t, uint64_t)` and `removeRangeClosed(uint64_t uint64_t)` which work with closed intervals, but then we have `flip(uint64_t, uint64_t)` working with half-open intervals. When the convention changes like that, it's a little harder to analyze.

Also, `flip()` had a couple of logic errors:
1. Missed a 'setCopyOnWrite' case when `start_high == end_high`
2. When given a half-open interval right at the end of a bitmap, e.g. [0xFFFFFFFF, 0x100000000), the code *should* see this as falling into a single inner Roaring but it doesn't. This is a (micro) performance problem, not a correctness problem.

I feel rewriting `flip()` in a style coherent with all the others hopefully makes it easier to understand and use. Kindly let me know what you think.