### PR TITLE
add avx512 optimization

### DIFF
--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -189,6 +189,10 @@ size_t bitset_extract_setbits_sse_uint16(const uint64_t *words, size_t length,
                                          uint16_t *out, size_t outcapacity,
                                          uint16_t base);
 
+size_t bitset_extract_setbits_avx512_uint16(const uint64_t *words, size_t length,
+                                         uint16_t *out, size_t outcapacity, 
+                                         uint16_t base);
+
 /*
  * Given a bitset containing "length" 64-bit words, write out the position
  * of all the set bits to "out",  values start at "base"
@@ -572,41 +576,13 @@ CROARING_TARGET_AVX2
 AVXPOPCNTFNC(andnot, _mm256_andnot_si256)
 CROARING_UNTARGET_REGION
 
+
+#define VPOPCNT_AND_ADD(ptr, i, accu)   \
+    const __m512i v##i = _mm512_loadu_si512((const __m512i*)ptr + i);  \
+    const __m512i p##i = _mm512_popcnt_epi64(v##i);    \
+    accu = _mm512_add_epi64(accu, p##i);  
+ 
 CROARING_TARGET_AVX512
-static inline __m512i popcount512(const __m512i v)
-{
-  const __m512i m1 = _mm512_set1_epi8(0x55);
-  const __m512i m2 = _mm512_set1_epi8(0x33);
-  const __m512i m4 = _mm512_set1_epi8(0x0F);
-
-  const __m512i t1 = _mm512_sub_epi8(v,       (_mm512_srli_epi16(v,  1) & m1));
-  const __m512i t2 = _mm512_add_epi8(t1 & m2, (_mm512_srli_epi16(t1, 2) & m2));
-  const __m512i t3 = _mm512_add_epi8(t2, _mm512_srli_epi16(t2, 4)) & m4;
-  return _mm512_sad_epu8(t3, _mm512_setzero_si512());
-}
-
-static inline void CSA512(__m512i *h, __m512i *l, __m512i a, __m512i b, __m512i c)
-{
-    /*
-        c b a | l h
-        ------+----
-        0 0 0 | 0 0
-        0 0 1 | 1 0
-        0 1 0 | 1 0
-        0 1 1 | 0 1
-        1 0 0 | 1 0
-        1 0 1 | 0 1
-        1 1 0 | 0 1
-        1 1 1 | 1 1
-
-        l - digit
-        h - carry
-    */
-
-  *l = _mm512_ternarylogic_epi32(c, b, a, 0x96);
-  *h = _mm512_ternarylogic_epi32(c, b, a, 0xe8);
-}
-
 static inline uint64_t sum_epu64_256(const __m256i v) {
 
     return (uint64_t)(_mm256_extract_epi64(v, 0))
@@ -624,51 +600,26 @@ static inline uint64_t simd_sum_epu64(const __m512i v) {
     return sum_epu64_256(lo) + sum_epu64_256(hi);
 }
 
-static inline uint64_t avx512_harley_seal_popcount512(const __m512i* data, const uint64_t size)
+static inline uint64_t avx512_vpopcount(const __m512i* data, const uint64_t size)
 {
-  __m512i total     = _mm512_setzero_si512();
-  __m512i ones      = _mm512_setzero_si512();
-  __m512i twos      = _mm512_setzero_si512();
-  __m512i fours     = _mm512_setzero_si512();
-  __m512i eights    = _mm512_setzero_si512();
-  __m512i sixteens  = _mm512_setzero_si512();
-  __m512i twosA, twosB, foursA, foursB, eightsA, eightsB;
+    const uint64_t limit = size - size % 4;
+    __m512i total = _mm512_setzero_si512();
+    uint64_t i = 0;
 
-  const uint64_t limit = size - size % 16;
-  uint64_t i = 0;
-
-  for(; i < limit; i += 16)
-  {
-    CSA512(&twosA, &ones, ones,  _mm512_loadu_si512(data + i), _mm512_loadu_si512(data + i + 1));
-    CSA512(&twosB, &ones, ones,  _mm512_loadu_si512(data + i + 2), _mm512_loadu_si512(data + i + 3));
-    CSA512(&foursA, &twos, twos, twosA, twosB);
-    CSA512(&twosA, &ones, ones, _mm512_loadu_si512(data + i + 4), _mm512_loadu_si512(data + i + 5));
-    CSA512(&twosB, &ones, ones, _mm512_loadu_si512(data + i + 6), _mm512_loadu_si512(data + i + 7));
-    CSA512(&foursB, &twos, twos, twosA, twosB);
-    CSA512(&eightsA, &fours, fours, foursA, foursB);
-    CSA512(&twosA, &ones, ones, _mm512_loadu_si512(data + i + 8), _mm512_loadu_si512(data + i + 9));
-    CSA512(&twosB, &ones, ones, _mm512_loadu_si512(data + i +10), _mm512_loadu_si512(data + i + 11));
-    CSA512(&foursA, &twos, twos, twosA, twosB);
-    CSA512(&twosA, &ones, ones, _mm512_loadu_si512(data + i + 12), _mm512_loadu_si512(data + i + 13));
-    CSA512(&twosB, &ones, ones, _mm512_loadu_si512(data + i + 14), _mm512_loadu_si512(data + i + 15));
-    CSA512(&foursB, &twos, twos, twosA, twosB);
-    CSA512(&eightsB, &fours, fours, foursA, foursB);
-    CSA512(&sixteens, &eights, eights, eightsA, eightsB);
-
-    total = _mm512_add_epi64(total, popcount512(sixteens));
-  }
-
-  total = _mm512_slli_epi64(total, 4);     // * 16
-  total = _mm512_add_epi64(total, _mm512_slli_epi64(popcount512(eights), 3)); // += 8 * ...
-  total = _mm512_add_epi64(total, _mm512_slli_epi64(popcount512(fours),  2)); // += 4 * ...
-  total = _mm512_add_epi64(total, _mm512_slli_epi64(popcount512(twos),   1)); // += 2 * ...
-  total = _mm512_add_epi64(total, popcount512(ones));
-
-  for(; i < size; i++)
-    total = _mm512_add_epi64(total, popcount512(_mm512_loadu_si512(data + i)));
-
-
-  return simd_sum_epu64(total);
+    for (; i < limit; i += 4)
+    {    
+        VPOPCNT_AND_ADD(data + i, 0, total);
+        VPOPCNT_AND_ADD(data + i, 1, total);
+        VPOPCNT_AND_ADD(data + i, 2, total);
+        VPOPCNT_AND_ADD(data + i, 3, total);
+    }
+    
+    for (; i < size; i++)
+    {
+        total = _mm512_add_epi64(total, _mm512_popcnt_epi64(_mm512_loadu_si512(data + i)));
+    }
+        
+    return simd_sum_epu64(total);
 }
 CROARING_UNTARGET_REGION
 
@@ -676,74 +627,26 @@ CROARING_UNTARGET_REGION
     static inline uint64_t avx512_harley_seal_popcount512_##opname(            \
         const __m512i *data1, const __m512i *data2, const uint64_t size) {     \
         __m512i total = _mm512_setzero_si512();                                \
-        __m512i ones = _mm512_setzero_si512();                                 \
-        __m512i twos = _mm512_setzero_si512();                                 \
-        __m512i fours = _mm512_setzero_si512();                                \
-        __m512i eights = _mm512_setzero_si512();                               \
-        __m512i sixteens = _mm512_setzero_si512();                             \
-        __m512i twosA, twosB, foursA, foursB, eightsA, eightsB;                \
-        __m512i A1, A2;                                                        \
-        const uint64_t limit = size - size % 16;                               \
+        const uint64_t limit = size - size % 4;                                \
         uint64_t i = 0;                                                        \
-        for (; i < limit; i += 16) {                                           \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i),                  \
-                               _mm512_loadu_si512(data2 + i));                 \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 1),              \
-                               _mm512_loadu_si512(data2 + i + 1));             \
-            CSA512(&twosA, &ones, ones, A1, A2);                               \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 2),              \
-                               _mm512_loadu_si512(data2 + i + 2));             \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 3),              \
-                               _mm512_loadu_si512(data2 + i + 3));             \
-            CSA512(&twosB, &ones, ones, A1, A2);                               \
-            CSA512(&foursA, &twos, twos, twosA, twosB);                        \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 4),              \
-                               _mm512_loadu_si512(data2 + i + 4));             \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 5),              \
-                               _mm512_loadu_si512(data2 + i + 5));             \
-            CSA512(&twosA, &ones, ones, A1, A2);                               \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 6),              \
-                               _mm512_loadu_si512(data2 + i + 6));             \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 7),              \
-                               _mm512_loadu_si512(data2 + i + 7));             \
-            CSA512(&twosB, &ones, ones, A1, A2);                               \
-            CSA512(&foursB, &twos, twos, twosA, twosB);                        \
-            CSA512(&eightsA, &fours, fours, foursA, foursB);                   \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 8),              \
-                               _mm512_loadu_si512(data2 + i + 8));             \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 9),              \
-                               _mm512_loadu_si512(data2 + i + 9));             \
-            CSA512(&twosA, &ones, ones, A1, A2);                               \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 10),             \
-                               _mm512_loadu_si512(data2 + i + 10));            \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 11),             \
-                               _mm512_loadu_si512(data2 + i + 11));            \
-            CSA512(&twosB, &ones, ones, A1, A2);                               \
-            CSA512(&foursA, &twos, twos, twosA, twosB);                        \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 12),             \
-                               _mm512_loadu_si512(data2 + i + 12));            \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 13),             \
-                               _mm512_loadu_si512(data2 + i + 13));            \
-            CSA512(&twosA, &ones, ones, A1, A2);                               \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 14),             \
-                               _mm512_loadu_si512(data2 + i + 14));            \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 15),             \
-                               _mm512_loadu_si512(data2 + i + 15));            \
-            CSA512(&twosB, &ones, ones, A1, A2);                               \
-            CSA512(&foursB, &twos, twos, twosA, twosB);                        \
-            CSA512(&eightsB, &fours, fours, foursA, foursB);                   \
-            CSA512(&sixteens, &eights, eights, eightsA, eightsB);              \
-            total = _mm512_add_epi64(total, popcount512(sixteens));            \
-        }                                                                      \
-        total = _mm512_slli_epi64(total, 4);                                   \
-        total = _mm512_add_epi64(total, _mm512_slli_epi64(popcount512(eights), 3)); \
-        total = _mm512_add_epi64(total, _mm512_slli_epi64(popcount512(fours),  2));  \
-        total = _mm512_add_epi64(total, _mm512_slli_epi64(popcount512(twos),   1));  \
-        total = _mm512_add_epi64(total, popcount512(ones));                    \
-        for(; i < size; i++) {                                                 \
-              A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i),                \
+	    for (; i < limit; i += 4) {                                        \
+            __m512i a1 = avx_intrinsic(_mm512_loadu_si512(data1 + i),          \
+                                       _mm512_loadu_si512(data2 + i));         \
+            total = _mm512_add_epi64(total, _mm512_popcnt_epi64(a1));          \
+            __m512i a2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 1),      \
+                                       _mm512_loadu_si512(data2 + i + 1));     \
+            total = _mm512_add_epi64(total, _mm512_popcnt_epi64(a2));          \
+             __m512i a3 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 2),     \
+                                       _mm512_loadu_si512(data2 + i + 2));     \
+            total = _mm512_add_epi64(total, _mm512_popcnt_epi64(a3));          \
+             __m512i a4 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 3),     \
+                                       _mm512_loadu_si512(data2 + i + 3));     \
+            total = _mm512_add_epi64(total, _mm512_popcnt_epi64(a4));          \
+       }                                                                       \
+       for(; i < size; i++) {                                                  \
+              __m512i a = avx_intrinsic(_mm512_loadu_si512(data1 + i),         \
                        _mm512_loadu_si512(data2 + i));                         \
-              total = _mm512_add_epi64(total, popcount512(A1));                \
+              total = _mm512_add_epi64(total, _mm512_popcnt_epi64(a));         \
         }                                                                      \
         return simd_sum_epu64(total);                                          \
     }                                                                          \
