### PR TITLE
Add roaring64 to amalgamation script

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -39,6 +39,7 @@ $SCRIPTPATH/include/roaring/portability.h
 $SCRIPTPATH/include/roaring/bitset/bitset.h
 $SCRIPTPATH/include/roaring/roaring.h
 $SCRIPTPATH/include/roaring/memory.h
+$SCRIPTPATH/include/roaring/roaring64.h
 "
 
 # .hh header files for the C++ API wrapper => Order does not matter at present
@@ -72,6 +73,7 @@ $SCRIPTPATH/include/roaring/containers/mixed_union.h
 $SCRIPTPATH/include/roaring/containers/mixed_xor.h
 $SCRIPTPATH/include/roaring/containers/containers.h
 $SCRIPTPATH/include/roaring/roaring_array.h
+$SCRIPTPATH/include/roaring/art/art.h
 "
 
 # .c implementation files
@@ -177,6 +179,11 @@ int main() {
   for (uint32_t i = 100; i < 1000; i++) roaring_bitmap_add(r1, i);
   printf("cardinality = %d\n", (int) roaring_bitmap_get_cardinality(r1));
   roaring_bitmap_free(r1);
+
+  roaring64_bitmap_t *r2 = roaring64_bitmap_create();
+  for (uint64_t i = 100; i < 1000; i++) roaring64_bitmap_add(r2, i);
+  printf("cardinality (64-bit) = %d\n", (int) roaring64_bitmap_get_cardinality(r2));
+  roaring64_bitmap_free(r2);
 
   bitset_t *b = bitset_create();
   for (int k = 0; k < 1000; ++k) {


### PR DESCRIPTION
Fixes #543.

Tested:
```
$ ./amalgamation.sh
We are about to amalgamate all CRoaring files into one source file.
For rationale, see: https://www.sqlite.org/amalgamation.html
and: https://en.wikipedia.org/wiki/Single_Compilation_Unit

Creating roaring.h...
Creating roaring.c...
Creating amalgamation_demo.c...
Creating roaring.hh...
Creating amalgamation_demo.cpp...

Files have been written to current directory: /home/soerian/repos/CRoaring
-rw-rw-r-- 1 soerian soerian    825 Jan  9 09:28 amalgamation_demo.c
-rw-rw-r-- 1 soerian soerian   2526 Jan  9 09:28 amalgamation_demo.cpp
-rw-rw-r-- 1 soerian soerian 951998 Jan  9 09:28 roaring.c
-rw-rw-r-- 1 soerian soerian  85995 Jan  9 09:28 roaring.h
-rw-rw-r-- 1 soerian soerian 105913 Jan  9 09:28 roaring.hh

The interface is found in the file 'include/roaring/roaring.h'.

For C, try:
cc -O3 -std=c11  -o amalgamation_demo amalgamation_demo.c  && ./amalgamation_demo

For C++, try:
c++ -O3 -std=c++11 -o amalgamation_demo amalgamation_demo.cpp  && ./amalgamation_demo

You can build a shared library with the following command:
cc -O3 -std=c11 -shared -o libroaring.so -fPIC roaring.c

$ cc -O3 -std=c11  -o amalgamation_demo amalgamation_demo.c  && ./amalgamation_demo
cardinality = 900
cardinality (64-bit) = 900
1000
```