### PR TITLE
Fix a handful of compilation issues with older C standards

### DIFF
--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -304,6 +304,12 @@ int bitset_container_union(const bitset_container_t *src_1,
 int bitset_container_union_justcard(const bitset_container_t *src_1,
                                     const bitset_container_t *src_2);
 
+/* Computes the union of bitsets `src_1' and `src_2' into `dst', but does
+ * not update the cardinality. Provided to optimize chained operations. */
+int bitset_container_union_nocard(const bitset_container_t *src_1,
+				  const bitset_container_t *src_2,
+				  bitset_container_t *dst);
+
 /* Computes the union of bitsets `src_1' and `src_2' into `dst', but does not
  * update the cardinality. Provided to optimize chained operations. */
 int bitset_container_or_nocard(const bitset_container_t *src_1,

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -340,6 +340,12 @@ int bitset_container_intersection_justcard(const bitset_container_t *src_1,
 
 /* Computes the intersection of bitsets `src_1' and `src_2' into `dst', but does
  * not update the cardinality. Provided to optimize chained operations. */
+int bitset_container_intersection_nocard(const bitset_container_t *src_1,
+					 const bitset_container_t *src_2,
+					 bitset_container_t *dst);
+
+/* Computes the intersection of bitsets `src_1' and `src_2' into `dst', but does
+ * not update the cardinality. Provided to optimize chained operations. */
 int bitset_container_and_nocard(const bitset_container_t *src_1,
                                 const bitset_container_t *src_2,
                                 bitset_container_t *dst);

--- a/include/roaring/isadetection.h
+++ b/include/roaring/isadetection.h
@@ -34,7 +34,7 @@ enum {
   ROARING_SUPPORTS_AVX2 = 1,
   ROARING_SUPPORTS_AVX512 = 2,
 };
-int croaring_hardware_support();
+int croaring_hardware_support(void);
 #ifdef __cplusplus
 } } }  // extern "C" { namespace roaring { namespace internal {
 #endif

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -503,6 +503,7 @@ static inline uint32_t croaring_refcount_get(croaring_refcount_t *val) {
     return *val;
 }
 #elif CROARING_ATOMIC_IMPL == CROARING_ATOMIC_IMPL_NONE
