### PR TITLE
Use typedef/inline functions to centralize atomic ref count ops

### DIFF
--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -55,25 +55,11 @@ extern "C" { namespace roaring { namespace internal {
  * A shared container is a wrapper around a container
  * with reference counting.
  */
-#if CROARING_C_ATOMIC
 STRUCT_CONTAINER(shared_container_s) {
     container_t *container;
     uint8_t typecode;
-    _Atomic(uint32_t) counter;  // to be managed atomically
+    croaring_refcount_t counter;  // to be managed atomically
 };
-#elif CROARING_CPP_ATOMIC
-STRUCT_CONTAINER(shared_container_s) {
-    container_t *container;
-    uint8_t typecode;
-    std::atomic<uint32_t> counter;  // to be managed atomically
-};
-#else
-STRUCT_CONTAINER(shared_container_s) {
-    container_t *container;
-    uint8_t typecode;
-    uint32_t counter;  // to be managed atomically
-};
-#endif
 
 typedef struct shared_container_s shared_container_t;
 

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -419,11 +419,9 @@ static inline int roaring_hamming(uint64_t x) {
     #endif //__has_include
   #elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
     #define CROARING_ATOMIC_IMPL CROARING_ATOMIC_IMPL_C
-  #elif !defined(__cplusplus) // (c, no atomics)
-    #if CROARING_REGULAR_VISUAL_STUDIO
-      // https://www.technetworkhub.com/c11-atomics-in-visual-studio-2022-version-17/
-      #define CROARING_ATOMIC_IMPL CROARING_ATOMIC_IMPL_C_WINDOWS
-    #endif
+  #elif CROARING_REGULAR_VISUAL_STUDIO
+    // https://www.technetworkhub.com/c11-atomics-in-visual-studio-2022-version-17/
+    #define CROARING_ATOMIC_IMPL CROARING_ATOMIC_IMPL_C_WINDOWS
   #endif
 #endif // !defined(CROARING_ATOMIC_IMPL)
 

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -370,7 +370,7 @@ static inline int roaring_hamming(uint64_t x) {
 
 #if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__)
  #define CROARING_IS_BIG_ENDIAN (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
- #elif defined(_WIN32)
+#elif defined(_WIN32)
  #define CROARING_IS_BIG_ENDIAN 0
  #else
  #if defined(__APPLE__) || defined(__FreeBSD__) // defined __BYTE_ORDER__ && defined __ORDER_BIG_ENDIAN__
@@ -399,40 +399,129 @@ static inline int roaring_hamming(uint64_t x) {
  #endif // __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #endif
 
-#if defined(__cplusplus) && __cplusplus >= 201103L
-#ifdef __has_include
-#if __has_include(<atomic>)
-// It is now safe:
-#define CROARING_CPP_ATOMIC 1
-#define CROARING_C_ATOMIC 0
-#define CROARING_CPP_WINDOWS_ATOMIC 0
-#include <atomic>
-#endif //__has_include(<endian.h>)
-#else
-// We lack __has_include to check:
-#define CROARING_CPP_ATOMIC 1
-#define CROARING_C_ATOMIC 0
-#define CROARING_CPP_WINDOWS_ATOMIC 0
-#include <atomic>
-#endif //__has_include
-#elif CROARING_REGULAR_VISUAL_STUDIO
-// https://www.technetworkhub.com/c11-atomics-in-visual-studio-2022-version-17/
-#define CROARING_ATOMIC 0
-#define CROARING_CPP_ATOMIC 0
-#define CROARING_CPP_WINDOWS_ATOMIC 1
-# include <intrin.h>
-# pragma intrinsic (_InterlockedIncrement)
-# pragma intrinsic (_InterlockedDecrement)
-#elif defined(__STDC_NO_ATOMICS__)
-#define CROARING_ATOMIC 0
-#define CROARING_CPP_ATOMIC 0
-#define CROARING_CPP_WINDOWS_ATOMIC 0
-#else // C
-#define CROARING_C_ATOMIC 1
-#define CROARING_CPP_ATOMIC 0
-#define CROARING_CPP_WINDOWS_ATOMIC 0
-#include <stdatomic.h>
+// Defines for the possible CROARING atomic implementations
+#define CROARING_ATOMIC_IMPL_NONE          1
+#define CROARING_ATOMIC_IMPL_CPP           2
+#define CROARING_ATOMIC_IMPL_C             3
+#define CROARING_ATOMIC_IMPL_C_WINDOWS     4
+
+// If the use has forced a specific implementation, use that, otherwise,
+// figure out the best implementation we can use.
+#if !defined(CROARING_ATOMIC_IMPL)
+  #if defined(__cplusplus) && __cplusplus >= 201103L
+    #ifdef __has_include
+      #if __has_include(<atomic>)
+        #define CROARING_ATOMIC_IMPL CROARING_ATOMIC_IMPL_CPP
+      #endif //__has_include(<atomic>)
+    #else
+       // We lack __has_include to check:
+       #define CROARING_ATOMIC_IMPL CROARING_ATOMIC_IMPL_CPP
+    #endif //__has_include
+  #elif !defined(__STDC_NO_ATOMICS__)
+    #define CROARING_ATOMIC_IMPL CROARING_ATOMIC_IMPL_C
+  #else // (c, no atomics)
+    #if CROARING_REGULAR_VISUAL_STUDIO
+      // https://www.technetworkhub.com/c11-atomics-in-visual-studio-2022-version-17/
+      #define CROARING_ATOMIC_IMPL CROARING_ATOMIC_IMPL_C_WINDOWS
+    #endif
+  #endif
+#endif // !defined(CROARING_ATOMIC_IMPL)
+
+#if !defined(CROARING_ATOMIC_IMPL)
+  #pragma message ( "No atomic implementation found, copy on write bitmaps will not be threadsafe" )
+  #define CROARING_ATOMIC_IMPL CROARING_ATOMIC_IMPL_NONE
 #endif
+
+#if CROARING_ATOMIC_IMPL == CROARING_ATOMIC_IMPL_C
+#include <stdatomic.h>
+typedef _Atomic(uint32_t) croaring_refcount_t;
+
+static inline void croaring_refcount_inc(croaring_refcount_t *val) {
+  // Increasing the reference counter can always be done with
+  // memory_order_relaxed: New references to an object can only be formed from
+  // an existing reference, and passing an existing reference from one thread to
+  // another must already provide any required synchronization.
+  atomic_fetch_add_explicit(val, 1, memory_order_relaxed);
+}
+
+static inline bool croaring_refcount_dec(croaring_refcount_t *val) {
+  // It is important to enforce any possible access to the object in one thread
+  // (through an existing reference) to happen before deleting the object in a
+  // different thread. This is achieved by a "release" operation after dropping
+  // a reference (any access to the object through this reference must obviously
+  // happened before), and an "acquire" operation before deleting the object.
+  bool is_zero = atomic_fetch_sub_explicit(val, 1, memory_order_release) == 1;
+    if (is_zero) {
+        atomic_thread_fence(memory_order_acquire);
+    }
+    return is_zero;
+}
+
+static inline uint32_t croaring_refcount_get(croaring_refcount_t *val) {
+    return atomic_load_explicit(val, memory_order_relaxed);
+}
+#elif CROARING_ATOMIC_IMPL == CROARING_ATOMIC_IMPL_CPP
+#include <atomic>
+typedef std::atomic<uint32_t> croaring_refcount_t;
+
+static inline void croaring_refcount_inc(croaring_refcount_t *val) {
+    val->fetch_add(1, std::memory_order_relaxed);
+}
+
+static inline bool croaring_refcount_dec(croaring_refcount_t *val) {
+    // See above comments on the c11 atomic implementation for memory ordering
+    bool is_zero = val->fetch_sub(1, std::memory_order_release) == 1;
+    if (is_zero) {
+        std::atomic_thread_fence(std::memory_order_acquire);
+    }
+    return is_zero;
+}
+
+static inline uint32_t croaring_refcount_get(croaring_refcount_t *val) {
+    return val->load(std::memory_order_relaxed);
+}
+#elif CROARING_ATOMIC_IMPL == CROARING_ATOMIC_IMPL_C_WINDOWS
+#include <intrin.h>
+#pragma intrinsic(_InterlockedIncrement)
+#pragma intrinsic(_InterlockedDecrement)
+
+typedef volatile uint32_t croaring_refcount_t;
+
+static inline void croaring_refcount_inc(croaring_refcount_t *val) {
+    _InterlockedIncrement(val);
+}
+
+static inline bool croaring_refcount_dec(croaring_refcount_t *val) {
+    return _InterlockedDecrement(val) == 0;
+}
+
+static inline uint32_t croaring_refcount_get(croaring_refcount_t *val) {
+    // Per https://learn.microsoft.com/en-us/windows/win32/sync/interlocked-variable-access
+    // > Simple reads and writes to properly-aligned 32-bit variables are atomic
+    // > operations. In other words, you will not end up with only one portion
+    // > of the variable updated; all bits are updated in an atomic fashion.
+    return *val;
+}
+#elif CROARING_ATOMIC_IMPL == CROARING_ATOMIC_IMPL_NONE
+typedef uint32_t croaring_refcount_t;
+
+static inline void croaring_refcount_inc(croaring_refcount_t *val) {
+    *val += 1;
+}
+
+static inline bool croaring_refcount_dec(croaring_refcount_t *val) {
+    assert(*val > 0);
+    *val -= 1;
+    return val == 0;
+}
+
+static inline uint32_t croaring_refcount_get(croaring_refcount_t *val) {
+    return *val;
+}
+#else
+#error "Unknown atomic implementation"
+#endif
+
 
 // We need portability.h to be included first,
 // but we also always want isadetection.h to be

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -483,7 +483,9 @@ static inline uint32_t croaring_refcount_get(croaring_refcount_t *val) {
 #pragma intrinsic(_InterlockedIncrement)
 #pragma intrinsic(_InterlockedDecrement)
 
-typedef volatile uint32_t croaring_refcount_t;
+// _InterlockedIncrement and _InterlockedDecrement take a (signed) long, and
+// overflow is defined to wrap, so we can pretend it is a uint32_t for our case
+typedef volatile long croaring_refcount_t;
 
 static inline void croaring_refcount_inc(croaring_refcount_t *val) {
     _InterlockedIncrement(val);

--- a/src/isadetection.c
+++ b/src/isadetection.c
@@ -194,14 +194,14 @@ static inline uint32_t dynamic_croaring_detect_supported_architectures() {
 
 #if defined(__x86_64__) || defined(_M_AMD64) // x64
 
-#if defined(__cplusplus)
+#if CROARING_ATOMIC_IMPL == CROARING_ATOMIC_IMPL_CPP
 static inline uint32_t croaring_detect_supported_architectures() {
     // thread-safe as per the C++11 standard.
     static uint32_t buffer = dynamic_croaring_detect_supported_architectures();
     return buffer;
 }
-#elif CROARING_C_ATOMIC
-uint32_t croaring_detect_supported_architectures() {
+#elif CROARING_ATOMIC_IMPL == CROARING_ATOMIC_IMPL_C
+static uint32_t croaring_detect_supported_architectures() {
     // we use an atomic for thread safety
     static _Atomic uint32_t buffer = CROARING_UNINITIALIZED;
     if (buffer == CROARING_UNINITIALIZED) {
@@ -211,9 +211,9 @@ uint32_t croaring_detect_supported_architectures() {
     return buffer;
 }
 #else
-// If we do not have C11 atomics, we do the best we can.
+// If we do not have atomics, we do the best we can.
 static inline uint32_t croaring_detect_supported_architectures() {
-    static int buffer = CROARING_UNINITIALIZED;
+    static uint32 buffer = CROARING_UNINITIALIZED;
     if (buffer == CROARING_UNINITIALIZED) {
       buffer = dynamic_croaring_detect_supported_architectures();
     }

--- a/src/isadetection.c
+++ b/src/isadetection.c
@@ -213,7 +213,7 @@ static uint32_t croaring_detect_supported_architectures() {
 #else
 // If we do not have atomics, we do the best we can.
 static inline uint32_t croaring_detect_supported_architectures() {
-    static uint32 buffer = CROARING_UNINITIALIZED;
+    static uint32_t buffer = CROARING_UNINITIALIZED;
     if (buffer == CROARING_UNINITIALIZED) {
       buffer = dynamic_croaring_detect_supported_architectures();
     }

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -348,20 +348,9 @@ void roaring_bitmap_printf_describe(const roaring_bitmap_t *r) {
                get_full_container_name(ra->containers[i], ra->typecodes[i]),
                container_get_cardinality(ra->containers[i], ra->typecodes[i]));
         if (ra->typecodes[i] == SHARED_CONTAINER_TYPE) {
-#if CROARING_C_ATOMIC
-            printf(
-                "(shared count = %" PRIu32 " )",
-                    atomic_load(&(CAST_shared(ra->containers[i])->counter)));
-#elif CROARING_CPP_ATOMIC
-            printf(
-                "(shared count = %" PRIu32 " )",
-                    std::atomic_load(&(CAST_shared(ra->containers[i])->counter)));
-#else
-            printf(
-                "(shared count = %" PRIu32 " )",
-                    CAST_shared(ra->containers[i])->counter);
-#endif
-
+            printf("(shared count = %" PRIu32 " )",
+                   croaring_refcount_get(
+                       &(CAST_shared(ra->containers[i])->counter)));
         }
 
         if (i + 1 < ra->size) {


### PR DESCRIPTION
It feels quite a bit cleaner to me to have the implementations of how to deal with atomic integers centralized like this.