### PR TITLE
Let us guard the malloc.h include with a check for glibc.

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -49,7 +49,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>  // will provide posix_memalign with _POSIX_C_SOURCE as defined above
-#if !(defined(__APPLE__)) && !(defined(__FreeBSD__))
+#ifdef __GLIBC__
 #include <malloc.h>  // this should never be needed but there are some reports that it is needed.
 #endif
 


### PR DESCRIPTION
Alternative to https://github.com/RoaringBitmap/CRoaring/pull/407