+#include <assert.h>
 typedef uint32_t croaring_refcount_t;
 
 static inline void croaring_refcount_inc(croaring_refcount_t *val) {

--- a/include/roaring/roaring_array.h
+++ b/include/roaring/roaring_array.h
@@ -168,6 +168,8 @@ inline void ra_set_container_at_index(
     ra->typecodes[i] = typecode;
 }
 
+container_t *ra_get_container(roaring_array_t *ra, uint16_t x, uint8_t *typecode);
+
 /**
  * If needed, increase the capacity of the array so that it can fit k values
  * (at

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -13,7 +13,7 @@ extern "C" { namespace roaring { namespace internal {
 #endif
 
 /* Create a new bitset. Return NULL in case of failure. */
-bitset_t *bitset_create() {
+bitset_t *bitset_create(void) {
     bitset_t *bitset = NULL;
     /* Allocate the bitset itself. */
     if ((bitset = (bitset_t *)roaring_malloc(sizeof(bitset_t))) == NULL) {

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -59,7 +59,7 @@ array_container_t *array_container_create_given_capacity(int32_t size) {
 }
 
 /* Create a new array. Return NULL in case of failure. */
-array_container_t *array_container_create() {
+array_container_t *array_container_create(void) {
     return array_container_create_given_capacity(ARRAY_DEFAULT_INIT_SIZE);
 }
 

--- a/src/isadetection.c
+++ b/src/isadetection.c
@@ -115,7 +115,7 @@ static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx,
 }
 
 
-static inline uint64_t xgetbv() {
+static inline uint64_t xgetbv(void) {
 #if defined(_MSC_VER)
   return _xgetbv(0);
 #else
@@ -130,7 +130,7 @@ static inline uint64_t xgetbv() {
  * *once* per compilation units. Normally, the CRoaring library is built
  * as one compilation unit.
  */
-static inline uint32_t dynamic_croaring_detect_supported_architectures() {
+static inline uint32_t dynamic_croaring_detect_supported_architectures(void) {
   uint32_t eax, ebx, ecx, edx;
   uint32_t host_isa = 0x0;
   // Can be found on Intel ISA Reference for CPUID
@@ -228,13 +228,13 @@ static inline uint32_t dynamic_croaring_detect_supported_architectures() {
 #if defined(__x86_64__) || defined(_M_AMD64) // x64
 
 #if CROARING_ATOMIC_IMPL == CROARING_ATOMIC_IMPL_CPP
-static inline uint32_t croaring_detect_supported_architectures() {
+static inline uint32_t croaring_detect_supported_architectures(void) {
     // thread-safe as per the C++11 standard.
     static uint32_t buffer = dynamic_croaring_detect_supported_architectures();
     return buffer;
 }
 #elif CROARING_ATOMIC_IMPL == CROARING_ATOMIC_IMPL_C
-static uint32_t croaring_detect_supported_architectures() {
+static uint32_t croaring_detect_supported_architectures(void) {
     // we use an atomic for thread safety
     static _Atomic uint32_t buffer = CROARING_UNINITIALIZED;
     if (buffer == CROARING_UNINITIALIZED) {
@@ -245,7 +245,7 @@ static uint32_t croaring_detect_supported_architectures() {
 }
 #else
 // If we do not have atomics, we do the best we can.
-static inline uint32_t croaring_detect_supported_architectures() {
+static inline uint32_t croaring_detect_supported_architectures(void) {
     static uint32_t buffer = CROARING_UNINITIALIZED;
     if (buffer == CROARING_UNINITIALIZED) {
       buffer = dynamic_croaring_detect_supported_architectures();
@@ -256,17 +256,17 @@ static inline uint32_t croaring_detect_supported_architectures() {
 
 #ifdef ROARING_DISABLE_AVX
 
-int croaring_hardware_support() {
+int croaring_hardware_support(void) {
     return 0;
 }
 
 #elif defined(__AVX512F__) && defined(__AVX512DQ__) && defined(__AVX512BW__) && defined(__AVX512VBMI2__) && defined(__AVX512BITALG__) && defined(__AVX512VPOPCNTDQ__)
-int croaring_hardware_support() {
+int croaring_hardware_support(void) {
     return  ROARING_SUPPORTS_AVX2 | ROARING_SUPPORTS_AVX512;
 }
 #elif defined(__AVX2__)
 
-int croaring_hardware_support() {
+int croaring_hardware_support(void) {
   static int support = 0xFFFFFFF;
   if(support == 0xFFFFFFF) {
     bool avx512_support = false;
@@ -280,7 +280,7 @@ int croaring_hardware_support() {
 }
 #else
 
-int croaring_hardware_support() {
+int croaring_hardware_support(void) {
   static int support = 0xFFFFFFF;
   if(support == 0xFFFFFFF) {
     bool has_avx2 = (croaring_detect_supported_architectures() & CROARING_AVX2) == CROARING_AVX2;


### PR DESCRIPTION
This pull request fixes a small handful of compilation issues noticed when integrating CRoaring into the Git project and compiling it with `DEVELOPER=1` enabled.

When compiling without Git's strict checks, everything works as expected (here and elsewhere I'm using the amalgamation build):

```ShellSession
$ make croaring/roaring.o
    * new build flags
    CC croaring/roaring.o
```

However, Git cannot compile the amalgamated build when `DEVELOPER=1` is set. Setting `DEVELOPER=1` when building enables a [handful of stricter compilation checks](https://github.com/git/git/blob/9e49351c3060e1fa6e0d2de64505b7becf157f28/config.mak.dev), including `-Werror=implicit-function-declaration`, `-Werror=old-style-definition`, `-Werror=missing-prototypes`. Compiling CRoaring with those flags does not currently work, but does (at least on my system!) after this PR.

(For posterity: Git's `DEVELOPER=1` mode also sets `-Wdeclaration-after-statement`, which produces ~300-ish warnings when compiling CRoaring. CRoaring and Git differ in convention here, and there isn't a need to force either project to change here, since we can `#pragma` ignore these).

##