### PR TITLE
convert.c: Remove set-but-not-used variable (Clang 15 warning)

### DIFF
--- a/src/containers/convert.c
+++ b/src/containers/convert.c
@@ -263,7 +263,6 @@ container_t *convert_run_optimize(
 
         int long_ctr = 0;
         uint64_t cur_word = c_qua_bitset->words[0];
-        int run_count = 0;
         while (true) {
             while (cur_word == UINT64_C(0) &&
                    long_ctr < BITSET_CONTAINER_SIZE_IN_WORDS - 1)
@@ -294,7 +293,6 @@ container_t *convert_run_optimize(
             int local_run_end = __builtin_ctzll(~cur_word_with_1s);
             run_end = local_run_end + long_ctr * 64;
             add_run(answer, run_start, run_end - 1);
-            run_count++;
             cur_word = cur_word_with_1s & (cur_word_with_1s + 1);
         }
         return answer;


### PR DESCRIPTION
Compiling with Clang 15 and lots of warnings reveals this unneeded variable.