### PR TITLE
Keep capacity sane when creating a bitmap with a capacity

### DIFF
--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -76,7 +76,10 @@ bool ra_init_with_capacity(roaring_array_t *new_ra, uint32_t cap) {
     if (!new_ra) return false;
     ra_init(new_ra);
 
-    if (cap > INT32_MAX) { return false; }
+    // Containers hold 64Ki elements, so 64Ki containers is enough to hold `0x10000 * 0x10000` (all 2^32) elements
+    if (cap > 0x10000) {
+        cap = 0x10000;
+    }
 
     if(cap > 0) {
       void *bigalloc = roaring_malloc(cap *

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -532,6 +532,13 @@ DEFINE_TEST(test_stats) {
     roaring_bitmap_free(r1);
 }
 
+DEFINE_TEST(with_huge_capacity) {
+    roaring_bitmap_t *r = roaring_bitmap_create_with_capacity(UINT32_MAX);
+    assert_non_null(r);
+    assert_int_equal(r->high_low_container.allocation_size, (1 << 16));
+    roaring_bitmap_free(r);
+}
+
 // this should expose memory leaks
 // (https://github.com/RoaringBitmap/CRoaring/pull/70)
 void leaks_with_empty(bool copy_on_write) {
@@ -4623,6 +4630,7 @@ int main() {
         cmocka_unit_test(test_silly_range),
         cmocka_unit_test(test_uint32_iterator_true),
         cmocka_unit_test(test_uint32_iterator_false),
+        cmocka_unit_test(with_huge_capacity),
         cmocka_unit_test(leaks_with_empty_true),
         cmocka_unit_test(leaks_with_empty_false),
         cmocka_unit_test(test_bitmap_from_range),


### PR DESCRIPTION
The previous code would happily accept and create _huge_ allocations (up to 22 GiB) for up to 2 billion containers. However, we know the maximum number of containers possible, so we instead clamp to that value.

This leads to two changes:
- When requesting more than 2^16 containers, we will only allocate space for 2^16 containers
- When requesting more than 2^31 containers, we will no longer error