### PR TITLE
fix the order of #endif for non X64 and compiling in cpp

### DIFF
--- a/src/isadetection.c
+++ b/src/isadetection.c
@@ -262,7 +262,7 @@ int croaring_hardware_support() {
 }
 #endif
 
+#endif // defined(__x86_64__) || defined(_M_AMD64) // x64
 #ifdef __cplusplus
 } } }  // extern "C" { namespace roaring { namespace internal {
 #endif
-#endif // defined(__x86_64__) || defined(_M_AMD64) // x64


### PR DESCRIPTION
It seems that when compiling croaring in C++ in a non X64 machine the compilation fails.
The reason seems to be the fact that 
```
#ifdef __cplusplus
} } }  // extern "C" { namespace roaring { namespace internal {
#endif
```
must be after `#endif // defined(__x86_64__) || defined(_M_AMD64) // x64` and not before

Changes:
- fix the order of #endif for when defined(__x86_64__) || defined(_M_AMD64) is false and __cplusplus is true
