### PR TITLE
ignore `dependencies/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Downloaded dependencies
 tests/vendor/cmocka
+dependencies
 
 # Object files
 *.o


### PR DESCRIPTION
I use `CRoaring` as an sub_module , but after `cmake` there will leave an annoying empty `dependency/` dir.
don't know why , just ignore it.