### PR TITLE
C++ Wrapper for Roaring32 `*Bulk`

### DIFF
--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -49,11 +49,16 @@ class RoaringSetBitForwardIterator;
  * (other than modifications performed with `Bulk()` functions with the context
  * passed) will invalidate any contexts associated with that bitmap.
  */
-class BulkContextWrapper {
+class BulkContext {
    public:
     friend class Roaring;
     using roaring_bitmap_bulk_context_t = api::roaring_bulk_context_t;
-    BulkContextWrapper() : context_{nullptr, 0, 0, 0} {}
+    BulkContext() : context_{nullptr, 0, 0, 0} {}
+
+    BulkContext(const BulkContext&) = delete;
+    BulkContext& operator=(const BulkContext&) = delete;
+    BulkContext(BulkContext&&) noexcept = default;
+    BulkContext& operator=(BulkContext&&) noexcept = default;
 
    private:
     roaring_bitmap_bulk_context_t context_;
@@ -191,7 +196,7 @@ public:
      * operations faster. `context` should be default-initialized before the
      * first call to this function.
      */
-    void addBulk(BulkContextWrapper &context, uint32_t x) noexcept {
+    void addBulk(BulkContext &context, uint32_t x) noexcept {
         api::roaring_bitmap_add_bulk(&roaring, &context.context_, x);
     }
 
@@ -203,7 +208,7 @@ public:
      * operations faster. `context` should be default-initialized before the
      * first call to this function.
      */
-    bool containsBulk(BulkContextWrapper& context, uint32_t x) const noexcept {
+    bool containsBulk(BulkContext& context, uint32_t x) const noexcept {
         return api::roaring_bitmap_contains_bulk(&roaring, &context.context_, x);
     }
 

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -196,6 +196,18 @@ public:
     }
 
     /**
+     * Check if item x is present, using context from a previous insert or search
+     * for speed optimization.
+     *
+     * `context` will be used to store information between calls to make bulk
+     * operations faster. `context` should be default-initialized before the
+     * first call to this function.
+     */
+    bool containsBulk(BulkContextWrapper& context, uint32_t x) const noexcept {
+        return api::roaring_bitmap_contains_bulk(&roaring, &context.context_, x);
+    }
+
+    /**
      * Remove value x
      */
     void remove(uint32_t x) noexcept { api::roaring_bitmap_remove(&roaring, x); }

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -42,6 +42,23 @@ namespace roaring {
 
 class RoaringSetBitForwardIterator;
 
+/**
+ * A bit of context usable with `*Bulk()` functions.
+ *
+ * A context may only be used with a single bitmap, and any modification to a bitmap
+ * (other than modifications performed with `Bulk()` functions with the context
+ * passed) will invalidate any contexts associated with that bitmap.
+ */
+class BulkContextWrapper {
+   public:
+    friend class Roaring;
+    using roaring_bitmap_bulk_context_t = api::roaring_bulk_context_t;
+    BulkContextWrapper() : context_{nullptr, 0, 0, 0} {}
+
+   private:
+    roaring_bitmap_bulk_context_t context_;
+};
+
 class Roaring {
     typedef api::roaring_bitmap_t roaring_bitmap_t;  // class-local name alias
 
@@ -164,6 +181,14 @@ public:
      */
     void addMany(size_t n_args, const uint32_t *vals) noexcept {
         api::roaring_bitmap_add_many(&roaring, n_args, vals);
+    }
+
+    /**
+     * Add value val, using context from a previous insert for speed
+     * optimization.
+     */
+    void addBulk(BulkContextWrapper *wrapper, uint32_t x) noexcept {
+        api::roaring_bitmap_add_bulk(&roaring, &wrapper->context_, x);
     }
 
     /**

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -186,9 +186,13 @@ public:
     /**
      * Add value val, using context from a previous insert for speed
      * optimization.
+     *
+     * `context` will be used to store information between calls to make bulk
+     * operations faster. `context` should be default-initialized before the
+     * first call to this function.
      */
-    void addBulk(BulkContextWrapper *wrapper, uint32_t x) noexcept {
-        api::roaring_bitmap_add_bulk(&roaring, &wrapper->context_, x);
+    void addBulk(BulkContextWrapper &context, uint32_t x) noexcept {
+        api::roaring_bitmap_add_bulk(&roaring, &context.context_, x);
     }
 
     /**

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -383,8 +383,8 @@ bool roaring_bitmap_contains_range(const roaring_bitmap_t *r,
                                    uint64_t range_end);
 
 /**
- * Check if an items is present, using context from a previous insert for speed
- * optimization.
+ * Check if an items is present, using context from a previous insert or search
+ * for speed optimization.
  *
  * `context` will be used to store information between calls to make bulk
  * operations faster. `*context` should be zero-initialized before the first

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -757,6 +757,18 @@ DEFINE_TEST(test_cpp_add_range) {
     }
 }
 
+DEFINE_TEST(test_cpp_add_bulk) {
+    std::vector<uint32_t> values = {9999, 123, 0xFFFFFFFF, 0xFFFFFFF7, 9999};
+    Roaring r1;
+    Roaring r2;
+    roaring::BulkContextWrapper bulk_container_wrapper;
+    for (const auto value : values) {
+        r1.addBulk(&bulk_container_wrapper, value);
+        r2.add(value);
+        assert_true(r1 == r2);
+    }
+}
+
 DEFINE_TEST(test_cpp_remove_range) {
     {
         // min < r1.minimum, max > r1.maximum
@@ -1974,6 +1986,7 @@ int main() {
         cmocka_unit_test(test_cpp_add_many),
         cmocka_unit_test(test_cpp_add_many_64),
         cmocka_unit_test(test_cpp_add_range_closed_combinatoric_64),
+        cmocka_unit_test(test_cpp_add_bulk),
         cmocka_unit_test(test_cpp_remove_range_closed_64),
         cmocka_unit_test(test_cpp_remove_range_64),
         cmocka_unit_test(test_run_compression_cpp_64_true),

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -763,7 +763,7 @@ DEFINE_TEST(test_cpp_add_bulk) {
     Roaring r2;
     roaring::BulkContextWrapper bulk_container_wrapper;
     for (const auto value : values) {
-        r1.addBulk(&bulk_container_wrapper, value);
+        r1.addBulk(bulk_container_wrapper, value);
         r2.add(value);
         assert_true(r1 == r2);
     }

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -761,9 +761,9 @@ DEFINE_TEST(test_cpp_add_bulk) {
     std::vector<uint32_t> values = {9999, 123, 0xFFFFFFFF, 0xFFFFFFF7, 9999};
     Roaring r1;
     Roaring r2;
-    roaring::BulkContextWrapper bulk_container_wrapper;
+    roaring::BulkContext bulk_context;
     for (const auto value : values) {
-        r1.addBulk(bulk_container_wrapper, value);
+        r1.addBulk(bulk_context, value);
         r2.add(value);
         assert_true(r1 == r2);
     }
@@ -774,12 +774,12 @@ DEFINE_TEST(test_cpp_contains_bulk) {
     std::vector<uint32_t> values_not_exists = {10, 12, 2000, 0xFFFFFFF, 0xFFFFFFF9, 2048};
     Roaring r;
     r.addMany(values_exists.size(), values_exists.data());
-    roaring::BulkContextWrapper bulk_container_wrapper;
+    roaring::BulkContext bulk_context;
     for (const auto value: values_exists) {
-        assert_true(r.containsBulk(bulk_container_wrapper, value));
+        assert_true(r.containsBulk(bulk_context, value));
     }
     for (const auto value: values_not_exists) {
-        assert_false(r.containsBulk(bulk_container_wrapper, value));
+        assert_false(r.containsBulk(bulk_context, value));
     }
 }
 

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -769,6 +769,20 @@ DEFINE_TEST(test_cpp_add_bulk) {
     }
 }
 
+DEFINE_TEST(test_cpp_contains_bulk) {
+    std::vector<uint32_t> values_exists = {9999, 123, 0xFFFFFFFF, 0xFFFFFFF7};
+    std::vector<uint32_t> values_not_exists = {10, 12, 2000, 0xFFFFFFF, 0xFFFFFFF9, 2048};
+    Roaring r;
+    r.addMany(values_exists.size(), values_exists.data());
+    roaring::BulkContextWrapper bulk_container_wrapper;
+    for (const auto value: values_exists) {
+        assert_true(r.containsBulk(bulk_container_wrapper, value));
+    }
+    for (const auto value: values_not_exists) {
+        assert_false(r.containsBulk(bulk_container_wrapper, value));
+    }
+}
+
 DEFINE_TEST(test_cpp_remove_range) {
     {
         // min < r1.minimum, max > r1.maximum
@@ -1987,6 +2001,7 @@ int main() {
         cmocka_unit_test(test_cpp_add_many_64),
         cmocka_unit_test(test_cpp_add_range_closed_combinatoric_64),
         cmocka_unit_test(test_cpp_add_bulk),
+        cmocka_unit_test(test_cpp_contains_bulk),
         cmocka_unit_test(test_cpp_remove_range_closed_64),
         cmocka_unit_test(test_cpp_remove_range_64),
         cmocka_unit_test(test_run_compression_cpp_64_true),


### PR DESCRIPTION
This patch adds:
1. `BulkContextWrapper` as a wrapper for `api::roaring_bulk_context_t`
2. `addBulk`, as a wrapper for `api::roaring_bitmap_add_bulk`

I'm not so familiar with C++ wrapper, but I'm glad to learn and resolve the problems in my code