### PR TITLE
Add ROARING_USE_CPM option in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,11 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 
-include(cmake/CPM.cmake)
+option(ROARING_USE_CPM "Use CPM to fetch dependencies" ON)
+
+if(ROARING_USE_CPM)
+  include(cmake/CPM.cmake)
+endif()
 find_package(CTargets)
 find_package(Options)
 find_package(LTO)

--- a/microbenchmarks/CMakeLists.txt
+++ b/microbenchmarks/CMakeLists.txt
@@ -3,19 +3,23 @@ set (BENCHMARK_DATA_DIR "${PROJECT_SOURCE_DIR}/benchmarks/realdata/")
 
 include(${PROJECT_SOURCE_DIR}/tools/cmake/Import.cmake)
 
-set_off(BENCHMARK_ENABLE_TESTING)
-set_off(BENCHMARK_ENABLE_INSTALL)
-set_off(BENCHMARK_ENABLE_WERROR)
-set(BENCHMARK_ENABLE_WERROR OFF)
- CPMAddPackage(
-     NAME benchmark
-     GITHUB_REPOSITORY google/benchmark
-     GIT_TAG 3441176
-     OPTIONS "BENCHMARK_ENABLE_TESTING OFF"
-             "BENCHMARK_ENABLE_INSTALL OFF"
-             "BENCHMARK_ENABLE_WERROR OFF"
+if(ROARING_USE_CPM)
+    set_off(BENCHMARK_ENABLE_TESTING)
+    set_off(BENCHMARK_ENABLE_INSTALL)
+    set_off(BENCHMARK_ENABLE_WERROR)
+    set(BENCHMARK_ENABLE_WERROR OFF)
+    CPMAddPackage(
+        NAME benchmark
+        GITHUB_REPOSITORY google/benchmark
+        GIT_TAG 3441176
+        OPTIONS "BENCHMARK_ENABLE_TESTING OFF"
+                "BENCHMARK_ENABLE_INSTALL OFF"
+                "BENCHMARK_ENABLE_WERROR OFF"
 
-   )
+    )
+else()
+    find_package(benchmark REQUIRED)
+endif()
 
 add_executable(bench bench.cpp)
 target_link_libraries(bench PRIVATE roaring)

--- a/tools/cmake/FindCTargets.cmake
+++ b/tools/cmake/FindCTargets.cmake
@@ -4,11 +4,15 @@ endif ()
 include(${PROJECT_SOURCE_DIR}/tools/cmake/Import.cmake)
 set(BUILD_STATIC_LIB ON)
 if (ENABLE_ROARING_TESTS)
-  CPMAddPackage(
-       NAME cmocka
-       GITHUB_REPOSITORY clibs/cmocka
-       GIT_TAG f5e2cd7
+  if(ROARING_USE_CPM)
+    CPMAddPackage(
+      NAME cmocka
+      GITHUB_REPOSITORY clibs/cmocka
+      GIT_TAG f5e2cd7
     )
+  else()
+    find_package(cmocka REQUIRED)
+  endif()
 endif()
 
 function(add_c_test TEST_NAME)
@@ -18,7 +22,11 @@ function(add_c_test TEST_NAME)
 
   add_executable(${TEST_NAME} ${TEST_NAME}.c)
 
-  target_link_libraries(${TEST_NAME} roaring cmocka-static)
+  if(ROARING_USE_CPM)
+    target_link_libraries(${TEST_NAME} roaring cmocka-static)
+  else()
+    target_link_libraries(${TEST_NAME} roaring cmocka)
+  endif()
 
   add_test(${TEST_NAME} ${TEST_NAME})
 endfunction(add_c_test)
@@ -35,7 +43,11 @@ if (CMAKE_VERSION VERSION_GREATER 2.8.10)
     get_directory_property(parent_dir PARENT_DIRECTORY)
     target_include_directories(${TEST_NAME} PRIVATE "${parent_dir}/cpp")
 
-    target_link_libraries(${TEST_NAME} roaring cmocka-static)
+    if(ROARING_USE_CPM)
+      target_link_libraries(${TEST_NAME} roaring cmocka-static)
+    else()
+      target_link_libraries(${TEST_NAME} roaring cmocka)
+    endif()
 
     add_test(${TEST_NAME} ${TEST_NAME})
   endfunction(add_cpp_test)


### PR DESCRIPTION
Add `ROARING_USE_CPM` option (ON by default), so that it can use CPM to deal with dependencies or use system dependencies, which it is helpful for packager to use the option of enabling tests.