### PR TITLE
Add link to Zig wrapper to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,9 @@ Yuce Tekol wrote a D wrapper available at https://github.com/yuce/droaring
 
 Antonio Guilherme Ferreira Viggiano wrote a Redis Module available at https://github.com/aviggiano/redis-roaring
 
+# Zig Wrapper
+
+Justin Whear wrote a Zig wrapper available at https://github.com/jwhear/roaring-zig
 
 
 # Mailing list/discussion group


### PR DESCRIPTION
For the last year and a half, I've maintained a Zig wrapper here: https://github.com/jwhear/roaring-zig

I don't know if there are any special criteria for inclusion on the README but thought I'd put it out there.