### PR TITLE
enabling fast inplace routines (tentative)

### DIFF
--- a/include/roaring/array_util.h
+++ b/include/roaring/array_util.h
@@ -208,21 +208,21 @@ size_t union_uint32(const uint32_t *set_1, size_t size_1, const uint32_t *set_2,
 /**
  * A fast SSE-based union function.
  */
-uint32_t union_vector16(const uint16_t *__restrict__ set_1, uint32_t size_1,
-                        const uint16_t *__restrict__ set_2, uint32_t size_2,
-                        uint16_t *__restrict__ buffer);
+uint32_t union_vector16(const uint16_t * set_1, uint32_t size_1,
+                        const uint16_t * set_2, uint32_t size_2,
+                        uint16_t * buffer);
 /**
  * A fast SSE-based XOR function.
  */
-uint32_t xor_vector16(const uint16_t *__restrict__ array1, uint32_t length1,
-                      const uint16_t *__restrict__ array2, uint32_t length2,
-                      uint16_t *__restrict__ output);
+uint32_t xor_vector16(const uint16_t * array1, uint32_t length1,
+                      const uint16_t * array2, uint32_t length2,
+                      uint16_t * output);
 
 /**
  * A fast SSE-based difference function.
  */
-int32_t difference_vector16(const uint16_t *__restrict__ A, size_t s_a,
-                            const uint16_t *__restrict__ B, size_t s_b,
+int32_t difference_vector16(const uint16_t * A, size_t s_a,
+                            const uint16_t * B, size_t s_b,
                             uint16_t *C);
 
 /**
@@ -232,8 +232,8 @@ size_t union_uint32_card(const uint32_t *set_1, size_t size_1,
                          const uint32_t *set_2, size_t size_2);
 
 /**
-* combines union_uint16 and  union_vector16 optimally
-*/
+ * combines union_uint16 and union_vector16 optimally
+ */
 size_t fast_union_uint16(const uint16_t *set_1, size_t size_1, const uint16_t *set_2,
                     size_t size_2, uint16_t *buffer);
 

--- a/include/roaring/containers/mixed_intersection.h
+++ b/include/roaring/containers/mixed_intersection.h
@@ -38,7 +38,7 @@ bool array_bitset_container_intersect(const array_container_t *src_1,
 
 /*
  * Compute the intersection between src_1 and src_2 and write the result
- * to *dst. If the return function is true, the result is a bitset_container_t
+ * to *dst. If the return function is true, the result is a bitset_container_t,
  * otherwise is a array_container_t. We assume that dst is not pre-allocated. In
  * case of failure, *dst will be NULL.
  */
@@ -54,7 +54,7 @@ void array_run_container_intersection(const array_container_t *src_1,
                                       array_container_t *dst);
 
 /* Compute the intersection between src_1 and src_2 and write the result to
- * *dst. If the result is true then the result is a bitset_container_t
+ * *dst. If the result is true then the result is a bitset_container_t,
  * otherwise is a array_container_t.
  * If *dst == src_2, then an in-place intersection is attempted
  **/

--- a/include/roaring/containers/mixed_union.h
+++ b/include/roaring/containers/mixed_union.h
@@ -34,7 +34,7 @@ void array_bitset_container_lazy_union(const array_container_t *src_1,
 
 /*
  * Compute the union between src_1 and src_2 and write the result
- * to *dst. If the return function is true, the result is a bitset_container_t
+ * to *dst. If the return function is true, the result is a bitset_container_t,
  * otherwise is a array_container_t. We assume that dst is not pre-allocated. In
  * case of failure, *dst will be NULL.
  */

--- a/src/array_util.c
+++ b/src/array_util.c
@@ -611,12 +611,8 @@ int32_t intersect_vector16_cardinality(const uint16_t *__restrict__ A,
 CROARING_UNTARGET_REGION
 
 CROARING_TARGET_AVX2
-/////////
-// Warning:
-// This function may not be safe if A == C or B == C.
-/////////
-int32_t difference_vector16(const uint16_t *__restrict__ A, size_t s_a,
-                            const uint16_t *__restrict__ B, size_t s_b,
+int32_t difference_vector16(const uint16_t * A, size_t s_a,
+                            const uint16_t * B, size_t s_b,
                             uint16_t *C) {
     // we handle the degenerate case
     if (s_a == 0) return 0;
@@ -1621,10 +1617,9 @@ static int uint16_compare(const void *a, const void *b) {
 
 CROARING_TARGET_AVX2
 // a one-pass SSE union algorithm
-// This function may not be safe if array1 == output or array2 == output.
-uint32_t union_vector16(const uint16_t *__restrict__ array1, uint32_t length1,
-                        const uint16_t *__restrict__ array2, uint32_t length2,
-                        uint16_t *__restrict__ output) {
+uint32_t union_vector16(const uint16_t * array1, uint32_t length1,
+                        const uint16_t * array2, uint32_t length2,
+                        uint16_t * output) {
     if ((length1 < 8) || (length2 < 8)) {
         return (uint32_t)union_uint16(array1, length1, array2, length2, output);
     }
@@ -1746,9 +1741,9 @@ static inline uint32_t unique_xor(uint16_t *out, uint32_t len) {
 }
 CROARING_TARGET_AVX2
 // a one-pass SSE xor algorithm
-uint32_t xor_vector16(const uint16_t *__restrict__ array1, uint32_t length1,
-                      const uint16_t *__restrict__ array2, uint32_t length2,
-                      uint16_t *__restrict__ output) {
+uint32_t xor_vector16(const uint16_t * array1, uint32_t length1,
+                      const uint16_t * array2, uint32_t length2,
+                      uint16_t * output) {
     if ((length1 < 8) || (length2 < 8)) {
         return xor_uint16(array1, length1, array2, length2, output);
     }

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -217,7 +217,7 @@ void array_container_andnot(const array_container_t *array_1,
     if (out->capacity < array_1->cardinality)
         array_container_grow(out, array_1->cardinality, false);
 #ifdef CROARING_IS_X64
-    if(( croaring_avx2() ) && (out != array_1) && (out != array_2)) {
+    if( croaring_avx2() ) {
       out->cardinality =
           difference_vector16(array_1->array, array_1->cardinality,
                             array_2->array, array_2->cardinality, out->array);

--- a/src/containers/mixed_intersection.c
+++ b/src/containers/mixed_intersection.c
@@ -110,7 +110,7 @@ void array_run_container_intersection(const array_container_t *src_1,
 }
 
 /* Compute the intersection of src_1 and src_2 and write the result to
- * *dst. If the result is true then the result is a bitset_container_t
+ * *dst. If the result is true then the result is a bitset_container_t,
  * otherwise is a array_container_t. If *dst ==  src_2, an in-place processing
  * is attempted.*/
 bool run_bitset_container_intersection(
@@ -299,7 +299,7 @@ bool run_bitset_container_intersect(const run_container_t *src_1,
 
 /*
  * Compute the intersection between src_1 and src_2 and write the result
- * to *dst. If the return function is true, the result is a bitset_container_t
+ * to *dst. If the return function is true, the result is a bitset_container_t,
  * otherwise is a array_container_t.
  */
 bool bitset_bitset_container_intersection(

--- a/src/containers/mixed_union.c
+++ b/src/containers/mixed_union.c
@@ -206,7 +206,7 @@ bool array_array_container_inplace_union(
           return false;  // not a bitset
         } else {
           memmove(src_1->array + src_2->cardinality, src_1->array, src_1->cardinality * sizeof(uint16_t));
-          src_1->cardinality = (int32_t)union_uint16(src_1->array + src_2->cardinality, src_1->cardinality,
+          src_1->cardinality = (int32_t)fast_union_uint16(src_1->array + src_2->cardinality, src_1->cardinality,
                                   src_2->array, src_2->cardinality, src_1->array);
           return false; // not a bitset
         }
@@ -302,7 +302,7 @@ bool array_array_container_lazy_inplace_union(
           return false;  // not a bitset
         } else {
           memmove(src_1->array + src_2->cardinality, src_1->array, src_1->cardinality * sizeof(uint16_t));
-          src_1->cardinality = (int32_t)union_uint16(src_1->array + src_2->cardinality, src_1->cardinality,
+          src_1->cardinality = (int32_t)fast_union_uint16(src_1->array + src_2->cardinality, src_1->cardinality,
                                   src_2->array, src_2->cardinality, src_1->array);
           return false; // not a bitset
         }

--- a/tests/bitset_container_unit.c
+++ b/tests/bitset_container_unit.c
@@ -116,8 +116,8 @@ DEFINE_TEST(and_or_test) {
 
     size_t max_value = 60000;
 
-    size_t b1_count = 0;
-    size_t bi_count = 0;
+    int b1_count = 0;
+    int bi_count = 0;
     for (size_t x = 0; x < max_value; x += 3) {
         bitset_container_set(B1, x);
         bitset_container_set(BI, x);
@@ -132,7 +132,7 @@ DEFINE_TEST(and_or_test) {
     assert_true(bitset_container_compute_cardinality(B1) == b1_count);
     assert_true(bitset_container_compute_cardinality(BI) == bi_count);
 
-    size_t b2_count = 0;
+    int b2_count = 0;
     // important: 62 is not divisible by 3
     for (size_t x = 0; x < max_value; x += 62) {
         bi_count += !bitset_container_get(BI, x);
@@ -144,7 +144,7 @@ DEFINE_TEST(and_or_test) {
 
     assert_true(bitset_container_compute_cardinality(B2) == b2_count);
     assert_true(bitset_container_compute_cardinality(BI) == bi_count);
-    size_t bo_count = 0;
+    int bo_count = 0;
     for (size_t x = 0; x < max_value; x += 62 * 3) {
         bitset_container_set(BO, x);
         bo_count++;
@@ -168,7 +168,7 @@ DEFINE_TEST(and_or_test) {
     bitset_container_printf(B1);  // does it crash?
     bitset_container_printf(B2);  // does it crash?
     bitset_container_printf(BI);  // does it crash?
-    size_t interc = 0;
+    int interc = 0;
     for (size_t x = 0; x < max_value; x ++) {
         bool in1 = bitset_container_get(B1, x);
         bool in2 = bitset_container_get(B2, x);


### PR DESCRIPTION
In several instance, fast routines are disabled as a safety precaution. For better performance, we should see whether they can be enabled.

This is an extension of https://github.com/RoaringBitmap/CRoaring/pull/452 by @CharlesChen888 