### PR TITLE
fix use of arena_alloc for C++ compilers when roaring.c is compiled as C++

### DIFF
--- a/src/roaring.c
+++ b/src/roaring.c
@@ -3281,8 +3281,8 @@ roaring_bitmap_t *roaring_bitmap_portable_deserialize_frozen(const char *buf) {
         (container_t **)arena_alloc(&arena,
                                     sizeof(container_t*) * num_containers);
 
-    uint16_t *keys = arena_alloc(&arena, num_containers * sizeof(uint16_t));
-    uint8_t *typecodes = arena_alloc(&arena, num_containers * sizeof(uint8_t));
+    uint16_t *keys = (uint16_t *)arena_alloc(&arena, num_containers * sizeof(uint16_t));
+    uint8_t *typecodes = (uint8_t *)arena_alloc(&arena, num_containers * sizeof(uint8_t));
 
     rb->high_low_container.keys = keys;
     rb->high_low_container.typecodes = typecodes;
@@ -3304,7 +3304,7 @@ roaring_bitmap_t *roaring_bitmap_portable_deserialize_frozen(const char *buf) {
 
         if (isbitmap) {
             typecodes[i] = BITSET_CONTAINER_TYPE;
-            bitset_container_t *c = arena_alloc(&arena, sizeof(bitset_container_t));
+            bitset_container_t *c = (bitset_container_t *)arena_alloc(&arena, sizeof(bitset_container_t));
             c->cardinality = cardinality;
             if(offset_headers != NULL) {
                 c->words = (uint64_t *) (start_of_buf + offset_headers[i]);
@@ -3315,7 +3315,7 @@ roaring_bitmap_t *roaring_bitmap_portable_deserialize_frozen(const char *buf) {
             rb->high_low_container.containers[i] = c;
         } else if (isrun) {
             typecodes[i] = RUN_CONTAINER_TYPE;
-            run_container_t *c = arena_alloc(&arena, sizeof(run_container_t));
+            run_container_t *c = (run_container_t *)arena_alloc(&arena, sizeof(run_container_t));
             c->capacity = cardinality;
             uint16_t n_runs;
             if(offset_headers != NULL) {
@@ -3332,7 +3332,7 @@ roaring_bitmap_t *roaring_bitmap_portable_deserialize_frozen(const char *buf) {
             rb->high_low_container.containers[i] = c;
         } else {
             typecodes[i] = ARRAY_CONTAINER_TYPE;
-            array_container_t *c = arena_alloc(&arena, sizeof(array_container_t));
+            array_container_t *c = (array_container_t *)arena_alloc(&arena, sizeof(array_container_t));
             c->cardinality = cardinality;
             c->capacity = cardinality;
             if(offset_headers != NULL) {


### PR DESCRIPTION
In roaring-node, roaring.c is compiled as C++ source.
The recent change in the roaring_bitmap_portable_deserialize_frozen that uses arena_alloc causes CPP compilation to fail.

The void* pointer need to be casted to the right pointer type.

![image](https://user-images.githubusercontent.com/6913178/215856104-9b714161-9d2d-4d13-b616-1cf2fe679ef4.png)