@@ -751,91 +654,31 @@ CROARING_UNTARGET_REGION
         const __m512i *__restrict__ data1, const __m512i *__restrict__ data2,  \
         __m512i *__restrict__ out, const uint64_t size) {                      \
         __m512i total = _mm512_setzero_si512();                                \
-        __m512i ones = _mm512_setzero_si512();                                 \
-        __m512i twos = _mm512_setzero_si512();                                 \
-        __m512i fours = _mm512_setzero_si512();                                \
-        __m512i eights = _mm512_setzero_si512();                               \
-        __m512i sixteens = _mm512_setzero_si512();                             \
-        __m512i twosA, twosB, foursA, foursB, eightsA, eightsB;                \
-        __m512i A1, A2;                                                        \
-        const uint64_t limit = size - size % 16;                               \
+        const uint64_t limit = size - size % 4;                                \
         uint64_t i = 0;                                                        \
-        for (; i < limit; i += 16) {                                           \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i),                  \
-                               _mm512_loadu_si512(data2 + i));                 \
-            _mm512_storeu_si512(out + i, A1);                                  \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 1),              \
-                               _mm512_loadu_si512(data2 + i + 1));             \
-            _mm512_storeu_si512(out + i + 1, A2);                              \
-            CSA512(&twosA, &ones, ones, A1, A2);                               \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 2),              \
-                               _mm512_loadu_si512(data2 + i + 2));             \
-            _mm512_storeu_si512(out + i + 2, A1);                              \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 3),              \
-                               _mm512_loadu_si512(data2 + i + 3));             \
-            _mm512_storeu_si512(out + i + 3, A2);                              \
-            CSA512(&twosB, &ones, ones, A1, A2);                               \
-            CSA512(&foursA, &twos, twos, twosA, twosB);                        \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 4),              \
-                               _mm512_loadu_si512(data2 + i + 4));             \
-            _mm512_storeu_si512(out + i + 4, A1);                              \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 5),              \
-                               _mm512_loadu_si512(data2 + i + 5));             \
-            _mm512_storeu_si512(out + i + 5, A2);                              \
-            CSA512(&twosA, &ones, ones, A1, A2);                               \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 6),              \
-                               _mm512_loadu_si512(data2 + i + 6));             \
-            _mm512_storeu_si512(out + i + 6, A1);                              \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 7),              \
-                               _mm512_loadu_si512(data2 + i + 7));             \
-            _mm512_storeu_si512(out + i + 7, A2);                              \
-            CSA512(&twosB, &ones, ones, A1, A2);                               \
-            CSA512(&foursB, &twos, twos, twosA, twosB);                        \
-            CSA512(&eightsA, &fours, fours, foursA, foursB);                   \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 8),              \
-                               _mm512_loadu_si512(data2 + i + 8));             \
-            _mm512_storeu_si512(out + i + 8, A1);                              \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 9),              \
-                               _mm512_loadu_si512(data2 + i + 9));             \
-            _mm512_storeu_si512(out + i + 9, A2);                              \
-            CSA512(&twosA, &ones, ones, A1, A2);                               \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 10),             \
-                               _mm512_loadu_si512(data2 + i + 10));            \
-            _mm512_storeu_si512(out + i + 10, A1);                             \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 11),             \
-                               _mm512_loadu_si512(data2 + i + 11));            \
-            _mm512_storeu_si512(out + i + 11, A2);                             \
-            CSA512(&twosB, &ones, ones, A1, A2);                               \
-            CSA512(&foursA, &twos, twos, twosA, twosB);                        \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 12),             \
-                               _mm512_loadu_si512(data2 + i + 12));            \
-            _mm512_storeu_si512(out + i + 12, A1);                             \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 13),             \
-                               _mm512_loadu_si512(data2 + i + 13));            \
-            _mm512_storeu_si512(out + i + 13, A2);                             \
-            CSA512(&twosA, &ones, ones, A1, A2);                               \
-            A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 14),             \
-                               _mm512_loadu_si512(data2 + i + 14));            \
-            _mm512_storeu_si512(out + i + 14, A1);                             \
-            A2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 15),             \
-                               _mm512_loadu_si512(data2 + i + 15));            \
-            _mm512_storeu_si512(out + i + 15, A2);                             \
-            CSA512(&twosB, &ones, ones, A1, A2);                               \
-            CSA512(&foursB, &twos, twos, twosA, twosB);                        \
-            CSA512(&eightsB, &fours, fours, foursA, foursB);                   \
-            CSA512(&sixteens, &eights, eights, eightsA, eightsB);              \
-            total = _mm512_add_epi64(total, popcount512(sixteens));            \
-        }                                                                      \
-        total = _mm512_slli_epi64(total, 4);                                   \
-        total = _mm512_add_epi64(total, _mm512_slli_epi64(popcount512(eights), 3)); \
-        total = _mm512_add_epi64(total, _mm512_slli_epi64(popcount512(fours),  2));  \
-        total = _mm512_add_epi64(total, _mm512_slli_epi64(popcount512(twos),   1));  \
-        total = _mm512_add_epi64(total, popcount512(ones));                    \
-        for(; i < size; i++) {                                                 \
-              A1 = avx_intrinsic(_mm512_loadu_si512(data1 + i),                \
+	    for (; i < limit; i += 4) {                                        \
+            __m512i a1 = avx_intrinsic(_mm512_loadu_si512(data1 + i),          \
+                                       _mm512_loadu_si512(data2 + i));         \
+            _mm512_storeu_si512(out + i, a1);                                  \
+            total = _mm512_add_epi64(total, _mm512_popcnt_epi64(a1));          \
+            __m512i a2 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 1),      \
+                                       _mm512_loadu_si512(data2 + i + 1));     \
+            _mm512_storeu_si512(out + i + 1, a2);                              \
+            total = _mm512_add_epi64(total, _mm512_popcnt_epi64(a2));          \
+             __m512i a3 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 2),     \
+                                       _mm512_loadu_si512(data2 + i + 2));     \
+            _mm512_storeu_si512(out + i + 2, a3);                              \
+            total = _mm512_add_epi64(total, _mm512_popcnt_epi64(a3));          \
+            __m512i a4 = avx_intrinsic(_mm512_loadu_si512(data1 + i + 3),      \
+                                       _mm512_loadu_si512(data2 + i + 3));     \
+            _mm512_storeu_si512(out + i + 3, a4);                              \
+            total = _mm512_add_epi64(total, _mm512_popcnt_epi64(a4));          \
+       }                                                                       \
+       for(; i < size; i++) {                                                  \
+              __m512i a = avx_intrinsic(_mm512_loadu_si512(data1 + i),         \
                        _mm512_loadu_si512(data2 + i));                         \
-               _mm512_storeu_si512(out + i, A1);                               \
-               total = _mm512_add_epi64(total, popcount512(A1));               \
+            _mm512_storeu_si512(out + i, a);                                   \
+ 	       total = _mm512_add_epi64(total, _mm512_popcnt_epi64(a));        \
         }                                                                      \
         return simd_sum_epu64(total);                                          \
     }                                                                          \

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -64,7 +64,7 @@ bitset_container_t *bitset_container_clone(const bitset_container_t *src);
 void bitset_container_set_range(bitset_container_t *bitset, uint32_t begin,
                                 uint32_t end);
 
