### PR TITLE
portability.h: add an build flag to suppress warnings

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -426,7 +426,9 @@ static inline int roaring_hamming(uint64_t x) {
 #endif // !defined(CROARING_ATOMIC_IMPL)
 
 #if !defined(CROARING_ATOMIC_IMPL)
-  #pragma message ( "No atomic implementation found, copy on write bitmaps will not be threadsafe" )
+  #ifndef CROARING_SILENT_BUILD
+    #pragma message ( "No atomic implementation found, copy on write bitmaps will not be threadsafe" )
+  #endif // CROARING_SILENT_BUILD
   #define CROARING_ATOMIC_IMPL CROARING_ATOMIC_IMPL_NONE
 #endif
 


### PR DESCRIPTION
When building CRoaring without support for atomics (for instance, in a pre-C11 environment where <stdatomic.h> is not part of the language specification), we get a compile-time message that copy-on-write bitmaps are unavailable.

Having a warning message is useful as a default behavior, since it can prevent surprises for CRoaring users who expect their bitmaps to be thread-safe, but aren't for whatever reason.

But in environments where we know that <stdatomic.h> is unavailable, or we are single-threaded, the message is noise, since we know ahead of time that CRoaring's bitmaps won't be threadsafe (and are OK with that).

Provide an opt-out build knob (CROARING_SILENT_BUILD) to suppress this warning for applications that wish to do so.

##