### PR TITLE
Fix 'error: expected ) before PRIu64' build error on some linux platform

### DIFF
--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -9,6 +9,7 @@
 #ifndef INCLUDE_ROARING_64_MAP_HH_
 #define INCLUDE_ROARING_64_MAP_HH_
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <algorithm>
 #include <cstdarg>  // for va_list handling in bitmapOf()


### PR DESCRIPTION
Fix "error: expected ) before PRIu64" build error on some linux platform.