-#if defined(CROARING_ASMBITMANIPOPTIMIZATION) && ( defined(__AVX2__) || defined(__AVX512__))
+#if defined(CROARING_ASMBITMANIPOPTIMIZATION) && defined(__AVX2__)
 /* Set the ith bit.  */
 static inline void bitset_container_set(bitset_container_t *bitset,
                                         uint16_t pos) {

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -64,7 +64,7 @@ bitset_container_t *bitset_container_clone(const bitset_container_t *src);
 void bitset_container_set_range(bitset_container_t *bitset, uint32_t begin,
                                 uint32_t end);
 
-#if defined(CROARING_ASMBITMANIPOPTIMIZATION) && defined(__AVX2__)
+#if defined(CROARING_ASMBITMANIPOPTIMIZATION) && ( defined(__AVX2__) || defined(__AVX512__))
 /* Set the ith bit.  */
 static inline void bitset_container_set(bitset_container_t *bitset,
                                         uint16_t pos) {

--- a/include/roaring/isadetection.h
+++ b/include/roaring/isadetection.h
@@ -266,15 +266,13 @@ static inline bool croaring_avx2() {
 }
 static inline bool croaring_avx512() {
   static bool avx512_support = false;
-  if( avx512_support )
-  {
-      return true;
-  }
-  else
+
+  if( !avx512_support )
   {
       avx512_support = ( (croaring_detect_supported_architectures() & (CROARING_AVX512F | CROARING_AVX512DQ | CROARING_AVX512BW | CROARING_AVX512VBMI2 | CROARING_AVX512BITALG | CROARING_AVX512VPOPCNTDQ)) 
 	  == (CROARING_AVX512F | CROARING_AVX512DQ | CROARING_AVX512BW | CROARING_AVX512VBMI2 | CROARING_AVX512BITALG | CROARING_AVX512VPOPCNTDQ));
   }
+  return avx512_support;
 }
 #endif
 

--- a/include/roaring/isadetection.h
+++ b/include/roaring/isadetection.h
@@ -71,6 +71,7 @@ enum croaring_instruction_set {
   CROARING_BMI1 = 0x20,
   CROARING_BMI2 = 0x40,
   CROARING_ALTIVEC = 0x80,
+  CROARING_AVX512 =0x100,
   CROARING_UNINITIALIZED = 0x8000
 };
 
@@ -131,6 +132,7 @@ static inline uint32_t dynamic_croaring_detect_supported_architectures() {
   static uint32_t cpuid_avx2_bit = 1 << 5;      ///< @private Bit 5 of EBX for EAX=0x7
   static uint32_t cpuid_bmi1_bit = 1 << 3;      ///< @private bit 3 of EBX for EAX=0x7
   static uint32_t cpuid_bmi2_bit = 1 << 8;      ///< @private bit 8 of EBX for EAX=0x7
+  static uint32_t cpuid_avx512f_bit = 1 << 16;  ///< @private bit 16 of EBX for EAX=0x7
   static uint32_t cpuid_sse42_bit = 1 << 20;    ///< @private bit 20 of ECX for EAX=0x1
   static uint32_t cpuid_pclmulqdq_bit = 1 << 1; ///< @private bit  1 of ECX for EAX=0x1
   // ECX for EAX=0x7
@@ -146,6 +148,10 @@ static inline uint32_t dynamic_croaring_detect_supported_architectures() {
 
   if (ebx & cpuid_bmi2_bit) {
     host_isa |= CROARING_BMI2;
+  }
+  
+  if (ebx & cpuid_avx512f_bit) {
+    host_isa |= CROARING_AVX512;
   }
 
   // EBX for EAX=0x1
@@ -207,13 +213,29 @@ static inline uint32_t croaring_detect_supported_architectures() {
 static inline bool croaring_avx2() {
   return false;
 }
+static inline bool croaring_avx512() {
+  return false;
+}
+#elif defined(__AVX512F__)
+static inline bool croaring_avx2() {
+  return true;
+}
+static inline bool croaring_avx512() {
+  return true;
+}
 #elif defined(__AVX2__)
 static inline bool croaring_avx2() {
   return true;
 }
+static inline bool croaring_avx512() {
+  return false;
+}
 #else
 static inline bool croaring_avx2() {
   return  (croaring_detect_supported_architectures() & CROARING_AVX2) == CROARING_AVX2;
+}
+static inline bool croaring_avx512() {
+  return  (croaring_detect_supported_architectures() & CROARING_AVX512) == CROARING_AVX512;
 }
 #endif
 

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -339,7 +339,7 @@ static inline int hamming(uint64_t x) {
 #define CROARING_UNTARGET_REGION
 #endif
 
-#ifdef __AVX512F__
+#if defined(__AVX512F__) && defined(__AVX512DQ__) && defined(__AVX512BW__) && defined(__AVX512VBMI2__) && defined(__AVX512BITALG__) && defined(__AVX512VPOPCNTDQ__)
 // No need for runtime dispatching.
 // It is unnecessary and harmful to old clang to tag regions.
 #undef CROARING_TARGET_AVX512

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -328,12 +328,22 @@ static inline int hamming(uint64_t x) {
 #endif
 
 #define CROARING_TARGET_AVX2 CROARING_TARGET_REGION("avx2,bmi,pclmul,lzcnt")
+#define CROARING_TARGET_AVX512 CROARING_TARGET_REGION("bmi2,avx512f,avx512bw,avx512dq")
 
 #ifdef __AVX2__
 // No need for runtime dispatching.
 // It is unnecessary and harmful to old clang to tag regions.
 #undef CROARING_TARGET_AVX2
 #define CROARING_TARGET_AVX2
+#undef CROARING_UNTARGET_REGION
+#define CROARING_UNTARGET_REGION
+#endif
+
+#ifdef __AVX512F__
+// No need for runtime dispatching.
+// It is unnecessary and harmful to old clang to tag regions.
+#undef CROARING_TARGET_AVX512
+#define CROARING_TARGET_AVX512
 #undef CROARING_UNTARGET_REGION
 #define CROARING_UNTARGET_REGION
 #endif

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -328,7 +328,7 @@ static inline int hamming(uint64_t x) {
 #endif
 
 #define CROARING_TARGET_AVX2 CROARING_TARGET_REGION("avx2,bmi,pclmul,lzcnt")
-#define CROARING_TARGET_AVX512 CROARING_TARGET_REGION("bmi2,avx512f,avx512bw,avx512dq")
+#define CROARING_TARGET_AVX512 CROARING_TARGET_REGION("bmi2,avx512f,avx512dq,avx512bw,avx512vbmi2,avx512bitalg,avx512vpopcntdq")
 
 #ifdef __AVX2__
 // No need for runtime dispatching.

--- a/src/array_util.c
+++ b/src/array_util.c
@@ -1892,6 +1892,64 @@ size_t fast_union_uint16(const uint16_t *set_1, size_t size_1, const uint16_t *s
 #endif
 }
 #ifdef CROARING_IS_X64
+CROARING_TARGET_AVX512
+static inline bool _avx512_memequals(const void *s1, const void *s2, size_t n) {
+    const uint8_t *ptr1 = (const uint8_t *)s1;
+    const uint8_t *ptr2 = (const uint8_t *)s2;
+    const uint8_t *end1 = ptr1 + n;
+    const uint8_t *end8 = ptr1 + ((n >> 3) << 3);
+    const uint8_t *end32 = ptr1 + ((n >> 5) << 5);
+    const uint8_t *end64 = ptr1 + ((n >> 6) << 6);
+    
+    while (ptr1 < end64){
+        __m512i r1 = _mm512_loadu_si512((const __m512i*)ptr1);
+        __m512i r2 = _mm512_loadu_si512((const __m512i*)ptr2);
+
+        uint64_t mask = _mm512_cmpeq_epi8_mask(r1, r2);
+        
+        if (mask != UINT64_MAX) {
+           return false;
+        }
+
+        ptr1 += 64;
+        ptr2 += 64;
+
+    }
+
+    while (ptr1 < end32) {
+        __m256i r1 = _mm256_loadu_si256((const __m256i*)ptr1);
+        __m256i r2 = _mm256_loadu_si256((const __m256i*)ptr2);
+        int mask = _mm256_movemask_epi8(_mm256_cmpeq_epi8(r1, r2));
+        if ((uint32_t)mask != UINT32_MAX) {
+            return false;
+        }
+        ptr1 += 32;
+        ptr2 += 32;
+    }
+
+    while (ptr1 < end8) {
+	uint64_t v1, v2;
+        memcpy(&v1,ptr1,sizeof(uint64_t));
+        memcpy(&v2,ptr2,sizeof(uint64_t));
+        if (v1 != v2) {
+            return false;
+        }
+        ptr1 += 8;
+        ptr2 += 8;
+    }
+
+    while (ptr1 < end1) {
+        if (*ptr1 != *ptr2) {
+            return false;
+        }
+        ptr1++;
+        ptr2++;
+    }
+
+    return true;
+}
+CROARING_UNTARGET_REGION
+
 CROARING_TARGET_AVX2
 static inline bool _avx2_memequals(const void *s1, const void *s2, size_t n) {
     const uint8_t *ptr1 = (const uint8_t *)s1;
@@ -1940,7 +1998,10 @@ bool memequals(const void *s1, const void *s2, size_t n) {
         return true;
     }
 #ifdef CROARING_IS_X64
-    if( croaring_avx2() ) {
+    if( croaring_avx512() ) {
+      return _avx512_memequals(s1, s2, n);
+    }
+    else if( croaring_avx2() ) {
       return _avx2_memequals(s1, s2, n);
     } else {
       return memcmp(s1, s2, n) == 0;

--- a/src/bitset_util.c
+++ b/src/bitset_util.c
@@ -553,6 +553,88 @@ static uint16_t vecDecodeTable_uint16[256][8] = {
 #endif
 
 #ifdef CROARING_IS_X64
+CROARING_TARGET_AVX512
+size_t bitset_extract_setbits_avx512(const uint64_t *words, size_t length, uint32_t *out,
+                                   size_t outcapacity, uint32_t base) {    
+    uint32_t *initout = out;
+    uint32_t *safeout = out + outcapacity;
+    
+    uint64_t msk_1 = 0xffffffff00000000ULL;
+    uint64_t msk_2 = 0xffff0000ffff0000ULL;
+    uint64_t msk_3 = 0xff00ff00ff00ff00ULL;
+    uint64_t msk_4 = 0xf0f0f0f0f0f0f0f0ULL;
+    uint64_t msk_5 = 0xccccccccccccccccULL;
+    uint64_t msk_6 = 0xaaaaaaaaaaaaaaaaULL;
+    __m512i v1_bit = _mm512_set1_epi8(1);
+    __m512i v2_bit = _mm512_set1_epi8(2);
+    __m512i v4_bit = _mm512_set1_epi8(4);
+    __m512i v8_bit = _mm512_set1_epi8(8);
+    __m512i v16_bit = _mm512_set1_epi8(16);
+    __m512i v32_bit = _mm512_set1_epi8(32);
+    
+    __m512i v64 = _mm512_set1_epi32(64);
+    __m512i v_base = _mm512_set1_epi32(base);
+    
+    
+    size_t i = 0;
+    for (; (i < length) && (out + 64 <= safeout); ++i) {
+        uint64_t v = words[i];
+	uint64_t v1 = _pext_u64(msk_1, v);
+	uint64_t v2 = _pext_u64(msk_2, v);
+	uint64_t v3 = _pext_u64(msk_3, v);
+	uint64_t v4 = _pext_u64(msk_4, v);
+	uint64_t v5 = _pext_u64(msk_5, v);
+	uint64_t v6 = _pext_u64(msk_6, v);
+	uint8_t advance = __builtin_popcountll(v);
+	__m512i vec;
+	
+        vec = _mm512_maskz_add_epi8(v1, v32_bit, _mm512_set1_epi8(0));
+	vec = _mm512_mask_add_epi8(vec, v2, v16_bit, vec);
+	vec = _mm512_mask_add_epi8(vec, v3, v8_bit, vec);
+	vec = _mm512_mask_add_epi8(vec, v4, v4_bit, vec);
+	vec = _mm512_mask_add_epi8(vec, v5, v2_bit, vec);
+	vec = _mm512_mask_add_epi8(vec, v6, v1_bit, vec);
+
+	//__m512i base = _mm512_set1_epi32(i*64);
+	__m512i r1 = _mm512_cvtepi8_epi32(_mm512_extracti32x4_epi32(vec,0));
+	__m512i r2 = _mm512_cvtepi8_epi32(_mm512_extracti32x4_epi32(vec,1));
+	__m512i r3 = _mm512_cvtepi8_epi32(_mm512_extracti32x4_epi32(vec,2));
+	__m512i r4 = _mm512_cvtepi8_epi32(_mm512_extracti32x4_epi32(vec,3));
+
+	r1 = _mm512_add_epi32(r1, v_base);
+	r2 = _mm512_add_epi32(r2, v_base);
+	r3 = _mm512_add_epi32(r3, v_base);
+	r4 = _mm512_add_epi32(r4, v_base);
+	_mm512_storeu_si512((__m512i *)out, r1);
+	_mm512_storeu_si512((__m512i *)(out + 16), r2);
+	_mm512_storeu_si512((__m512i *)(out + 32), r3);
+	_mm512_storeu_si512((__m512i *)(out + 48), r4);
+	out += advance;
+        
+        v_base = _mm512_add_epi32(v_base, v64);
+
+    }
+
+    base += i * 64;
+    
+    for (; (i < length) && (out < safeout); ++i) {
+        uint64_t w = words[i];
+        while ((w != 0) && (out < safeout)) {
+            uint64_t t = w & (~w + 1); // on x64, should compile to BLSI (careful: the Intel compiler seems to fail)
+            int r = __builtin_ctzll(w); // on x64, should compile to TZCNT
+            uint32_t val = r + base;
+            memcpy(out, &val,
+                   sizeof(uint32_t));  // should be compiled as a MOV on x64
+            out++;
+            w ^= t;
+        }
+        base += 64;
+    }
+    return out - initout;
+
+}
+CROARING_UNTARGET_REGION
+
 CROARING_TARGET_AVX2
 size_t bitset_extract_setbits_avx2(const uint64_t *words, size_t length,
                                    uint32_t *out, size_t outcapacity,

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -53,9 +53,16 @@ bitset_container_t *bitset_container_create(void) {
     if (!bitset) {
         return NULL;
     }
-    // sizeof(__m256i) == 32
-    bitset->words = (uint64_t *)roaring_aligned_malloc(
-        32, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+    if ( croaring_avx512() )
+    {
+        bitset->words = (uint64_t *)roaring_aligned_malloc(
+            64, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+    }
+    else {
+        // sizeof(__m256i) == 32
+        bitset->words = (uint64_t *)roaring_aligned_malloc(
+            32, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+    }
     if (!bitset->words) {
         roaring_free(bitset);
         return NULL;
@@ -218,6 +225,9 @@ bool bitset_container_intersect(const bitset_container_t *src_1,
 #ifndef WORDS_IN_AVX2_REG
 #define WORDS_IN_AVX2_REG sizeof(__m256i) / sizeof(uint64_t)
 #endif
+#ifndef WORDS_IN_AVX512_REG
+#define WORDS_IN_AVX512_REG sizeof(__m512i) / sizeof(uint64_t)
+#endif
 /* Get the number of bits set (force computation) */
 static inline int _scalar_bitset_container_compute_cardinality(const bitset_container_t *bitset) {
   const uint64_t *words = bitset->words;
@@ -232,7 +242,12 @@ static inline int _scalar_bitset_container_compute_cardinality(const bitset_cont
 }
 /* Get the number of bits set (force computation) */
 int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
-    if( croaring_avx2() ) {
+    if( croaring_avx512() ) {
+      return (int) avx512_harley_seal_popcount512(
+        (const __m512i *)bitset->words,
+        BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX512_REG));
+    }
+    else if( croaring_avx2() ) {
       return (int) avx2_harley_seal_popcount256(
         (const __m256i *)bitset->words,
         BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));
@@ -286,6 +301,165 @@ int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
 #ifdef CROARING_IS_X64
 
 #define BITSET_CONTAINER_FN_REPEAT 8
+#ifndef WORDS_IN_AVX512_REG
+#define WORDS_IN_AVX512_REG sizeof(__m512i) / sizeof(uint64_t)
+#endif // WORDS_IN_AVX512_REG
+/*#define LOOP_SIZE                    \
+    BITSET_CONTAINER_SIZE_IN_WORDS / \
+        ((WORDS_IN_AVX512_REG)*BITSET_CONTAINER_FN_REPEAT)
+*/
+/* Computes a binary operation (eg union) on bitset1 and bitset2 and write the
+   result to bitsetout */
+// clang-format off
+#define AVX512_BITSET_CONTAINER_FN1(before, opname, opsymbol, avx_intrinsic,   \
+                                neon_intrinsic, after)                         \
+  static inline int _avx512_bitset_container_##opname##_nocard(                \
+      const bitset_container_t *src_1, const bitset_container_t *src_2,        \
+      bitset_container_t *dst) {                                               \
+        const uint8_t * __restrict__ words_1 = (const uint8_t *)src_1->words;  \
+    const uint8_t * __restrict__ words_2 = (const uint8_t *)src_2->words;      \
+    /* not using the blocking optimization for some reason*/                   \
+    uint8_t *out = (uint8_t*)dst->words;                                       \
+    const int innerloop = 8;                                                   \
+    for (size_t i = 0;                                                         \
+        i < BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX512_REG);            \
+                                                         i+=innerloop) {       \
+        __m512i A1, A2, AO;                                                    \
+        A1 = _mm512_loadu_si512((const __m512i *)(words_1));                   \
+        A2 = _mm512_loadu_si512((const __m512i *)(words_2));                   \
+        AO = avx_intrinsic(A2, A1);                                            \
+        _mm512_storeu_si512((__m512i *)out, AO);                               \
+        A1 = _mm512_loadu_si512((const __m512i *)(words_1 + 64));              \
+        A2 = _mm512_loadu_si512((const __m512i *)(words_2 + 64));              \
+        AO = avx_intrinsic(A2, A1);                                            \
+        _mm512_storeu_si512((__m512i *)(out+64), AO);                          \
+        A1 = _mm512_loadu_si512((const __m512i *)(words_1 + 128));             \
+        A2 = _mm512_loadu_si512((const __m512i *)(words_2 + 128));             \
+        AO = avx_intrinsic(A2, A1);                                            \
+        _mm512_storeu_si512((__m512i *)(out+128), AO);                         \
+        A1 = _mm512_loadu_si512((const __m512i *)(words_1 + 192));             \
+        A2 = _mm512_loadu_si512((const __m512i *)(words_2 + 192));             \
+        AO = avx_intrinsic(A2, A1);                                            \
+        _mm512_storeu_si512((__m512i *)(out+192), AO);                         \
+        A1 = _mm512_loadu_si512((const __m512i *)(words_1 + 256));             \
+        A2 = _mm512_loadu_si512((const __m512i *)(words_2 + 256));             \
+        AO = avx_intrinsic(A2, A1);                                            \
+        _mm512_storeu_si512((__m512i *)(out+256), AO);                         \
+        A1 = _mm512_loadu_si512((const __m512i *)(words_1 + 320));             \
+        A2 = _mm512_loadu_si512((const __m512i *)(words_2 + 320));             \
+        AO = avx_intrinsic(A2, A1);                                            \
+        _mm512_storeu_si512((__m512i *)(out+320), AO);                         \
+        A1 = _mm512_loadu_si512((const __m512i *)(words_1 + 384));             \
+        A2 = _mm512_loadu_si512((const __m512i *)(words_2 + 384));             \
+        AO = avx_intrinsic(A2, A1);                                            \
+        _mm512_storeu_si512((__m512i *)(out+384), AO);                         \
+        A1 = _mm512_loadu_si512((const __m512i *)(words_1 + 448));             \
+        A2 = _mm512_loadu_si512((const __m512i *)(words_2 + 448));             \
+        AO = avx_intrinsic(A2, A1);                                     \
+        _mm512_storeu_si512((__m512i *)(out+448), AO);                  \
+        out+=512;                                                       \
+        words_1 += 512;                                                 \
+        words_2 += 512;                                                 \
+    }                                                                   \
+    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;                      \
+    return dst->cardinality;                                            \
+  }
+
+#define AVX512_BITSET_CONTAINER_FN2(before, opname, opsymbol, avx_intrinsic,           \
+                                neon_intrinsic, after)                                 \
+  /* next, a version that updates cardinality*/                                        \
+  static inline int _avx512_bitset_container_##opname(const bitset_container_t *src_1, \
+                                      const bitset_container_t *src_2,         \
+                                      bitset_container_t *dst) {               \
+    const __m512i * __restrict__ words_1 = (const __m512i *) src_1->words; \
+    const __m512i * __restrict__ words_2 = (const __m512i *) src_2->words; \
+    __m512i *out = (__m512i *) dst->words;                              \
+    dst->cardinality = (int32_t)avx512_harley_seal_popcount512andstore_##opname(words_2, \
+    		words_1, out,BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX512_REG)); \
+    return dst->cardinality;                                            \
+  }                                                                            
+
+#define AVX512_BITSET_CONTAINER_FN3(before, opname, opsymbol, avx_intrinsic,               \
+                                neon_intrinsic, after)                                \
+  /* next, a version that just computes the cardinality*/                      \
+  static inline int _avx512_bitset_container_##opname##_justcard(                              \
+      const bitset_container_t *src_1, const bitset_container_t *src_2) {      \
+    const __m512i * __restrict__ data1 = (const __m512i *) src_1->words; \
+    const __m512i * __restrict__ data2 = (const __m512i *) src_2->words; \
+    return (int)avx512_harley_seal_popcount512_##opname(data2,                \
+    		data1, BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX512_REG));\
+  }
+
+
+// we duplicate the function because other containers use the "or" term, makes API more consistent
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, or,    |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, union, |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+
+// we duplicate the function because other containers use the "intersection" term, makes API more consistent
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, and,          &, _mm512_or_si512, vandq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, intersection, &, _mm512_or_si512, vandq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, xor,    ^,  _mm512_or_si512,    veorq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, andnot, &~, _mm512_or_si512, vbicq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+
+// we duplicate the function because other containers use the "or" term, makes API more consistent
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, or,    |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, union, |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+
+// we duplicate the function because other containers use the "intersection" term, makes API more consistent
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, and,          &, _mm512_or_si512, vandq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, intersection, &, _mm512_or_si512, vandq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, xor,    ^,  _mm512_or_si512,    veorq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, andnot, &~, _mm512_or_si512, vbicq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+
+// we duplicate the function because other containers use the "or" term, makes API more consistent
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, or,    |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, union, |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+
+// we duplicate the function because other containers use the "intersection" term, makes API more consistent
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, and,          &, _mm512_or_si512, vandq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, intersection, &, _mm512_or_si512, vandq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, xor,    ^,  _mm512_or_si512,    veorq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+CROARING_TARGET_AVX512
+AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, andnot, &~, _mm512_or_si512, vbicq_u64, CROARING_UNTARGET_REGION)
+CROARING_UNTARGET_REGION
+
 #ifndef WORDS_IN_AVX2_REG
 #define WORDS_IN_AVX2_REG sizeof(__m256i) / sizeof(uint64_t)
 #endif // WORDS_IN_AVX2_REG
@@ -509,7 +683,10 @@ SCALAR_BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
   int bitset_container_##opname(const bitset_container_t *src_1,               \
                                 const bitset_container_t *src_2,               \
                                 bitset_container_t *dst) {                     \
-    if ( croaring_avx2() ) {                                                       \
+    if ( croaring_avx512() ) {                                                 \
+      return _avx512_bitset_container_##opname(src_1, src_2, dst);             \
+    }                                                                          \
+    else if ( croaring_avx2() ) {                                              \
       return _avx2_bitset_container_##opname(src_1, src_2, dst);               \
     } else {                                                                   \
       return _scalar_bitset_container_##opname(src_1, src_2, dst);             \
@@ -518,7 +695,10 @@ SCALAR_BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
   int bitset_container_##opname##_nocard(const bitset_container_t *src_1,      \
                                          const bitset_container_t *src_2,      \
                                          bitset_container_t *dst) {            \
-    if ( croaring_avx2() ) {                                                       \
+    if ( croaring_avx512() ) {                                                 \
+      return _avx512_bitset_container_##opname##_nocard(src_1, src_2, dst);    \
+    }                                                                          \
+    else if ( croaring_avx2() ) {                                              \
       return _avx2_bitset_container_##opname##_nocard(src_1, src_2, dst);      \
     } else {                                                                   \
       return _scalar_bitset_container_##opname##_nocard(src_1, src_2, dst);    \
@@ -526,7 +706,11 @@ SCALAR_BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
   }                                                                            \
   int bitset_container_##opname##_justcard(const bitset_container_t *src_1,    \
                                            const bitset_container_t *src_2) {  \
-    if ((croaring_detect_supported_architectures() & CROARING_AVX2) ==         \
+    if ((croaring_detect_supported_architectures() & CROARING_AVX512) ==       \
+        CROARING_AVX512) {                                                     \
+      return _avx512_bitset_container_##opname##_justcard(src_1, src_2);       \
+    }                                                                          \
+    else if ((croaring_detect_supported_architectures() & CROARING_AVX2) ==    \
         CROARING_AVX2) {                                                       \
       return _avx2_bitset_container_##opname##_justcard(src_1, src_2);         \
     } else {                                                                   \
@@ -693,7 +877,10 @@ int bitset_container_to_uint32_array(
     uint32_t base
 ){
 #ifdef CROARING_IS_X64
-    if(( croaring_avx2() ) &&  (bc->cardinality >= 8192))  // heuristic
+   if(( croaring_avx512() ) &&  (bc->cardinality >= 8192))  // heuristic
+		return (int) bitset_extract_setbits_avx512(bc->words,
+                BITSET_CONTAINER_SIZE_IN_WORDS, out, bc->cardinality, base);
+   else if(( croaring_avx2() ) &&  (bc->cardinality >= 8192))  // heuristic
 		return (int) bitset_extract_setbits_avx2(bc->words,
                 BITSET_CONTAINER_SIZE_IN_WORDS, out, bc->cardinality, base);
 	else
@@ -816,6 +1003,23 @@ bool bitset_container_iterate64(const bitset_container_t *cont, uint32_t base, r
 }
 
 #ifdef CROARING_IS_X64
+CROARING_TARGET_AVX512
+ALLOW_UNALIGNED
+static inline bool _avx512_bitset_container_equals(const bitset_container_t *container1, const bitset_container_t *container2) {
+  const __m512i *ptr1 = (const __m512i*)container1->words;
+  const __m512i *ptr2 = (const __m512i*)container2->words;
+  for (size_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS*sizeof(uint64_t)/64; i++) {
+      __m512i r1 = _mm512_loadu_si512(ptr1+i);
+      __m512i r2 = _mm512_loadu_si512(ptr2+i);
+      __mmask64 mask = _mm512_cmpeq_epi8_mask(r1, r2);
+      if ((uint64_t)mask != UINT64_MAX) {
+          return false;
+      }
+  }
+	return true;
+}
+CROARING_UNTARGET_REGION
+
 CROARING_TARGET_AVX2
 ALLOW_UNALIGNED
 static inline bool _avx2_bitset_container_equals(const bitset_container_t *container1, const bitset_container_t *container2) {
@@ -845,7 +1049,10 @@ bool bitset_container_equals(const bitset_container_t *container1, const bitset_
     }
   }
 #ifdef CROARING_IS_X64
-  if( croaring_avx2() ) {
+  if( croaring_avx512() ) {
+    return _avx512_bitset_container_equals(container1, container2);
+  }
+  else if( croaring_avx2() ) {
     return _avx2_bitset_container_equals(container1, container2);
   }
 #endif

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -53,15 +53,20 @@ bitset_container_t *bitset_container_create(void) {
     if (!bitset) {
         return NULL;
     }
+
+    size_t align_size = 32;
+#ifdef CROARING_IS_X64     
     if ( croaring_avx512() ) {
-        bitset->words = (uint64_t *)roaring_aligned_malloc(
-            64, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+	// sizeof(__m512i) == 64
+	align_size = 64;
     }
     else {
         // sizeof(__m256i) == 32
-        bitset->words = (uint64_t *)roaring_aligned_malloc(
-            32, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+	align_size = 32; 
     }
+#endif
+    bitset->words = (uint64_t *)roaring_aligned_malloc(
+        align_size, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
     if (!bitset->words) {
         roaring_free(bitset);
         return NULL;
@@ -123,15 +128,20 @@ bitset_container_t *bitset_container_clone(const bitset_container_t *src) {
     if (!bitset) {
         return NULL;
     }
+
+    size_t align_size = 32;
+#ifdef CROARING_IS_X64     
     if ( croaring_avx512() ) {
-        bitset->words = (uint64_t *)roaring_aligned_malloc(
-            64, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+	// sizeof(__m512i) == 64
+	align_size = 64;
     }
     else {
         // sizeof(__m256i) == 32
-        bitset->words = (uint64_t *)roaring_aligned_malloc(
-            32, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+	align_size = 32; 
     }
+#endif
+    bitset->words = (uint64_t *)roaring_aligned_malloc(
+        align_size, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
     if (!bitset->words) {
         roaring_free(bitset);
         return NULL;

--- a/src/containers/convert.c
+++ b/src/containers/convert.c
@@ -48,11 +48,19 @@ array_container_t *array_container_from_bitset(const bitset_container_t *bits) {
     array_container_t *result =
         array_container_create_given_capacity(bits->cardinality);
     result->cardinality = bits->cardinality;
-    //  sse version ends up being slower here
-    // (bitset_extract_setbits_sse_uint16)
-    // because of the sparsity of the data
-    bitset_extract_setbits_uint16(bits->words, BITSET_CONTAINER_SIZE_IN_WORDS,
+
+    if( croaring_avx512() ) {
+        bitset_extract_setbits_avx512_uint16(bits->words, BITSET_CONTAINER_SIZE_IN_WORDS,
+                                  result->array, bits->cardinality , 0);
+    }
+    else {
+        //  sse version ends up being slower here
+        // (bitset_extract_setbits_sse_uint16)
+        // because of the sparsity of the data
+        bitset_extract_setbits_uint16(bits->words, BITSET_CONTAINER_SIZE_IN_WORDS,
                                   result->array, 0);
+    }
+	
     return result;
 }
 

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -833,6 +833,48 @@ int run_container_rank(const run_container_t *container, uint16_t x) {
 
 #ifdef CROARING_IS_X64
 
+CROARING_TARGET_AVX512
+ALLOW_UNALIGNED
+/* Get the cardinality of `run'. Requires an actual computation. */
+static inline int _avx512_run_container_cardinality(const run_container_t *run) {
+    const int32_t n_runs = run->n_runs;
+    const rle16_t *runs = run->runs;
+
+    /* by initializing with n_runs, we omit counting the +1 for each pair. */
+    int sum = n_runs;
+    int32_t k = 0;
+    const int32_t step = sizeof(__m512i) / sizeof(rle16_t);
+    if (n_runs > step) {
+        __m512i total = _mm512_setzero_si512();
+        for (; k + step <= n_runs; k += step) {
+            __m512i ymm1 = _mm512_loadu_si512((const __m512i *)(runs + k));
+            __m512i justlengths = _mm512_srli_epi32(ymm1, 16);
+            total = _mm512_add_epi32(total, justlengths);
+        }
+ 
+        __m256i lo = _mm512_extracti32x8_epi32(total, 0);      
+        __m256i hi = _mm512_extracti32x8_epi32(total, 1);
+     
+        // a store might be faster than extract?
+        uint32_t buffer[sizeof(__m256i) / sizeof(rle16_t)];
+        _mm256_storeu_si256((__m256i *)buffer, lo);
+        sum += (buffer[0] + buffer[1]) + (buffer[2] + buffer[3]) +
+               (buffer[4] + buffer[5]) + (buffer[6] + buffer[7]);
+        
+        _mm256_storeu_si256((__m256i *)buffer, hi);
+        sum += (buffer[0] + buffer[1]) + (buffer[2] + buffer[3]) +
+               (buffer[4] + buffer[5]) + (buffer[6] + buffer[7]);
+    
+    }
+    for (; k < n_runs; ++k) {
+        sum += runs[k].length;
+    }
+
+    return sum;
+}
+
+CROARING_UNTARGET_REGION
+
 CROARING_TARGET_AVX2
 ALLOW_UNALIGNED
 /* Get the cardinality of `run'. Requires an actual computation. */
@@ -881,7 +923,10 @@ static inline int _scalar_run_container_cardinality(const run_container_t *run) 
 }
 
 int run_container_cardinality(const run_container_t *run) {
-  if( croaring_avx2() ) {
+  if( croaring_avx512() ) {
+    return _avx512_run_container_cardinality(run);
+  } 
+  else if( croaring_avx2() ) {
     return _avx2_run_container_cardinality(run);
   } else {
     return _scalar_run_container_cardinality(run);

--- a/tools/cmake/FindOptions.cmake
+++ b/tools/cmake/FindOptions.cmake
@@ -36,6 +36,14 @@ else()
 endif()
 endif()
 
+if(FORCE_AVX512) # some compilers like clang do not automagically define __AVX512__ even when the hardware supports it
+if(NOT MSVC)
+   set (OPT_FLAGS "${OPT_FLAGS} -mbmi2 -mavx512f -mavx512bw -mavx512dq")
+else()
+   set (OPT_FLAGS "${OPT_FLAGS} /arch:AVX512")
+endif()
+endif()
+
 if(NOT MSVC)
 set(STD_FLAGS "-std=c11 -fPIC")
 set(CXXSTD_FLAGS "-std=c++11 -fPIC")

--- a/tools/cmake/FindOptions.cmake
+++ b/tools/cmake/FindOptions.cmake
@@ -38,7 +38,7 @@ endif()
 
 if(FORCE_AVX512) # some compilers like clang do not automagically define __AVX512__ even when the hardware supports it
 if(NOT MSVC)
-   set (OPT_FLAGS "${OPT_FLAGS} -mbmi2 -mavx512f -mavx512bw -mavx512dq")
+   set (OPT_FLAGS "${OPT_FLAGS} -mbmi2 -mavx512f -mavx512bw -mavx512dq -mavx512vbmi2 -mavx512bitalg -mavx512vpopcntdq")
 else()
    set (OPT_FLAGS "${OPT_FLAGS} /arch:AVX512")
 endif()


### PR DESCRIPTION
Nowadays icelake servers are widely used.  this patch add avx512 optimization for better performance than avx2.  croaring_avx512() will be true if platform support avx512 during runtime dispatch.

Signed-off-by: lifan lin(lifan.lin@intel.com) 
                        hui han(hui.han@intel.com)

here is the benchmark result(platform icelake 6330), 
Not all operations have improvement, but some operations have  obvious performance boost.
avx2                                          
taskset -c 0 benchmarks/add_benchmark         
[cycles/element]
intvlen=1 density=0.200000 order=SHUFFLE
  roaring_bitmap_add():            62.9
  roaring_bitmap_add_many():       85.5
  roaring_bitmap_add_bulk():       65.4
  roaring_bitmap_add_range():      79.4
  roaring_bitmap_remove():        993.9
  roaring_bitmap_remove_range():   81.6
intvlen=4 density=0.200000 order=SHUFFLE
  roaring_bitmap_add():            24.7
  roaring_bitmap_add_many():       23.7
  roaring_bitmap_add_bulk():       23.1
  roaring_bitmap_add_range():      16.6
  roaring_bitmap_remove():        548.9
  roaring_bitmap_remove_range():   26.8
intvlen=16 density=0.200000 order=SHUFFLE
  roaring_bitmap_add():            15.0
  roaring_bitmap_add_many():       10.8
  roaring_bitmap_add_bulk():       12.6
  roaring_bitmap_add_range():       8.1
  roaring_bitmap_remove():        191.8
  roaring_bitmap_remove_range():   15.4
intvlen=64 density=0.200000 order=SHUFFLE
  roaring_bitmap_add():            13.8
  roaring_bitmap_add_many():        8.7
  roaring_bitmap_add_bulk():       11.4
  roaring_bitmap_add_range():       2.0
  roaring_bitmap_remove():         70.2
  roaring_bitmap_remove_range():    3.4

intvlen=1 density=0.200000 order=ASC
  roaring_bitmap_add():             7.5
  roaring_bitmap_add_many():       13.9
  roaring_bitmap_add_bulk():        6.4
  roaring_bitmap_add_range():      27.8
  roaring_bitmap_remove():        606.3
  roaring_bitmap_remove_range():   41.5
intvlen=4 density=0.200000 order=ASC
  roaring_bitmap_add():             7.1
  roaring_bitmap_add_many():        5.3
  roaring_bitmap_add_bulk():        5.8
  roaring_bitmap_add_range():       6.9
  roaring_bitmap_remove():        389.0
  roaring_bitmap_remove_range():   15.1
intvlen=16 density=0.200000 order=ASC
  roaring_bitmap_add():             6.9
  roaring_bitmap_add_many():        3.6
  roaring_bitmap_add_bulk():        5.7
  roaring_bitmap_add_range():       2.7
  roaring_bitmap_remove():        164.3
  roaring_bitmap_remove_range():    8.2
intvlen=64 density=0.200000 order=ASC
  roaring_bitmap_add():             6.9
  roaring_bitmap_add_many():        3.3
  roaring_bitmap_add_bulk():        5.8
  roaring_bitmap_add_range():       0.8
  roaring_bitmap_remove():         66.1
  roaring_bitmap_remove_range():    1.7

intvlen=1 density=0.200000 order=DESC
  roaring_bitmap_add():            28.5
  roaring_bitmap_add_many():       35.1
  roaring_bitmap_add_bulk():       24.5
  roaring_bitmap_add_range():      34.3
  roaring_bitmap_remove():        884.0
  roaring_bitmap_remove_range():   48.6
intvlen=4 density=0.200000 order=DESC
  roaring_bitmap_add():            17.1
  roaring_bitmap_add_many():       14.1
  roaring_bitmap_add_bulk():       14.0
  roaring_bitmap_add_range():       8.6
  roaring_bitmap_remove():        610.2
  roaring_bitmap_remove_range():   18.1
intvlen=16 density=0.200000 order=DESC
  roaring_bitmap_add():            15.3
  roaring_bitmap_add_many():       10.1
  roaring_bitmap_add_bulk():       12.2
  roaring_bitmap_add_range():       4.3
  roaring_bitmap_remove():        182.8
  roaring_bitmap_remove_range():   10.4
intvlen=64 density=0.200000 order=DESC
  roaring_bitmap_add():            16.1
  roaring_bitmap_add_many():       11.2
  roaring_bitmap_add_bulk():       13.8
  roaring_bitmap_add_range():       0.9
  roaring_bitmap_remove():         67.2
  roaring_bitmap_remove_range():    2.0

avx512
taskset -c 0 benchmarks/add_benchmark
[cycles/element]
intvlen=1 density=0.200000 order=SHUFFLE
  roaring_bitmap_add():            64.7
  roaring_bitmap_add_many():       86.4
  roaring_bitmap_add_bulk():       66.5
  roaring_bitmap_add_range():      82.5
  roaring_bitmap_remove():        852.2
  roaring_bitmap_remove_range():   78.1
intvlen=4 density=0.200000 order=SHUFFLE
  roaring_bitmap_add():            25.7
  roaring_bitmap_add_many():       24.6
  roaring_bitmap_add_bulk():       23.0
  roaring_bitmap_add_range():      17.4
  roaring_bitmap_remove():        391.7
  roaring_bitmap_remove_range():   24.5
intvlen=16 density=0.200000 order=SHUFFLE
  roaring_bitmap_add():            15.3
  roaring_bitmap_add_many():       11.7
  roaring_bitmap_add_bulk():       13.1
  roaring_bitmap_add_range():       8.1
  roaring_bitmap_remove():        126.0
  roaring_bitmap_remove_range():   13.1
intvlen=64 density=0.200000 order=SHUFFLE
  roaring_bitmap_add():            14.5
  roaring_bitmap_add_many():        9.5
  roaring_bitmap_add_bulk():       11.6
  roaring_bitmap_add_range():       2.0
  roaring_bitmap_remove():         57.1
  roaring_bitmap_remove_range():    2.9

intvlen=1 density=0.200000 order=ASC
  roaring_bitmap_add():             8.4
  roaring_bitmap_add_many():       15.0
  roaring_bitmap_add_bulk():        6.9
  roaring_bitmap_add_range():      31.6
  roaring_bitmap_remove():        374.2
  roaring_bitmap_remove_range():   36.9
intvlen=4 density=0.200000 order=ASC
  roaring_bitmap_add():             7.7
  roaring_bitmap_add_many():        6.1
  roaring_bitmap_add_bulk():        6.2
  roaring_bitmap_add_range():       7.9
  roaring_bitmap_remove():        226.5
  roaring_bitmap_remove_range():   12.5
intvlen=16 density=0.200000 order=ASC
  roaring_bitmap_add():             7.4
  roaring_bitmap_add_many():        4.4
  roaring_bitmap_add_bulk():        6.0
  roaring_bitmap_add_range():       2.9
  roaring_bitmap_remove():        103.1
  roaring_bitmap_remove_range():    6.2
intvlen=64 density=0.200000 order=ASC
  roaring_bitmap_add():             7.6
  roaring_bitmap_add_many():        4.0
  roaring_bitmap_add_bulk():        6.3
  roaring_bitmap_add_range():       0.9
  roaring_bitmap_remove():         51.6
  roaring_bitmap_remove_range():    1.4

intvlen=1 density=0.200000 order=DESC
  roaring_bitmap_add():            28.8
  roaring_bitmap_add_many():       35.7
  roaring_bitmap_add_bulk():       24.7
  roaring_bitmap_add_range():      38.2
  roaring_bitmap_remove():        752.7
  roaring_bitmap_remove_range():   46.5
intvlen=4 density=0.200000 order=DESC
  roaring_bitmap_add():            17.5
  roaring_bitmap_add_many():       15.0
  roaring_bitmap_add_bulk():       14.4
  roaring_bitmap_add_range():       9.4
  roaring_bitmap_remove():        466.9
  roaring_bitmap_remove_range():   16.6
intvlen=16 density=0.200000 order=DESC
  roaring_bitmap_add():            15.2
  roaring_bitmap_add_many():       10.9
  roaring_bitmap_add_bulk():       12.2
  roaring_bitmap_add_range():       4.4
  roaring_bitmap_remove():        124.5
  roaring_bitmap_remove_range():    8.9
intvlen=64 density=0.200000 order=DESC
  roaring_bitmap_add():            17.1
  roaring_bitmap_add_many():       12.0
  roaring_bitmap_add_bulk():       14.3
  roaring_bitmap_add_range():       0.9
  roaring_bitmap_remove():         57.1
  roaring_bitmap_remove_range():    1.8

avx2
taskset -c 0 benchmarks/bitset_container_benchmark
bitset container benchmarks
set_test(B):  1.50 cycles per operation
get_test(B):  0.96 cycles per operation
bitset_container_cardinality(B):  201.00 cycles per operation
bitset_container_compute_cardinality(B):  0.40 cycles per operation
unset_test(B):  1.51 cycles per operation

 number of values in container = 4096
bitset_container_to_uint32_array(out, Bt, 1234):  0.89 cycles per operation
bitset_container_get bitset_cache_prefetch:  205.69 cycles per operation
bitset_container_get bitset_cache_flush:  327.49 cycles per operation

 number of values in container = 8192
bitset_container_to_uint32_array(out, Bt, 1234):  1.16 cycles per operation
bitset_container_get bitset_cache_prefetch:  208.41 cycles per operation
bitset_container_get bitset_cache_flush:  312.30 cycles per operation

 number of values in container = 16384
bitset_container_to_uint32_array(out, Bt, 1234):  0.60 cycles per operation
bitset_container_get bitset_cache_prefetch:  210.64 cycles per operation
bitset_container_get bitset_cache_flush:  308.05 cycles per operation

 number of values in container = 32768
bitset_container_to_uint32_array(out, Bt, 1234):  0.30 cycles per operation
bitset_container_get bitset_cache_prefetch:  206.42 cycles per operation
bitset_container_get bitset_cache_flush:  309.61 cycles per operation

 number of values in container = 65536
bitset_container_to_uint32_array(out, Bt, 1234):  0.17 cycles per operation
bitset_container_get bitset_cache_prefetch:  212.69 cycles per operation
bitset_container_get bitset_cache_flush:  317.35 cycles per operation


Logical operations (time units per single operation):
bitset_container_and_nocard(B1, B2, BO):  507.00 cycles per operation
bitset_container_and(B1, B2, BO):  534.00 cycles per operation
bitset_container_and_justcard(B1, B2):  353.00 cycles per operation
bitset_container_compute_cardinality(BO):  417.00 cycles per operation
bitset_container_or_nocard(B1, B2, BO):  628.00 cycles per operation
bitset_container_or(B1, B2, BO):  528.00 cycles per operation
bitset_container_or_justcard(B1, B2):  351.00 cycles per operation
bitset_container_compute_cardinality(BO):  419.00 cycles per operation

get_cardinality_through_conversion_to_array(B1):  4.28 cycles per operation

avx512
taskset -c 0 benchmarks/bitset_container_benchmark
bitset container benchmarks
set_test(B):  2.40 cycles per operation
get_test(B):  1.14 cycles per operation
bitset_container_cardinality(B):  203.00 cycles per operation
bitset_container_compute_cardinality(B):  0.31 cycles per operation
unset_test(B):  2.41 cycles per operation

 number of values in container = 4096
bitset_container_to_uint32_array(out, Bt, 1234):  0.96 cycles per operation
bitset_container_get bitset_cache_prefetch:  209.76 cycles per operation
bitset_container_get bitset_cache_flush:  207.77 cycles per operation

 number of values in container = 8192
bitset_container_to_uint32_array(out, Bt, 1234):  0.73 cycles per operation
bitset_container_get bitset_cache_prefetch:  209.72 cycles per operation
bitset_container_get bitset_cache_flush:  208.29 cycles per operation

 number of values in container = 16384
bitset_container_to_uint32_array(out, Bt, 1234):  0.36 cycles per operation
bitset_container_get bitset_cache_prefetch:  210.37 cycles per operation
bitset_container_get bitset_cache_flush:  207.80 cycles per operation

 number of values in container = 32768
bitset_container_to_uint32_array(out, Bt, 1234):  0.21 cycles per operation
bitset_container_get bitset_cache_prefetch:  208.17 cycles per operation
bitset_container_get bitset_cache_flush:  208.69 cycles per operation

 number of values in container = 65536
bitset_container_to_uint32_array(out, Bt, 1234):  0.13 cycles per operation
bitset_container_get bitset_cache_prefetch:  207.84 cycles per operation
bitset_container_get bitset_cache_flush:  208.03 cycles per operation


Logical operations (time units per single operation):
bitset_container_and_nocard(B1, B2, BO):  392.00 cycles per operation
bitset_container_and(B1, B2, BO):  424.00 cycles per operation
bitset_container_and_justcard(B1, B2):  333.00 cycles per operation
bitset_container_compute_cardinality(BO):  322.00 cycles per operation
bitset_container_or_nocard(B1, B2, BO):  392.00 cycles per operation
bitset_container_or(B1, B2, BO):  424.00 cycles per operation
bitset_container_or_justcard(B1, B2):  337.00 cycles per operation
bitset_container_compute_cardinality(BO):  316.00 cycles per operation

get_cardinality_through_conversion_to_array(B1):  4.30 cycles per operation
