### PR TITLE
Add support for portable_deserialize_frozen to C++ API

### DIFF
--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -699,6 +699,21 @@ public:
     }
 
     /**
+     * For advanced users; see roaring_bitmap_portable_deserialize_frozen.
+     * This function may throw std::runtime_error.
+     */
+    static const Roaring portableDeserializeFrozen(const char* buf) {
+        const roaring_bitmap_t *s =
+            api::roaring_bitmap_portable_deserialize_frozen(buf);
+        if (s == NULL) {
+            ROARING_TERMINATE("failed to read portable frozen bitmap");
+        }
+        Roaring r;
+        r.roaring = *s;
+        return r;
+    }
+
+    /**
      * For advanced users.
      */
     void writeFrozen(char *buf) const noexcept {

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -1266,6 +1266,26 @@ public:
         return result;
     }
 
+    static const Roaring64Map portableDeserializeFrozen(const char* buf) {
+        Roaring64Map result;
+        // get map size
+        uint64_t map_size;
+        std::memcpy(&map_size, buf, sizeof(uint64_t));
+        buf += sizeof(uint64_t);
+        for (uint64_t lcv = 0; lcv < map_size; lcv++) {
+            // get map key
+            uint32_t key;
+            std::memcpy(&key, buf, sizeof(uint32_t));
+            buf += sizeof(uint32_t);
+            // read map value Roaring
+            Roaring read_var = Roaring::portableDeserializeFrozen(buf);
+            // forward buffer past the last Roaring bitmap
+            buf += read_var.getSizeInBytes(true);
+            result.emplaceOrInsert(key, std::move(read_var));
+        }
+        return result;
+    }
+
     // As with serialized 64-bit bitmaps, 64-bit frozen bitmaps are serialized
     // by concatenating one or more Roaring::write output buffers with the
     // preceeding map key. Unlike standard bitmap serialization, frozen bitmaps

--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -209,6 +209,7 @@ int32_t array_container_read(int32_t cardinality, array_container_t *container,
  * that the cardinality of the container is already known.
  *
  */
+ALLOW_UNALIGNED
 static inline int32_t array_container_size_in_bytes(
     const array_container_t *container) {
     return container->cardinality * sizeof(uint16_t);

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -475,6 +475,7 @@ int32_t run_container_read(int32_t cardinality, run_container_t *container,
  * Return the serialized size in bytes of a container (see run_container_write).
  * This is meant to be compatible with the Java and Go versions of Roaring.
  */
+ALLOW_UNALIGNED
 static inline int32_t run_container_size_in_bytes(
     const run_container_t *container) {
     return run_container_serialized_size_in_bytes(container->n_runs);

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -78,6 +78,7 @@ array_container_t * array_container_create_range(uint32_t min, uint32_t max) {
 }
 
 /* Duplicate container */
+ALLOW_UNALIGNED
 array_container_t *array_container_clone(const array_container_t *src) {
     array_container_t *newcontainer =
         array_container_create_given_capacity(src->capacity);

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -128,6 +128,7 @@ void bitset_container_free(bitset_container_t *bitset) {
 }
 
 /* duplicate container. */
+ALLOW_UNALIGNED
 bitset_container_t *bitset_container_clone(const bitset_container_t *src) {
     bitset_container_t *bitset =
         (bitset_container_t *)roaring_malloc(sizeof(bitset_container_t));

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -111,6 +111,7 @@ run_container_t *run_container_create(void) {
     return run_container_create_given_capacity(RUN_DEFAULT_INIT_SIZE);
 }
 
+ALLOW_UNALIGNED
 run_container_t *run_container_clone(const run_container_t *src) {
     run_container_t *run = run_container_create_given_capacity(src->capacity);
     if (run == NULL) return NULL;


### PR DESCRIPTION
As tittle. `roaring_bitmap_portable_deserialize_frozen` was not supported in the C++ API, this PR adds it for both `Roaring` and `Roaring64Map`, and adds tests.