### PR TITLE
roaring64: container_add_range _is_ inclusive

### DIFF
--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -1,8 +1,8 @@
 #include <assert.h>
 #include <roaring/art/art.h>
 #include <roaring/containers/containers.h>
-#include <roaring/roaring64.h>
 #include <roaring/portability.h>
+#include <roaring/roaring64.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <string.h>
@@ -272,7 +272,7 @@ static inline void add_range_closed_at(art_t *art, uint8_t *high48,
     if (leaf != NULL) {
         uint8_t typecode2;
         container_t *container2 = container_add_range(
-            leaf->container, leaf->typecode, min, max + 1, &typecode2);
+            leaf->container, leaf->typecode, min, max, &typecode2);
         if (container2 != leaf->container) {
             container_free(leaf->container, leaf->typecode);
             leaf->container = container2;
@@ -281,6 +281,8 @@ static inline void add_range_closed_at(art_t *art, uint8_t *high48,
         return;
     }
     uint8_t typecode;
+    // container_add_range is inclusive, but `container_range_of_ones` is
+    // exclusive.
     container_t *container = container_range_of_ones(min, max + 1, &typecode);
     leaf = create_leaf(container, typecode);
     art_insert(art, high48, (art_val_t *)leaf);
@@ -531,8 +533,6 @@ static inline void remove_range_closed_at(art_t *art, uint8_t *high48,
         return;
     }
     uint8_t typecode2;
-    // container_add_range is exclusive but container_remove_range is
-    // inclusive...
     container_t *container2 = container_remove_range(
         leaf->container, leaf->typecode, min, max, &typecode2);
     if (container2 != leaf->container) {

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -199,6 +199,16 @@ DEFINE_TEST(test_add_range_closed) {
         assert_false(roaring64_bitmap_contains_bulk(r, &context, 300001));
         roaring64_bitmap_free(r);
     }
+    {
+        // Add range to existing container
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        roaring64_bitmap_add(r, 100);
+        roaring64_bitmap_add_range_closed(r, 0, 0);
+        assert_int_equal(roaring64_bitmap_get_cardinality(r), 2);
+        assert_true(roaring64_bitmap_contains(r, 0));
+        assert_true(roaring64_bitmap_contains(r, 100));
+        roaring64_bitmap_free(r);
+    }
 }
 
 DEFINE_TEST(test_contains_bulk) {


### PR DESCRIPTION
`container_add_range` is from `[min, max]`, no need to add one: https://github.com/RoaringBitmap/CRoaring/blob/f3ad2f2e52c53d0241a6327bdf193423c47059c0/include/roaring/containers/containers.h#L2377

Add a test to verify adding a range to an existing container works correctly