### PR TITLE
fix missing semicolon

### DIFF
--- a/src/isadetection.c
+++ b/src/isadetection.c
@@ -230,7 +230,7 @@ int croaring_hardware_support() {
 
 #elif defined(__AVX512F__) && defined(__AVX512DQ__) && defined(__AVX512BW__) && defined(__AVX512VBMI2__) && defined(__AVX512BITALG__) && defined(__AVX512VPOPCNTDQ__)
 int croaring_hardware_support() {
-    return  ROARING_SUPPORTS_AVX2 | ROARING_SUPPORTS_AVX512
+    return  ROARING_SUPPORTS_AVX2 | ROARING_SUPPORTS_AVX512;
 }
 #elif defined(__AVX2__)
 


### PR DESCRIPTION
I'm getting amalgamation build failures due to a missing semicolon in `isadetection.c`. 