### PR TITLE
roaring64: container_remove_range returns null rather than returning an empty container

### DIFF
--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -538,13 +538,13 @@ static inline void remove_range_closed_at(art_t *art, uint8_t *high48,
         leaf->container, leaf->typecode, min, max, &typecode2);
     if (container2 != leaf->container) {
         container_free(leaf->container, leaf->typecode);
-        leaf->container = container2;
-        leaf->typecode = typecode2;
-    }
-    if (!container_nonzero_cardinality(container2, typecode2)) {
-        art_erase(art, high48);
-        container_free(container2, typecode2);
-        free_leaf(leaf);
+        if (container2 != NULL) {
+            leaf->container = container2;
+            leaf->typecode = typecode2;
+        } else {
+            art_erase(art, high48);
+            free_leaf(leaf);
+        }
     }
 }
 

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -383,6 +383,21 @@ DEFINE_TEST(test_remove_range_closed) {
         assert_true(roaring64_bitmap_contains_bulk(r, &context, 300000));
         roaring64_bitmap_free(r);
     }
+    {
+        // Range completely clears the bitmap.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        // array container
+        roaring64_bitmap_add(r, 1);
+        // range container
+        roaring64_bitmap_add_range_closed(r, 0x10000, 0x20000);
+        // bitmap container
+        for (int i = 0x20000; i < 0x25000; i += 2) {
+            roaring64_bitmap_add(r, i);
+        }
+        roaring64_bitmap_remove_range_closed(r, 0, 0x30000);
+        assert_true(roaring64_bitmap_is_empty(r));
+        roaring64_bitmap_free(r);
+    }
 }
 
 DEFINE_TEST(test_get_cardinality) {


### PR DESCRIPTION
This would lead to all sorts of issues: `typecode2` is read uninitialized, and hopefully just asserts that it's not one of the known typecodes. Then, we've stored a null container into the bitmap.