### PR TITLE
We do not allow empty containers as part of the specification.

### DIFF
--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -860,6 +860,9 @@ void roaring_bitmap_statistics(const roaring_bitmap_t *r,
 
 /**
  * Perform internal consistency checks. Returns true if the bitmap is consistent.
+ * It may be useful to call this after deserializing bitmaps from untrusted sources.
+ * If roaring_bitmap_internal_validate returns true, then the bitmap should be consistent
+ * and can be trusted not to cause crashes or memory corruption.
  *
  * Note that some operations intentionally leave bitmaps in an inconsistent state temporarily,
  * for example, `roaring_bitmap_lazy_*` functions, until `roaring_bitmap_repair_after_lazy` is called.

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -568,6 +568,10 @@ roaring_bitmap_t *roaring_bitmap_portable_deserialize(const char *buf);
  * run containers should be in sorted non-overlapping order. This is is guaranteed to
  * happen when serializing an existing bitmap, but not for random inputs.
  *
+ * You may use roaring_bitmap_internal_validate to check the validity of the bitmap prior
+ * to using it. You may also use other strategies to check for corrupted inputs (e.g.,
+ * checksums).
+ *
  * This function is endian-sensitive. If you have a big-endian system (e.g., a mainframe IBM s390x),
  * the data format is going to be big-endian and not compatible with little-endian systems.
  */

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -465,7 +465,8 @@ bool array_container_validate(const array_container_t *v, const char **reason) {
         return false;
     }
     if (v->cardinality == 0) {
-        return true;
+        *reason = "zero cardinality";
+        return false;
     }
 
     if (v->array == NULL) {

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -1015,7 +1015,7 @@ bool bitset_container_validate(const bitset_container_t *v, const char **reason)
         return false;
     }
     if (v->cardinality <= DEFAULT_MAX_SIZE) {
-        *reason = "cardinality is too small";
+        *reason = "cardinality is too small for a bitmap container";
         return false;
     }
     // Attempt to forcibly load the first and last words, hopefully causing

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -12,6 +12,7 @@
 
 #include <roaring/bitset_util.h>
 #include <roaring/containers/bitset.h>
+#include <roaring/containers/array.h>
 #include <roaring/portability.h>
 #include <roaring/memory.h>
 #include <roaring/utilasm.h>
@@ -1011,6 +1012,10 @@ bool bitset_container_validate(const bitset_container_t *v, const char **reason)
     }
     if (v->cardinality != bitset_container_compute_cardinality(v)) {
         *reason = "cardinality is incorrect";
+        return false;
+    }
+    if (v->cardinality <= DEFAULT_MAX_SIZE) {
+        *reason = "cardinality is too small";
         return false;
     }
     // Attempt to forcibly load the first and last words, hopefully causing

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -695,7 +695,8 @@ bool run_container_validate(const run_container_t *run, const char **reason) {
     }
 
     if (run->n_runs == 0) {
-        return true;
+        *reason = "zero run count";
+        return false;
     }
     if (run->runs == NULL) {
         *reason = "NULL runs";

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -4778,7 +4778,6 @@ int main() {
     tellmeall();
 
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(issue_15jan2024),
         cmocka_unit_test(issue538b),
         cmocka_unit_test(issue538),
         cmocka_unit_test(simple_roaring_bitmap_or_many),
@@ -4929,6 +4928,7 @@ int main() {
         cmocka_unit_test(test_frozen_serialization),
         cmocka_unit_test(test_frozen_serialization_max_containers),
         cmocka_unit_test(test_portable_deserialize_frozen),
+        cmocka_unit_test(issue_15jan2024),
 #endif
     };
 

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -4758,10 +4758,27 @@ DEFINE_TEST(issue538b) {
   roaring_bitmap_free(expected);
 }
 
+DEFINE_TEST(issue_15jan2024) {
+    roaring_bitmap_t *r1 = roaring_bitmap_create();
+    roaring_bitmap_add(r1, 1);
+    // Serialized bitmap data
+    char diff_bitmap[] = {
+        0x3b, 0x30, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+    roaring_bitmap_t *r2 = roaring_bitmap_portable_deserialize_safe(diff_bitmap, sizeof(diff_bitmap));
+    assert_true (r2 != NULL);
+    const char *reason = NULL;
+    assert_false(roaring_bitmap_internal_validate(r2, &reason));
+    printf("reason = %s\n", reason);
+    roaring_bitmap_free(r1);
+    roaring_bitmap_free(r2);
+}
+
 int main() {
     tellmeall();
 
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(issue_15jan2024),
         cmocka_unit_test(issue538b),
         cmocka_unit_test(issue538),
         cmocka_unit_test(simple_roaring_bitmap_or_many),


### PR DESCRIPTION
When validating a container, we should reject it if it is empty.

The Roaring format does not allow empty containers.