### PR TITLE
Reference actions by commit SHA

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -8,7 +8,7 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: start docker
         run: |
           docker run -w /src -dit --name alpine -v $PWD:/src alpine:latest

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -8,12 +8,12 @@ jobs:
     steps:
     - name: Build Fuzzers
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@d318097b285bc695f785b98d40c2d058c0f438b5 # master
       with:
         oss-fuzz-project-name: 'croaring'
         dry-run: false
     - name: Run Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@d318097b285bc695f785b98d40c2d058c0f438b5 # master
       with:
         oss-fuzz-project-name: 'croaring'
         fuzz-seconds: 300

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -19,7 +19,7 @@ jobs:
         fuzz-seconds: 300
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,15 +30,15 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@f3feb00acb00f31a6f60280e6ace9ca31d91c76a # v2.3.2
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@f3feb00acb00f31a6f60280e6ace9ca31d91c76a # v2.3.2
         if: ${{ matrix.language == 'cpp' || matrix.language == 'python' }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@f3feb00acb00f31a6f60280e6ace9ca31d91c76a # v2.3.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Generate Doxygen Documentation
         run: doxygen ./doxygen
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/html

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,7 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Install Doxygen
         run: sudo apt-get install doxygen graphviz -y
       - run: mkdir docs

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: macos-llvm
     runs-on: macos-latest
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Build and Test
         run: |
           mkdir build

--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: uraimo/run-on-arch-action@v2
         name: Test
         id: runcmd

--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: uraimo/run-on-arch-action@v2
+      - uses: uraimo/run-on-arch-action@a8003307a739516fdd80ee6d3da8924db811b8da # v2.5.0
         name: Test
         id: runcmd
         with:

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -17,7 +17,7 @@ jobs:
       CXX: g++
 
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Build and Test
         run: |
           mkdir build

--- a/.github/workflows/ubuntu-debug-sani-ci.yml
+++ b/.github/workflows/ubuntu-debug-sani-ci.yml
@@ -17,7 +17,7 @@ jobs:
       CXX: g++
 
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Build and Test
         run: |
           mkdir build

--- a/.github/workflows/ubuntu-gcc10-ci.yml
+++ b/.github/workflows/ubuntu-gcc10-ci.yml
@@ -15,7 +15,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - run:   |
          sudo apt update
          sudo apt install gcc-10 g++-10

--- a/.github/workflows/ubuntu-legacy-ci.yml
+++ b/.github/workflows/ubuntu-legacy-ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Build and Test
         run: |
           mkdir build

--- a/.github/workflows/ubuntu-noexcept-ci.yml
+++ b/.github/workflows/ubuntu-noexcept-ci.yml
@@ -17,7 +17,7 @@ jobs:
       CXX: g++
 
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Build and Test
         run: |
           mkdir build

--- a/.github/workflows/ubuntu-sani-ci.yml
+++ b/.github/workflows/ubuntu-sani-ci.yml
@@ -17,7 +17,7 @@ jobs:
       CXX: g++
 
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Build and Test
         run: |
           mkdir build

--- a/.github/workflows/vs16-arm-ci.yml
+++ b/.github/workflows/vs16-arm-ci.yml
@@ -17,7 +17,7 @@ jobs:
           - {gen: Visual Studio 16 2019, arch: ARM64}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Configure
         run: |
           mkdir build

--- a/.github/workflows/vs16-ci.yml
+++ b/.github/workflows/vs16-ci.yml
@@ -17,7 +17,7 @@ jobs:
           - {gen: Visual Studio 16 2019, arch: x64}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Configure
         run: |
           mkdir build

--- a/.github/workflows/vs17-arm-ci.yml
+++ b/.github/workflows/vs17-arm-ci.yml
@@ -17,7 +17,7 @@ jobs:
           - {arch: ARM64}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Use cmake
         run: |
           cmake -A ${{ matrix.arch }} -DCMAKE_CROSSCOMPILING=1 -B build  &&

--- a/.github/workflows/vs17-ci.yml
+++ b/.github/workflows/vs17-ci.yml
@@ -17,7 +17,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: x64}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Configure
         run: |
           mkdir build

--- a/.github/workflows/vs17-clang-ci.yml
+++ b/.github/workflows/vs17-clang-ci.yml
@@ -17,7 +17,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: x64}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Configure
         run: |
           mkdir build


### PR DESCRIPTION
Closes https://github.com/RoaringBitmap/CRoaring/issues/467

FYI I have verified that all SHAs belong to the original repositories, not forks, which is a caution we must have.

------

Refs:
https://github.com/actions/checkout/releases/tag/v2.7.0
https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5

https://github.com/actions/checkout/releases/tag/v3.5.2
https://github.com/actions/checkout/commit/8e5e7e5ab8b370d6c329ec480221332ada57f0ab

https://github.com/google/oss-fuzz/commit/d318097b285bc695f785b98d40c2d058c0f438b5

https://github.com/actions/upload-artifact/releases/tag/v3.1.2
https://github.com/actions/upload-artifact/commit/0b7f8abb1508181956e8e162db84b466c27e18ce

https://github.com/github/codeql-action/releases/tag/v2.3.2 
https://github.com/github/codeql-action/commit/f3feb00acb00f31a6f60280e6ace9ca31d91c76a

https://github.com/peaceiris/actions-gh-pages/releases/tag/v3.9.3
https://github.com/peaceiris/actions-gh-pages/commit/373f7f263a76c20808c831209c920827a82a2847 

https://github.com/uraimo/run-on-arch-action/releases/tag/v2.5.0
https://github.com/uraimo/run-on-arch-action/commit/a8003307a739516fdd80ee6d3da8924db811b8da

