### PR TITLE
Add roaring_bitmap_deserialize_safe

### DIFF
--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -515,6 +515,20 @@ size_t roaring_bitmap_serialize(const roaring_bitmap_t *r, char *buf);
 roaring_bitmap_t *roaring_bitmap_deserialize(const void *buf);
 
 /**
+ * Use with `roaring_bitmap_serialize()`.
+ *
+ * (See `roaring_bitmap_portable_deserialize_safe()` if you want a format that's
+ * compatible with Java and Go implementations).
+ *
+ * This function is endian-sensitive. If you have a big-endian system (e.g., a mainframe IBM s390x),
+ * the data format is going to be big-endian and not compatible with little-endian systems.
+ * 
+ * The difference with `roaring_bitmap_deserialize()` is that this function checks that the input buffer
+ * is a valid bitmap.  If the buffer is too small, NULL is returned.
+ */
+roaring_bitmap_t *roaring_bitmap_deserialize_safe(const void *buf, size_t maxbytes);
+
+/**
  * How many bytes are required to serialize this bitmap (NOT compatible
  * with Java and Go versions)
  */

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1463,10 +1463,25 @@ roaring_bitmap_t *roaring_bitmap_deserialize(const void *buf) {
     if (bufaschar[0] == CROARING_SERIALIZATION_ARRAY_UINT32) {
         /* This looks like a compressed set of uint32_t elements */
         uint32_t card;
+
         memcpy(&card, bufaschar + 1, sizeof(uint32_t));
+
         const uint32_t *elems =
             (const uint32_t *)(bufaschar + 1 + sizeof(uint32_t));
-        return roaring_bitmap_of_ptr(card, elems);
+        
+        roaring_bitmap_t *bitmap = roaring_bitmap_create();
+        if (bitmap == NULL) {
+            return NULL;
+        }
+        roaring_bulk_context_t context = {0};
+        for (uint32_t i = 0; i < card; i++) {
+            // elems may not be aligned, read with memcpy
+            uint32_t elem;
+            memcpy(&elem, elems + i, sizeof(elem));
+            roaring_bitmap_add_bulk(bitmap, &context, elem);
+        }
+        return bitmap;
+
     } else if (bufaschar[0] == CROARING_SERIALIZATION_CONTAINER) {
         return roaring_bitmap_portable_deserialize(bufaschar + 1);
     } else
@@ -1495,7 +1510,20 @@ roaring_bitmap_t* roaring_bitmap_deserialize_safe(const void *buf, size_t maxbyt
 
         const uint32_t *elems =
             (const uint32_t *)(bufaschar + 1 + sizeof(uint32_t));
-        return roaring_bitmap_of_ptr(card, elems);
+        
+        roaring_bitmap_t *bitmap = roaring_bitmap_create();
+        if (bitmap == NULL) {
+            return NULL;
+        }
+        roaring_bulk_context_t context = {0};
+        for (uint32_t i = 0; i < card; i++) {
+            // elems may not be aligned, read with memcpy
+            uint32_t elem;
+            memcpy(&elem, elems + i, sizeof(elem));
+            roaring_bitmap_add_bulk(bitmap, &context, elem);
+        }
+        return bitmap;
+        
     } else if (bufaschar[0] == CROARING_SERIALIZATION_CONTAINER) {
         return roaring_bitmap_portable_deserialize_safe(bufaschar + 1, maxbytes - 1);
     } else

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1466,20 +1466,38 @@ roaring_bitmap_t *roaring_bitmap_deserialize(const void *buf) {
         memcpy(&card, bufaschar + 1, sizeof(uint32_t));
         const uint32_t *elems =
             (const uint32_t *)(bufaschar + 1 + sizeof(uint32_t));
-        roaring_bitmap_t *bitmap = roaring_bitmap_create();
-        if (bitmap == NULL) {
-            return NULL;
-        }
-        roaring_bulk_context_t context = {0};
-        for (uint32_t i = 0; i < card; i++) {
-            // elems may not be aligned, read with memcpy
-            uint32_t elem;
-            memcpy(&elem, elems + i, sizeof(elem));
-            roaring_bitmap_add_bulk(bitmap, &context, elem);
-        }
-        return bitmap;
+        return roaring_bitmap_of_ptr(card, elems);
     } else if (bufaschar[0] == CROARING_SERIALIZATION_CONTAINER) {
         return roaring_bitmap_portable_deserialize(bufaschar + 1);
+    } else
+        return (NULL);
+}
+
+roaring_bitmap_t* roaring_bitmap_deserialize_safe(const void *buf, size_t maxbytes) {
+    if (maxbytes < 1) {
+        return NULL;
+    }
+
+    const char *bufaschar = (const char *)buf;
+    if (bufaschar[0] == CROARING_SERIALIZATION_ARRAY_UINT32) {
+        if (maxbytes < 5) {
+            return NULL;
+        }
+
+        /* This looks like a compressed set of uint32_t elements */
+        uint32_t card;
+        memcpy(&card, bufaschar + 1, sizeof(uint32_t));
+
+        // Check the buffer is big enough to contain card uint32_t elements
+        if (maxbytes < 1 + sizeof(uint32_t) + card * sizeof(uint32_t)) {
+            return NULL;
+        }
+
+        const uint32_t *elems =
+            (const uint32_t *)(bufaschar + 1 + sizeof(uint32_t));
+        return roaring_bitmap_of_ptr(card, elems);
+    } else if (bufaschar[0] == CROARING_SERIALIZATION_CONTAINER) {
+        return roaring_bitmap_portable_deserialize_safe(bufaschar + 1, maxbytes - 1);
     } else
         return (NULL);
 }

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1480,7 +1480,7 @@ roaring_bitmap_t* roaring_bitmap_deserialize_safe(const void *buf, size_t maxbyt
 
     const char *bufaschar = (const char *)buf;
     if (bufaschar[0] == CROARING_SERIALIZATION_ARRAY_UINT32) {
-        if (maxbytes < 5) {
+        if (maxbytes < 1 + sizeof(uint32_t)) {
             return NULL;
         }
 

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -1407,6 +1407,23 @@ DEFINE_TEST(test_serialize) {
     r2 = roaring_bitmap_deserialize(serialized);
     assert_true(roaring_bitmap_equals(r1, r2));
 
+    // Check that roaring_bitmap_deserialize_safe fails on invalid length
+
+    assert_null(roaring_bitmap_deserialize_safe(serialized, 0));
+    assert_null(roaring_bitmap_deserialize_safe(serialized, serialize_len - 1));
+
+    // Check that roaring_bitmap_deserialize_safe succeed with valid length
+
+    roaring_bitmap_t *t_safe = roaring_bitmap_deserialize_safe(serialized, serialize_len);
+    assert_true(roaring_bitmap_equals(r1, t_safe));
+    roaring_bitmap_free(t_safe);
+
+    // Check that roaring_bitmap_deserialize_safe succeed with larger length
+
+    t_safe = roaring_bitmap_deserialize_safe(serialized, serialize_len + 10);
+    assert_true(roaring_bitmap_equals(r1, t_safe));
+    roaring_bitmap_free(t_safe);
+
     free(serialized);
     roaring_bitmap_free(r1);
     roaring_bitmap_free(r2);
@@ -1460,6 +1477,7 @@ DEFINE_TEST(test_serialize) {
 
     assert_true(array_equals(arr1, card1, arr2, card2));
     assert_true(roaring_bitmap_equals(r1, r2));
+
     free(arr1);
     free(arr2);
     free(serialized);
@@ -1473,6 +1491,14 @@ DEFINE_TEST(test_serialize) {
     uint32_t size = roaring_bitmap_serialize(old_bm, buff);
     assert_int_equal(size, roaring_bitmap_size_in_bytes(old_bm));
     roaring_bitmap_t *new_bm = roaring_bitmap_deserialize(buff);
+
+    // Check that roaring_bitmap_deserialize_safe fails on invalid length
+    assert_null(roaring_bitmap_deserialize_safe(buff, size - 1));
+    // Check that roaring_bitmap_deserialize_safe succeed with valid length
+    t_safe = roaring_bitmap_deserialize_safe(buff, size);
+    assert_true(roaring_bitmap_equals(new_bm, t_safe));
+    roaring_bitmap_free(t_safe);
+
     free(buff);
     assert_true((unsigned int)roaring_bitmap_get_cardinality(old_bm) ==
                 (unsigned int)roaring_bitmap_get_cardinality(new_bm));


### PR DESCRIPTION
CRoaring offers `roaring_bitmap_portable_deserialize_safe` but it does not provide `roaring_bitmap_deserialize_safe`.

- Add new function `roaring_bitmap_t *roaring_bitmap_deserialize_safe(const void *buf, size_t maxbytes);`
- Add some basic unit tests for it
