### PR TITLE
add support for initializer list

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,11 @@ int main() {
     r2.printf();
     printf("\n");
 
+    // create a new bitmap with initializer list
+    Roaring r2i = Roaring::bitmapOf({1, 2, 3, 5, 6});
+
+    assert(r2i == r2);
+
     // we can also create a bitmap from a pointer to 32-bit integers
     const uint32_t values[] = {2, 3, 4};
     Roaring r3(3, values);

--- a/README.md
+++ b/README.md
@@ -377,6 +377,11 @@ int main() {
 
     assert(r2i == r2);
 
+    // create a new bitmap directly from initializer list
+    Roaring r2id = {1, 2, 3, 5, 6};
+
+    assert(r2id == r2);
+
     // we can also create a bitmap from a pointer to 32-bit integers
     const uint32_t values[] = {2, 3, 4};
     Roaring r3(3, values);

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ int main() {
     printf("\n");
 
     // create a new bitmap with initializer list
-    Roaring r2i = Roaring::bitmapOf({1, 2, 3, 5, 6});
+    Roaring r2i = Roaring::bitmapOfList({1, 2, 3, 5, 6});
 
     assert(r2i == r2);
 

--- a/README.md
+++ b/README.md
@@ -377,11 +377,6 @@ int main() {
 
     assert(r2i == r2);
 
-    // create a new bitmap directly from initializer list
-    Roaring r2id = {1, 2, 3, 5, 6};
-
-    assert(r2id == r2);
-
     // we can also create a bitmap from a pointer to 32-bit integers
     const uint32_t values[] = {2, 3, 4};
     Roaring r3(3, values);

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -7,6 +7,7 @@ A C++ header for Roaring Bitmaps.
 #include <cstdarg>
 
 #include <algorithm>
+#include <initializer_list>
 #include <new>
 #include <stdexcept>
 #include <string>

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -113,6 +113,18 @@ public:
     }
 
     /**
+     * Construct a bitmap from a list of uint32_t values.
+     * E.g., bitmapOf({1,2,3}).
+     */
+    static Roaring bitmapOf(std::initializer_list<uint32_t> l) {
+        Roaring ans;
+        for(uint32_t x : l) {
+            ans.add(x);
+        }
+        return ans;
+    }
+
+    /**
      * Add value x
      */
     void add(uint32_t x) { api::roaring_bitmap_add(&roaring, x); }

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -125,7 +125,7 @@ public:
      * Construct a bitmap from a list of uint32_t values.
      * E.g., bitmapOf({1,2,3}).
      */
-    static Roaring bitmapOf(std::initializer_list<uint32_t> l) {
+    static Roaring bitmapOfList(std::initializer_list<uint32_t> l) {
         Roaring ans;
         for(uint32_t x : l) {
             ans.add(x);

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -62,6 +62,15 @@ public:
     }
 
     /**
+     * Construct a bitmap from an initializer list.
+     */
+    Roaring(std::initializer_list<uint32_t> l) : Roaring() {
+        for(uint32_t x : l) {
+            add(x);
+        }
+    }
+
+    /**
      * Copy constructor
      */
     Roaring(const Roaring &r) : Roaring() {

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -63,15 +63,6 @@ public:
     }
 
     /**
-     * Construct a bitmap from an initializer list.
-     */
-    Roaring(std::initializer_list<uint32_t> l) : Roaring() {
-        for(uint32_t x : l) {
-            add(x);
-        }
-    }
-
-    /**
      * Copy constructor
      */
     Roaring(const Roaring &r) : Roaring() {
@@ -128,9 +119,7 @@ public:
      */
     static Roaring bitmapOfList(std::initializer_list<uint32_t> l) {
         Roaring ans;
-        for(uint32_t x : l) {
-            ans.add(x);
-        }
+        ans.addMany(l.size(), l.begin());
         return ans;
     }
 

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -115,7 +115,7 @@ public:
 
     /**
      * Construct a bitmap from a list of uint32_t values.
-     * E.g., bitmapOf({1,2,3}).
+     * E.g., bitmapOfList({1,2,3}).
      */
     static Roaring bitmapOfList(std::initializer_list<uint32_t> l) {
         Roaring ans;

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -53,14 +53,6 @@ public:
     Roaring64Map(size_t n, const uint64_t *data) { addMany(n, data); }
 
     /**
-     * Construct a bitmap from an initializer list.
-     */
-    Roaring64Map(std::initializer_list<uint64_t> l)  {
-        for(uint64_t x : l) {
-            add(x);
-        }
-    }
-    /**
      * Construct a 64-bit map from a 32-bit one
      */
     explicit Roaring64Map(const Roaring &r) { emplaceOrInsert(0, r); }
@@ -113,9 +105,7 @@ public:
      */
     static Roaring64Map bitmapOfList(std::initializer_list<uint64_t> l) {
         Roaring64Map ans;
-        for(uint64_t x : l) {
-            ans.add(x);
-        }
+        ans.addMany(l.size(), l.begin());
         return ans;
     }
     /**

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -99,6 +99,17 @@ public:
     }
 
     /**
+     * Construct a bitmap from a list of uint64_t values.
+     * E.g., bitmapOf({1,2,3}).
+     */
+    static Roaring64Map bitmapOf(std::initializer_list<uint64_t> l) {
+        Roaring64Map ans;
+        for(uint32_t x : l) {
+            ans.add(x);
+        }
+        return ans;
+    }
+    /**
      * Add value x
      */
     void add(uint32_t x) {

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -52,6 +52,14 @@ public:
     Roaring64Map(size_t n, const uint64_t *data) { addMany(n, data); }
 
     /**
+     * Construct a bitmap from an initializer list.
+     */
+    Roaring64Map(std::initializer_list<uint64_t> l)  {
+        for(uint64_t x : l) {
+            add(x);
+        }
+    }
+    /**
      * Construct a 64-bit map from a 32-bit one
      */
     explicit Roaring64Map(const Roaring &r) { emplaceOrInsert(0, r); }
@@ -104,7 +112,7 @@ public:
      */
     static Roaring64Map bitmapOf(std::initializer_list<uint64_t> l) {
         Roaring64Map ans;
-        for(uint32_t x : l) {
+        for(uint64_t x : l) {
             ans.add(x);
         }
         return ans;

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -108,9 +108,9 @@ public:
 
     /**
      * Construct a bitmap from a list of uint64_t values.
-     * E.g., bitmapOf({1,2,3}).
+     * E.g., bitmapOfList({1,2,3}).
      */
-    static Roaring64Map bitmapOf(std::initializer_list<uint64_t> l) {
+    static Roaring64Map bitmapOfList(std::initializer_list<uint64_t> l) {
         Roaring64Map ans;
         for(uint64_t x : l) {
             ans.add(x);

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -15,6 +15,7 @@
 #include <cstdio>  // for std::printf() in the printf() method
 #include <cstring>  // for std::memcpy()
 #include <functional>
+#include <initializer_list>
 #include <limits>
 #include <map>
 #include <new>

--- a/tests/cpp_random_unit.cpp
+++ b/tests/cpp_random_unit.cpp
@@ -21,6 +21,7 @@
 //
 
 #include <assert.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -378,7 +379,7 @@ DEFINE_TEST(random_doublecheck_test_64) {
         const Roaring64Map &right = roars[rand() % NUM_ROARS];
 
 #ifdef ROARING_CPP_RANDOM_PRINT_STATUS
-        printf("[%lu]: %llu %llu %llu\n", step,
+        printf("[%lu]: %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", step,
                static_cast<unsigned long long>(left.cardinality()),
                static_cast<unsigned long long>(right.cardinality()),
                static_cast<unsigned long long>(out.cardinality()));
@@ -482,7 +483,7 @@ DEFINE_TEST(random_doublecheck_test_64) {
 int main() {
     uint64_t seed = time(nullptr);
     srand(seed);
-    printf("Seed: %llu\n", seed);
+    printf("Seed:  %" PRIu64 "\n", seed);
 
     gravity = rand() % 10000;  // starting focal point
 

--- a/tests/cpp_random_unit.cpp
+++ b/tests/cpp_random_unit.cpp
@@ -482,7 +482,7 @@ DEFINE_TEST(random_doublecheck_test_64) {
 int main() {
     uint64_t seed = time(nullptr);
     srand(seed);
-    printf("Seed: %lu\n", seed);
+    printf("Seed: %llu\n", seed);
 
     gravity = rand() % 10000;  // starting focal point
 

--- a/tests/cpp_random_unit.cpp
+++ b/tests/cpp_random_unit.cpp
@@ -20,12 +20,12 @@
 // https://www.llvm.org/docs/LibFuzzer.html
 //
 
-#include <assert.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+#include <cassert>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 
 #include <iostream>
 #include <type_traits>

--- a/tests/cpp_random_unit.cpp
+++ b/tests/cpp_random_unit.cpp
@@ -380,9 +380,9 @@ DEFINE_TEST(random_doublecheck_test_64) {
 
 #ifdef ROARING_CPP_RANDOM_PRINT_STATUS
         printf("[%lu]: %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", step,
-               static_cast<unsigned long long>(left.cardinality()),
-               static_cast<unsigned long long>(right.cardinality()),
-               static_cast<unsigned long long>(out.cardinality()));
+               left.cardinality(),
+               right.cardinality(),
+               out.cardinality());
 #endif
 
         int op = rand() % 6;

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -329,10 +329,7 @@ void test_example_cpp(bool copy_on_write) {
     Roaring r2i = Roaring::bitmapOfList({1, 2, 3, 5, 6});
 
     assert(r2i == r2);
-    // create a new bitmap directly from initializer list
-    Roaring r2id = {1, 2, 3, 5, 6};
 
-    assert(r2id == r2);
     // test select
     uint32_t element;
     r2.select(3, &element);
@@ -536,11 +533,6 @@ void test_example_cpp_64(bool copy_on_write) {
         Roaring64Map::bitmapOfList({1, 2, 234294967296, 195839473298,
                                14000000000000000100ull});
     assert(r2i == r2);
-
-    // create a new bitmap directly from initializer list
-    Roaring64Map r2id = {1, 2, 234294967296, 195839473298,
-                               14000000000000000100ull};
-    assert(r2id == r2);
 
     // test select
     uint64_t element;
@@ -816,21 +808,22 @@ DEFINE_TEST(test_cpp_add_range_64) {
 }
 DEFINE_TEST(test_bitmap_of_32) {
         Roaring r1 = Roaring::bitmapOfList({1,2,4});
+        r1.printf();
+        printf("\n");
         Roaring r2 =
             Roaring::bitmapOf(3, uint64_t(1), uint64_t(2), uint64_t(4));
+        r2.printf();
+        printf("\n");
         assert_true(r1 == r2);
-        Roaring r1d = {1,2,4};
-        assert_true(r1 == r1d);
 }
 
 DEFINE_TEST(test_bitmap_of_64) {
-        Roaring64Map r1 =
-            Roaring64Map::bitmapOfList({1,2,4});
+        Roaring64Map r1 = Roaring64Map::bitmapOfList({1,2,4});
+        r1.printf();
         Roaring64Map r2 =
             Roaring64Map::bitmapOf(3, uint64_t(1), uint64_t(2), uint64_t(4));
+        r2.printf();
         assert_true(r1 == r2);
-        Roaring64Map r1d = {1,2,4};
-        assert_true(r1 == r1d);
 }
 
 DEFINE_TEST(test_cpp_remove_range_closed_64) {

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -326,7 +326,7 @@ void test_example_cpp(bool copy_on_write) {
     r2.printf();
     printf("\n");
     // create a new bitmap with initializer list
-    Roaring r2i = Roaring::bitmapOf({1, 2, 3, 5, 6});
+    Roaring r2i = Roaring::bitmapOfList({1, 2, 3, 5, 6});
 
     assert(r2i == r2);
     // create a new bitmap directly from initializer list
@@ -533,7 +533,7 @@ void test_example_cpp_64(bool copy_on_write) {
     printf("\n");
     // create a new bitmap with initializer list
     Roaring64Map r2i =
-        Roaring64Map::bitmapOf({1ull, 2ull, 234294967296ull, 195839473298ull,
+        Roaring64Map::bitmapOfList({1ull, 2ull, 234294967296ull, 195839473298ull,
                                14000000000000000100ull});
     assert(r2i == r2);
 
@@ -816,7 +816,7 @@ DEFINE_TEST(test_cpp_add_range_64) {
 }
 DEFINE_TEST(test_bitmap_of_32) {
         Roaring r1 =
-            Roaring::bitmapOf({1,2,4});
+            Roaring::bitmapOfList({1,2,4});
         Roaring r2 =
             Roaring::bitmapOf(3, uint64_t(1), uint64_t(2), uint64_t(4));
         assert_true(r1 == r2);
@@ -826,7 +826,7 @@ DEFINE_TEST(test_bitmap_of_32) {
 
 DEFINE_TEST(test_bitmap_of_64) {
         Roaring64Map r1 =
-            Roaring64Map::bitmapOf({1,2,4});
+            Roaring64Map::bitmapOfList({1,2,4});
         Roaring64Map r2 =
             Roaring64Map::bitmapOf(3, uint64_t(1), uint64_t(2), uint64_t(4));
         assert_true(r1 == r2);

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -329,6 +329,10 @@ void test_example_cpp(bool copy_on_write) {
     Roaring r2i = Roaring::bitmapOf({1, 2, 3, 5, 6});
 
     assert(r2i == r2);
+    // create a new bitmap directly from initializer list
+    Roaring r2id = {1, 2, 3, 5, 6};
+
+    assert(r2id == r2);
     // test select
     uint32_t element;
     r2.select(3, &element);
@@ -532,6 +536,11 @@ void test_example_cpp_64(bool copy_on_write) {
         Roaring64Map::bitmapOf({1ull, 2ull, 234294967296ull, 195839473298ull,
                                14000000000000000100ull});
     assert(r2i == r2);
+
+    // create a new bitmap directly from initializer list
+    Roaring64Map r2id = {1ull, 2ull, 234294967296ull, 195839473298ull,
+                               14000000000000000100ull};
+    assert(r2id == r2);
 
     // test select
     uint64_t element;
@@ -811,6 +820,8 @@ DEFINE_TEST(test_bitmap_of_32) {
         Roaring r2 =
             Roaring::bitmapOf(3, uint64_t(1), uint64_t(2), uint64_t(4));
         assert_true(r1 == r2);
+        Roaring r1d = {1,2,4};
+        assert_true(r1 == r1d);
 }
 
 DEFINE_TEST(test_bitmap_of_64) {
@@ -819,6 +830,8 @@ DEFINE_TEST(test_bitmap_of_64) {
         Roaring64Map r2 =
             Roaring64Map::bitmapOf(3, uint64_t(1), uint64_t(2), uint64_t(4));
         assert_true(r1 == r2);
+        Roaring64Map r1d = {1,2,4};
+        assert_true(r1 == r1d);
 }
 
 DEFINE_TEST(test_cpp_remove_range_closed_64) {

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -811,7 +811,7 @@ DEFINE_TEST(test_bitmap_of_32) {
         r1.printf();
         printf("\n");
         Roaring r2 =
-            Roaring::bitmapOf(3, uint64_t(1), uint64_t(2), uint64_t(4));
+            Roaring::bitmapOf(3, 1, 2, 4);
         r2.printf();
         printf("\n");
         assert_true(r1 == r2);

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -815,8 +815,7 @@ DEFINE_TEST(test_cpp_add_range_64) {
     }
 }
 DEFINE_TEST(test_bitmap_of_32) {
-        Roaring r1 =
-            Roaring::bitmapOfList({1,2,4});
+        Roaring r1 = Roaring::bitmapOfList({1,2,4});
         Roaring r2 =
             Roaring::bitmapOf(3, uint64_t(1), uint64_t(2), uint64_t(4));
         assert_true(r1 == r2);

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -325,7 +325,10 @@ void test_example_cpp(bool copy_on_write) {
 
     r2.printf();
     printf("\n");
+    // create a new bitmap with initializer list
+    Roaring r2i = Roaring::bitmapOf({1, 2, 3, 5, 6});
 
+    assert(r2i == r2);
     // test select
     uint32_t element;
     r2.select(3, &element);
@@ -524,6 +527,11 @@ void test_example_cpp_64(bool copy_on_write) {
 
     r2.printf();
     printf("\n");
+    // create a new bitmap with initializer list
+    Roaring64Map r2i =
+        Roaring64Map::bitmapOf({1ull, 2ull, 234294967296ull, 195839473298ull,
+                               14000000000000000100ull});
+    assert(r2i == r2);
 
     // test select
     uint64_t element;
@@ -796,6 +804,21 @@ DEFINE_TEST(test_cpp_add_range_64) {
         }
         assert_true(r1 == r2);
     }
+}
+DEFINE_TEST(test_bitmap_of_32) {
+        Roaring r1 =
+            Roaring::bitmapOf({1,2,4});
+        Roaring r2 =
+            Roaring::bitmapOf(3, uint64_t(1), uint64_t(2), uint64_t(4));
+        assert_true(r1 == r2);
+}
+
+DEFINE_TEST(test_bitmap_of_64) {
+        Roaring64Map r1 =
+            Roaring64Map::bitmapOf({1,2,4});
+        Roaring64Map r2 =
+            Roaring64Map::bitmapOf(3, uint64_t(1), uint64_t(2), uint64_t(4));
+        assert_true(r1 == r2);
 }
 
 DEFINE_TEST(test_cpp_remove_range_closed_64) {
@@ -1425,6 +1448,8 @@ DEFINE_TEST(test_cpp_contains_range_interleaved_containers) {
 int main() {
     roaring::misc::tellmeall();
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_bitmap_of_32),
+        cmocka_unit_test(test_bitmap_of_64),
         cmocka_unit_test(serial_test),
         cmocka_unit_test(test_example_true),
         cmocka_unit_test(test_example_false),

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -533,12 +533,12 @@ void test_example_cpp_64(bool copy_on_write) {
     printf("\n");
     // create a new bitmap with initializer list
     Roaring64Map r2i =
-        Roaring64Map::bitmapOfList({1ull, 2ull, 234294967296ull, 195839473298ull,
+        Roaring64Map::bitmapOfList({1, 2, 234294967296, 195839473298,
                                14000000000000000100ull});
     assert(r2i == r2);
 
     // create a new bitmap directly from initializer list
-    Roaring64Map r2id = {1ull, 2ull, 234294967296ull, 195839473298ull,
+    Roaring64Map r2id = {1, 2, 234294967296, 195839473298,
                                14000000000000000100ull};
     assert(r2id == r2);
 


### PR DESCRIPTION
Basically, we want to be able to do the following:

```C++
Roaring b = Roaring::bitmapOfList({1,2,4});
```

Instead of the awkward

```C++
Roaring  = Roaring::bitmapOf(3, 1, 2, 4);
```

