### PR TITLE
Issue 457

### DIFF
--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -131,7 +131,7 @@ void run_container_offset(const run_container_t *c,
         lo_cap = c->n_runs;
         hi_cap = 0;
     } else {
-        split = c->runs[pivot].value <= top;
+        split = c->runs[pivot].value < top;
         lo_cap = pivot + (split ? 1 : 0);
         hi_cap = c->n_runs - pivot;
     }

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -46,6 +46,17 @@ bool roaring_iterator_sumall(uint32_t value, void *param) {
     *(uint32_t *)param += value;
     return true;  // continue till the end
 }
+DEFINE_TEST(issue457) {
+  roaring_bitmap_t *r1 = roaring_bitmap_from_range(65539, 65541, 1);
+  roaring_bitmap_printf_describe(r1);
+  assert_true(roaring_bitmap_get_cardinality(r1) == 2);
+  roaring_bitmap_t *r2 = roaring_bitmap_add_offset(r1, -3);
+  roaring_bitmap_printf_describe(r2);
+  assert_true(roaring_bitmap_get_cardinality(r2) == 2);
+  roaring_bitmap_printf(r2);
+  roaring_bitmap_free(r1);
+  roaring_bitmap_free(r2);
+}
 
 DEFINE_TEST(issue429) {
   // This is a memory leak test, so we don't need to check the results.
@@ -4440,6 +4451,7 @@ int main() {
     tellmeall();
 
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(issue457),
         cmocka_unit_test(convert_to_bitset),
         cmocka_unit_test(issue440),
         cmocka_unit_test(issue436),


### PR DESCRIPTION
It is a silly "off by one" bug which triggers an overflow.

Fix https://github.com/RoaringBitmap/CRoaring/issues/457

Thanks to @Ezibenroc  for the report.