### PR TITLE
Use `inline` in headers, `extern inline` in c files

### DIFF
--- a/include/roaring/bitset/bitset.h
+++ b/include/roaring/bitset/bitset.h
@@ -56,17 +56,17 @@ bitset_t *bitset_copy(const bitset_t *bitset);
 bool bitset_resize(bitset_t *bitset, size_t newarraysize, bool padwithzeroes);
 
 /* returns how many bytes of memory the backend buffer uses */
-static inline size_t bitset_size_in_bytes(const bitset_t *bitset) {
+inline size_t bitset_size_in_bytes(const bitset_t *bitset) {
     return bitset->arraysize * sizeof(uint64_t);
 }
 
 /* returns how many bits can be accessed */
-static inline size_t bitset_size_in_bits(const bitset_t *bitset) {
+inline size_t bitset_size_in_bits(const bitset_t *bitset) {
     return bitset->arraysize * 64;
 }
 
 /* returns how many words (64-bit) of memory the backend buffer uses */
-static inline size_t bitset_size_in_words(const bitset_t *bitset) {
+inline size_t bitset_size_in_words(const bitset_t *bitset) {
     return bitset->arraysize;
 }
 
@@ -88,7 +88,7 @@ void bitset_shift_right(bitset_t *bitset, size_t s);
 
 /* Set the ith bit. Attempts to resize the bitset if needed (may silently fail)
  */
-static inline void bitset_set(bitset_t *bitset, size_t i) {
+inline void bitset_set(bitset_t *bitset, size_t i) {
     size_t shiftedi = i / 64;
     if (shiftedi >= bitset->arraysize) {
         if (!bitset_grow(bitset, shiftedi + 1)) {
@@ -100,7 +100,7 @@ static inline void bitset_set(bitset_t *bitset, size_t i) {
 
 /* Set the ith bit to the specified value. Attempts to resize the bitset if
  * needed (may silently fail) */
-static inline void bitset_set_to_value(bitset_t *bitset, size_t i, bool flag) {
+inline void bitset_set_to_value(bitset_t *bitset, size_t i, bool flag) {
     size_t shiftedi = i / 64;
     uint64_t mask = ((uint64_t)1) << (i % 64);
     uint64_t dynmask = ((uint64_t)flag) << (i % 64);
@@ -116,7 +116,7 @@ static inline void bitset_set_to_value(bitset_t *bitset, size_t i, bool flag) {
 }
 
 /* Get the value of the ith bit.  */
-static inline bool bitset_get(const bitset_t *bitset, size_t i) {
+inline bool bitset_get(const bitset_t *bitset, size_t i) {
     size_t shiftedi = i / 64;
     if (shiftedi >= bitset->arraysize) {
         return false;
@@ -184,7 +184,7 @@ size_t bitset_symmetric_difference_count(const bitset_t *CBITSET_RESTRICT b1,
     //.....
   }
   */
-static inline bool bitset_next_set_bit(const bitset_t *bitset, size_t *i) {
+inline bool bitset_next_set_bit(const bitset_t *bitset, size_t *i) {
     size_t x = *i / 64;
     if (x >= bitset->arraysize) {
         return false;
@@ -216,8 +216,8 @@ static inline bool bitset_next_set_bit(const bitset_t *bitset, size_t *i) {
     //.....
   }
   */
-static inline size_t bitset_next_set_bits(const bitset_t *bitset, size_t *buffer,
-                                 size_t capacity, size_t *startfrom) {
+inline size_t bitset_next_set_bits(const bitset_t *bitset, size_t *buffer,
+                                   size_t capacity, size_t *startfrom) {
     if (capacity == 0) return 0;  // sanity check
     size_t x = *startfrom / 64;
     if (x >= bitset->arraysize) {
@@ -252,8 +252,8 @@ end:
 typedef bool (*bitset_iterator)(size_t value, void *param);
 
 // return true if uninterrupted
-static inline bool bitset_for_each(const bitset_t *b, bitset_iterator iterator,
-                                   void *ptr) {
+inline bool bitset_for_each(const bitset_t *b, bitset_iterator iterator,
+                            void *ptr) {
     size_t base = 0;
     for (size_t i = 0; i < b->arraysize; ++i) {
         uint64_t w = b->array[i];
@@ -268,7 +268,7 @@ static inline bool bitset_for_each(const bitset_t *b, bitset_iterator iterator,
     return true;
 }
 
-static inline void bitset_print(const bitset_t *b) {
+inline void bitset_print(const bitset_t *b) {
     printf("{");
     for (size_t i = 0; bitset_next_set_bit(b, &i); i++) {
         printf("%zu, ", i);

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -35,7 +35,7 @@ roaring_bitmap_t *roaring_bitmap_create_with_capacity(uint32_t cap);
  * Returns NULL if the allocation fails.
  * Client is responsible for calling `roaring_bitmap_free()`.
  */
-static inline roaring_bitmap_t *roaring_bitmap_create(void)
+inline roaring_bitmap_t *roaring_bitmap_create(void)
   { return roaring_bitmap_create_with_capacity(0); }
 
 /**
@@ -50,7 +50,7 @@ bool roaring_bitmap_init_with_capacity(roaring_bitmap_t *r, uint32_t cap);
  * The bitmap will be in a "clear" state, with no auxiliary allocations.
  * Since this performs no allocations, the function will not fail.
  */
-static inline void roaring_bitmap_init_cleared(roaring_bitmap_t *r)
+inline void roaring_bitmap_init_cleared(roaring_bitmap_t *r)
   { roaring_bitmap_init_with_capacity(r, 0); }
 
 /**
@@ -74,11 +74,10 @@ roaring_bitmap_t *roaring_bitmap_of_ptr(size_t n_args, const uint32_t *vals);
  * do so for all of your bitmaps, since interactions between bitmaps with and
  * without COW is unsafe.
  */
-static inline bool roaring_bitmap_get_copy_on_write(const roaring_bitmap_t* r) {
+inline bool roaring_bitmap_get_copy_on_write(const roaring_bitmap_t* r) {
     return r->high_low_container.flags & ROARING_FLAG_COW;
 }
-static inline void roaring_bitmap_set_copy_on_write(roaring_bitmap_t* r,
-                                                    bool cow) {
+inline void roaring_bitmap_set_copy_on_write(roaring_bitmap_t* r, bool cow) {
     if (cow) {
         r->high_low_container.flags |= ROARING_FLAG_COW;
     } else {
@@ -332,8 +331,8 @@ void roaring_bitmap_add_range_closed(roaring_bitmap_t *r,
 /**
  * Add all values in range [min, max)
  */
-static inline void roaring_bitmap_add_range(roaring_bitmap_t *r,
-                                            uint64_t min, uint64_t max) {
+inline void roaring_bitmap_add_range(roaring_bitmap_t *r,
+                                     uint64_t min, uint64_t max) {
     if(max <= min) return;
     roaring_bitmap_add_range_closed(r, (uint32_t)min, (uint32_t)(max - 1));
 }
@@ -352,8 +351,8 @@ void roaring_bitmap_remove_range_closed(roaring_bitmap_t *r,
 /**
  * Remove all values in range [min, max)
  */
-static inline void roaring_bitmap_remove_range(roaring_bitmap_t *r,
-                                               uint64_t min, uint64_t max) {
+inline void roaring_bitmap_remove_range(roaring_bitmap_t *r,
+                                        uint64_t min, uint64_t max) {
     if(max <= min) return;
     roaring_bitmap_remove_range_closed(r, (uint32_t)min, (uint32_t)(max - 1));
 }

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -18,13 +18,14 @@ extern inline bool bitset_for_each(const bitset_t *b, bitset_iterator iterator,
 extern inline size_t bitset_next_set_bits(const bitset_t *bitset, size_t *buffer,
                                  size_t capacity, size_t *startfrom);
 extern inline void bitset_set_to_value(bitset_t *bitset, size_t i, bool flag);
+extern inline bool bitset_next_set_bit(const bitset_t *bitset, size_t *i);
 extern inline void bitset_set(bitset_t *bitset, size_t i);
+extern inline bool bitset_get(const bitset_t *bitset, size_t i);
 extern inline size_t bitset_size_in_words(const bitset_t *bitset);
 extern inline size_t bitset_size_in_bits(const bitset_t *bitset);
 extern inline size_t bitset_size_in_bytes(const bitset_t *bitset);
 
 
-extern inline bool bitset_get(const bitset_t *bitset, size_t i);
 /* Create a new bitset. Return NULL in case of failure. */
 bitset_t *bitset_create(void) {
     bitset_t *bitset = NULL;

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -25,6 +25,8 @@ extern inline void roaring_bitmap_init_cleared(roaring_bitmap_t *r);
 extern inline bool roaring_bitmap_get_copy_on_write(const roaring_bitmap_t* r);
 extern inline void roaring_bitmap_set_copy_on_write(roaring_bitmap_t* r, bool cow);
 extern inline roaring_bitmap_t *roaring_bitmap_create(void);
+extern inline void roaring_bitmap_add_range(roaring_bitmap_t *r, uint64_t min, uint64_t max);
+extern inline void roaring_bitmap_remove_range(roaring_bitmap_t *r, uint64_t min, uint64_t max);
 
 static inline bool is_cow(const roaring_bitmap_t *r) {
     return r->high_low_container.flags & ROARING_FLAG_COW;
@@ -322,9 +324,6 @@ void roaring_bitmap_remove_range_closed(roaring_bitmap_t *r, uint32_t min, uint3
         ra_shift_tail(ra, ra->size - src, dst - src);
     }
 }
-
-extern inline void roaring_bitmap_add_range(roaring_bitmap_t *r, uint64_t min, uint64_t max);
-extern inline void roaring_bitmap_remove_range(roaring_bitmap_t *r, uint64_t min, uint64_t max);
 
 void roaring_bitmap_printf(const roaring_bitmap_t *r) {
     const roaring_array_t *ra = &r->high_low_container;


### PR DESCRIPTION
Don't use `static inline` for functions meant to be part of the API, so they should always get an external linkage version. `static inline` and `extern inline` shouldn't even work together, but it seems they do.

See #489, #487, #488 