### PR TITLE
Correct macro ROARING_DISABLE_X64.

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -97,7 +97,7 @@ extern "C" {  // portability definitions are in global scope, not a namespace
 #undef CROARING_IS_X64
 #endif
 
-#ifdef CROARING_DISABLE_X64
+#ifdef ROARING_DISABLE_X64
 #undef CROARING_IS_X64
 #endif
 // we include the intrinsic header


### PR DESCRIPTION
In file src/CMakeLists.txt
```
if(ROARING_DISABLE_X64)
  target_compile_definitions(roaring PUBLIC ROARING_DISABLE_X64=1)
endif(ROARING_DISABLE_X64)
```
But in include/roaring/portability.h
```
#ifdef CROARING_DISABLE_X64 // should be ROARING... instead of CROARING...
#undef CROARING_IS_X64
#endif
```