### PR TITLE
add get_idx function to return the 1 index of x

### DIFF
--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -500,6 +500,17 @@ public:
     }
 
     /**
+     * Returns the 1 index of x in the bitmap.
+     * If the bitmap dosen't contain x , this function will return -1.
+     * The difference with rank function is that this function will return -1
+     * when x isn't in the bitmap, but the rank funciton will return a
+     * non-negative number.
+     */
+    int64_t get_idx(uint32_t x) const noexcept {
+        return api::roaring_bitmap_get_idx(&roaring, x);
+    }
+
+    /**
      * Write a bitmap to a char buffer. This is meant to be compatible with
      * the Java and Go versions. Returns how many bytes were written which
      * should be getSizeInBytes().

--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -410,6 +410,17 @@ inline int array_container_rank(const array_container_t *arr, uint16_t x) {
     }
 }
 
+/* Returns the 1 idx of x , if not exsist return -1 */
+inline int array_container_get_idx(const array_container_t *arr, uint16_t x) {
+    const int32_t idx = binarySearch(arr->array, arr->cardinality, x);
+    const bool is_present = idx >= 0;
+    if (is_present) {
+        return idx + 1;
+    } else {
+        return -1;
+    }
+}
+
 /* Returns the index of the first value equal or smaller than x, or -1 */
 inline int array_container_index_equalorlarger(const array_container_t *arr, uint16_t x) {
     const int32_t idx = binarySearch(arr->array, arr->cardinality, x);

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -481,6 +481,9 @@ uint16_t bitset_container_maximum(const bitset_container_t *container);
 /* Returns the number of values equal or smaller than x */
 int bitset_container_rank(const bitset_container_t *container, uint16_t x);
 
+/* Returns the 1 idx of x , if not exsist return -1 */
+int bitset_container_get_idx(const bitset_container_t *container, uint16_t x);
+
 /* Returns the index of the first value equal or larger than x, or -1 */
 int bitset_container_index_equalorlarger(const bitset_container_t *container, uint16_t x);
 

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -2329,6 +2329,26 @@ static inline int container_rank(
     return false;
 }
 
+// return the 1 idx of x, if not exsist return -1
+static inline int container_get_idx(const container_t *c, uint8_t type,
+                                    uint16_t x) {
+    c = container_unwrap_shared(c, &type);
+    switch (type) {
+        case BITSET_CONTAINER_TYPE:
+            return bitset_container_get_idx(const_CAST_bitset(c), x);
+        case ARRAY_CONTAINER_TYPE:
+            return array_container_get_idx(const_CAST_array(c), x);
+        case RUN_CONTAINER_TYPE:
+            return run_container_get_idx(const_CAST_run(c), x);
+        default:
+            assert(false);
+            roaring_unreachable;
+    }
+    assert(false);
+    roaring_unreachable;
+    return false;
+}
+
 /**
  * Add all values in range [min, max] to a given container.
  *

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -559,6 +559,9 @@ inline uint16_t run_container_maximum(const run_container_t *run) {
 /* Returns the number of values equal or smaller than x */
 int run_container_rank(const run_container_t *arr, uint16_t x);
 
+/* Returns the 1 idx of x, if not exsist return -1 */
+int run_container_get_idx(const run_container_t *arr, uint16_t x);
+
 /* Returns the index of the first run containing a value at least as large as x, or -1 */
 inline int run_container_index_equalorlarger(const run_container_t *arr, uint16_t x) {
     int32_t index = interleavedBinarySearch(arr->runs, arr->n_runs, x);

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -800,6 +800,15 @@ bool roaring_bitmap_select(const roaring_bitmap_t *r, uint32_t rank,
 uint64_t roaring_bitmap_rank(const roaring_bitmap_t *r, uint32_t x);
 
 /**
+ * Returns the 1 index of x in the given roaring bitmap.
+ * If the roaring bitmap dosen't contain x , this function will return -1.
+ * The difference with rank function is that this function will return -1 when x
+ * is not the element of roaring bitmap, but the rank funciton will return a
+ * non-negative number.
+ */
+int64_t roaring_bitmap_get_idx(const roaring_bitmap_t *r, uint32_t x);
+
+/**
  * Returns the smallest value in the set, or UINT32_MAX if the set is empty.
  */
 uint32_t roaring_bitmap_minimum(const roaring_bitmap_t *r);

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -25,6 +25,8 @@ extern inline int array_container_index_equalorlarger(const array_container_t *a
 
 extern inline int array_container_rank(const array_container_t *arr,
                                        uint16_t x);
+extern inline int array_container_get_idx(const array_container_t *arr,
+                                          uint16_t x);
 extern inline bool array_container_contains(const array_container_t *arr,
                                             uint16_t pos);
 extern inline int array_container_cardinality(const array_container_t *array);

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -1212,6 +1212,25 @@ int bitset_container_rank(const bitset_container_t *container, uint16_t x) {
   return sum;
 }
 
+/* Returns the 1 idx of x , if not exsist return -1 */
+int bitset_container_get_idx(const bitset_container_t *container, uint16_t x) {
+  if (bitset_container_get(container, x)) {
+    // credit: aqrit
+    int sum = 0;
+    int i = 0;
+    for (int end = x / 64; i < end; i++){
+      sum += roaring_hamming(container->words[i]);
+    }
+    uint64_t lastword = container->words[i];
+    uint64_t lastpos = UINT64_C(1) << (x % 64);
+    uint64_t mask = lastpos + lastpos - 1; // smear right
+    sum += roaring_hamming(lastword & mask);
+    return sum;
+  } else {
+    return -1;
+  }
+}
+
 /* Returns the index of the first value equal or larger than x, or -1 */
 int bitset_container_index_equalorlarger(const bitset_container_t *container, uint16_t x) {
   uint32_t x32 = x;

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -837,6 +837,27 @@ int run_container_rank(const run_container_t *container, uint16_t x) {
     return sum;
 }
 
+int run_container_get_idx(const run_container_t *container, uint16_t x) {
+    if (run_container_contains(container, x)) {
+        int sum = 0;
+        uint32_t x32 = x;
+        for (int i = 0; i < container->n_runs; i++) {
+            uint32_t startpoint = container->runs[i].value;
+            uint32_t length = container->runs[i].length;
+            uint32_t endpoint = length + startpoint;
+            if (x <= endpoint) {
+                if (x < startpoint) break;
+                return sum + (x32 - startpoint) + 1;
+            } else {
+                sum += length + 1;
+            }
+        }
+        return sum;
+    } else {
+        return -1;
+    }
+}
+
 #if defined(CROARING_IS_X64) && CROARING_COMPILER_SUPPORTS_AVX512
 
 CROARING_TARGET_AVX512

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2678,6 +2678,34 @@ uint64_t roaring_bitmap_rank(const roaring_bitmap_t *bm, uint32_t x) {
 }
 
 /**
+ * roaring_bitmap_get_idx returns the 1 idx of x, if not exsist return -1.
+ */
+int64_t roaring_bitmap_get_idx(const roaring_bitmap_t *bm, uint32_t x) {
+    int64_t index = 0;
+    const uint16_t xhigh = x >> 16;
+    int32_t high_idx = ra_get_index(&bm->high_low_container, xhigh);
+    if (high_idx < 0) return -1;
+
+    for (int i = 0; i < bm->high_low_container.size; i++) {
+        uint32_t key = bm->high_low_container.keys[i];
+        if (xhigh > key) {
+            index +=
+                container_get_cardinality(bm->high_low_container.containers[i],
+                                          bm->high_low_container.typecodes[i]);
+        } else if (xhigh == key) {
+            int32_t low_idx = container_get_idx(
+                bm->high_low_container.containers[high_idx],
+                bm->high_low_container.typecodes[high_idx], x & 0xFFFF);
+            if (low_idx < 0) return -1;
+            return index + low_idx;
+        } else {
+            return -1;
+        }
+    }
+    return index;
+}
+
+/**
 * roaring_bitmap_smallest returns the smallest value in the set.
 * Returns UINT32_MAX if the set is empty.
 */


### PR DESCRIPTION
When using the CRoaring library, the normal way to get the 1 index of a value in a RoaringBitmap is:
1. Call contains() to check if the value exists
2. If it exists, call rank() to get the 1 index
3. If it not exists, do something else
However, this requires traversing the RoaringBitmap twice, which is inefficient. To improve this, a get_idx() interface was created. It works as follows:
1. Traverse the RoaringBitmap once
2. If the value is found, return its 1 index in the set
4. If the value is not found, return -1