### PR TITLE
Remove inline on exported functions, better grow

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -180,7 +180,7 @@ extern "C" {  // portability definitions are in global scope, not a namespace
 
 /* wrappers for Visual Studio built-ins that look like gcc built-ins __builtin_ctzll */
 /* result might be undefined when input_num is zero */
-static inline int roaring_trailing_zeroes(unsigned long long input_num) {
+inline int roaring_trailing_zeroes(unsigned long long input_num) {
     unsigned long index;
 #ifdef _WIN64  // highly recommended!!!
     _BitScanForward64(&index, input_num);

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -180,7 +180,7 @@ extern "C" {  // portability definitions are in global scope, not a namespace
 
 /* wrappers for Visual Studio built-ins that look like gcc built-ins __builtin_ctzll */
 /* result might be undefined when input_num is zero */
-inline int roaring_trailing_zeroes(unsigned long long input_num) {
+static inline int roaring_trailing_zeroes(unsigned long long input_num) {
     unsigned long index;
 #ifdef _WIN64  // highly recommended!!!
     _BitScanForward64(&index, input_num);
@@ -197,7 +197,7 @@ inline int roaring_trailing_zeroes(unsigned long long input_num) {
 
 /* wrappers for Visual Studio built-ins that look like gcc built-ins __builtin_clzll */
 /* result might be undefined when input_num is zero */
-inline int roaring_leading_zeroes(unsigned long long input_num) {
+static inline int roaring_leading_zeroes(unsigned long long input_num) {
     unsigned long index;
 #ifdef _WIN64  // highly recommended!!!
     _BitScanReverse64(&index, input_num);

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -144,7 +144,7 @@ static inline int32_t grow_capacity(int32_t capacity) {
     return (capacity <= 0) ? ARRAY_DEFAULT_INIT_SIZE
                            : capacity < 64 ? capacity * 2
                                            : capacity < 1024 ? capacity * 3 / 2
-                                                             : capacity * 5 / 4;
+                                                             : (capacity & 0xfffff000) + 4096;
 }
 
 static inline int32_t clamp(int32_t val, int32_t min, int32_t max) {

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -1482,7 +1482,6 @@ DEFINE_TEST(array_negation_range_test3) {
  * sparse */
 static int bitset_negation_range_tests(int sparsity, int r_start, int r_end,
                                        bool is_bitset, bool inplace) {
-    int ctr = 0;
     bitset_container_t* BI = bitset_container_create();
     container_t* BO;
     bool result_is_bitset;
@@ -1490,7 +1489,6 @@ static int bitset_negation_range_tests(int sparsity, int r_start, int r_end,
 
     for (int x = 0; x < (1 << 16); x++) {
         if (x % sparsity) bitset_container_add(BI, (uint16_t)x);
-        ++ctr;
     }
 
     for (int x = 0; x < (1 << 16); x++) {


### PR DESCRIPTION
best would be to set all static inline, but some
are exported, so let the compiler decide what to inline

also improve grow, by pagesize