### PR TITLE
Replace `roaring{,64}_bitmap_of` with `roaring{,64}_bitmap_from` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ int main() {
            expectedsizebasic, expectedsizerun);
 
     // create a new bitmap containing the values {1,2,3,5,6}
-    roaring_bitmap_t *r2 = roaring_bitmap_of(5, 1, 2, 3, 5, 6);
+    roaring_bitmap_t *r2 = roaring_bitmap_from(1, 2, 3, 5, 6);
     roaring_bitmap_printf(r2);  // print it
 
     // we can also create a bitmap from a pointer to 32-bit integers

--- a/tests/c_example1.c
+++ b/tests/c_example1.c
@@ -30,7 +30,7 @@ int main() {
     printf("size before run optimize %d bytes, and after %d bytes\n",
            expectedsizebasic, expectedsizerun);
     // create a new bitmap containing the values {1,2,3,5,6}
-    roaring_bitmap_t *r2 = roaring_bitmap_of(5, 1, 2, 3, 5, 6);
+    roaring_bitmap_t *r2 = roaring_bitmap_from(1, 2, 3, 5, 6);
     roaring_bitmap_printf(r2);  // print it
 
     // we can also create a bitmap from a pointer to 32-bit integers

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -101,7 +101,7 @@ void test_example(bool copy_on_write) {
     printf("size before run optimize %zu bytes, and after %zu bytes\n", size,
            compact_size);
     // create a new bitmap with varargs
-    roaring_bitmap_t *r2 = roaring_bitmap_of(5, 1, 2, 3, 5, 6);
+    roaring_bitmap_t *r2 = roaring_bitmap_from(1, 2, 3, 5, 6);
     assert_ptr_not_equal(r2, NULL);
     roaring_bitmap_printf(r2);
     printf("\n");

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -93,7 +93,7 @@ DEFINE_TEST(test_of_ptr) {
 }
 
 DEFINE_TEST(test_of) {
-    roaring64_bitmap_t* r = roaring64_bitmap_of(3, 1ULL, 20000ULL, 500000ULL);
+    roaring64_bitmap_t* r = roaring64_bitmap_from(1, 20000, 500000);
     assert_true(roaring64_bitmap_contains(r, 1));
     assert_true(roaring64_bitmap_contains(r, 20000));
     assert_true(roaring64_bitmap_contains(r, 500000));
@@ -1038,9 +1038,9 @@ DEFINE_TEST(test_flip) {
     }
     {
         // Only the specified range should be flipped.
-        roaring64_bitmap_t* r1 = roaring64_bitmap_of(3, 1ULL, 3ULL, 6ULL);
+        roaring64_bitmap_t* r1 = roaring64_bitmap_from(1, 3, 6);
         roaring64_bitmap_t* r2 = roaring64_bitmap_flip(r1, 2, 5);
-        roaring64_bitmap_t* r3 = roaring64_bitmap_of(4, 1ULL, 2ULL, 4ULL, 6ULL);
+        roaring64_bitmap_t* r3 = roaring64_bitmap_from(1, 2, 4, 6);
         assert_true(roaring64_bitmap_equals(r2, r3));
 
         roaring64_bitmap_free(r1);
@@ -1049,7 +1049,7 @@ DEFINE_TEST(test_flip) {
     }
     {
         // An empty range does nothing.
-        roaring64_bitmap_t* r1 = roaring64_bitmap_of(3, 1ULL, 3ULL, 6);
+        roaring64_bitmap_t* r1 = roaring64_bitmap_from(1, 3, 6);
         roaring64_bitmap_t* r2 = roaring64_bitmap_flip(r1, 3, 3);
         assert_true(roaring64_bitmap_equals(r2, r1));
 
@@ -1058,8 +1058,8 @@ DEFINE_TEST(test_flip) {
     }
     {
         // A bitmap with values in all affected containers.
-        roaring64_bitmap_t* r1 = roaring64_bitmap_of(
-            3, (2ULL << 16), (3ULL << 16) + 1, (4ULL << 16) + 3);
+        roaring64_bitmap_t* r1 = roaring64_bitmap_from(
+            (2 << 16), (3 << 16) + 1, (4 << 16) + 3);
         roaring64_bitmap_t* r2 =
             roaring64_bitmap_flip(r1, (2 << 16), (4 << 16) + 4);
         roaring64_bitmap_t* r3 =
@@ -1084,9 +1084,9 @@ DEFINE_TEST(test_flip_inplace) {
     }
     {
         // Only the specified range should be flipped.
-        roaring64_bitmap_t* r1 = roaring64_bitmap_of(3, 1ULL, 3ULL, 6ULL);
+        roaring64_bitmap_t* r1 = roaring64_bitmap_from(1, 3, 6);
         roaring64_bitmap_flip_inplace(r1, 2, 5);
-        roaring64_bitmap_t* r2 = roaring64_bitmap_of(4, 1ULL, 2ULL, 4ULL, 6ULL);
+        roaring64_bitmap_t* r2 = roaring64_bitmap_from(1, 2, 4, 6);
         assert_true(roaring64_bitmap_equals(r1, r2));
 
         roaring64_bitmap_free(r1);
@@ -1094,9 +1094,9 @@ DEFINE_TEST(test_flip_inplace) {
     }
     {
         // An empty range does nothing.
-        roaring64_bitmap_t* r1 = roaring64_bitmap_of(3, 1ULL, 3ULL, 6ULL);
+        roaring64_bitmap_t* r1 = roaring64_bitmap_from(1, 3, 6);
         roaring64_bitmap_flip_inplace(r1, 3, 3);
-        roaring64_bitmap_t* r2 = roaring64_bitmap_of(3, 1ULL, 3ULL, 6ULL);
+        roaring64_bitmap_t* r2 = roaring64_bitmap_from(1, 3, 6);
         assert_true(roaring64_bitmap_equals(r1, r2));
 
         roaring64_bitmap_free(r1);
@@ -1104,8 +1104,8 @@ DEFINE_TEST(test_flip_inplace) {
     }
     {
         // A bitmap with values in all affected containers.
-        roaring64_bitmap_t* r1 = roaring64_bitmap_of(
-            3, (2ULL << 16), (3ULL << 16) + 1, (4ULL << 16) + 3);
+        roaring64_bitmap_t* r1 = roaring64_bitmap_from(
+            (2 << 16), (3 << 16) + 1, (4 << 16) + 3);
         roaring64_bitmap_flip_inplace(r1, (2 << 16), (4 << 16) + 4);
         roaring64_bitmap_t* r2 =
             roaring64_bitmap_from_range((2 << 16) + 1, (4 << 16) + 3, 1);

--- a/tests/threads_unit.cpp
+++ b/tests/threads_unit.cpp
@@ -39,7 +39,7 @@ bool run_threads_unit_tests() {
     
     roaring_bitmap_set_copy_on_write(r1, true);
     roaring_bitmap_run_optimize(r1);
-    roaring_bitmap_t *r2 = roaring_bitmap_of(5, 10010,10020,10030,10040,10050);
+    roaring_bitmap_t *r2 = roaring_bitmap_from(10010,10020,10030,10040,10050);
     roaring_bitmap_set_copy_on_write(r2, true);
     roaring_bitmap_t *r3 = roaring_bitmap_copy(r1);
     roaring_bitmap_set_copy_on_write(r3, true);

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -575,7 +575,7 @@ DEFINE_TEST(leaks_with_empty_false) { leaks_with_empty(false); }
 
 DEFINE_TEST(check_interval) {
     // create a new bitmap with varargs
-    roaring_bitmap_t *r = roaring_bitmap_of(4, 1, 2, 3, 1000);
+    roaring_bitmap_t *r = roaring_bitmap_from(1, 2, 3, 1000);
     assert_non_null(r);
 
     roaring_bitmap_printf(r);
@@ -728,7 +728,7 @@ void test_example(bool copy_on_write) {
            compact_size);
 
     // create a new bitmap with varargs
-    roaring_bitmap_t *r2 = roaring_bitmap_of(5, 1, 2, 3, 5, 6);
+    roaring_bitmap_t *r2 = roaring_bitmap_from(1, 2, 3, 5, 6);
     assert_bitmap_validate(r2);
     assert_non_null(r2);
 
@@ -1186,7 +1186,7 @@ DEFINE_TEST(test_bitmap_from_range) {
 
 DEFINE_TEST(test_printf) {
     roaring_bitmap_t *r1 =
-        roaring_bitmap_of(8, 1, 2, 3, 100, 1000, 10000, 1000000, 20000000);
+        roaring_bitmap_from(1, 2, 3, 100, 1000, 10000, 1000000, 20000000);
     assert_bitmap_validate(r1);
     assert_non_null(r1);
     roaring_bitmap_printf(r1);
@@ -1230,7 +1230,7 @@ bool dummy_iterator(uint32_t value, void *param) {
 
 DEFINE_TEST(test_iterate) {
     roaring_bitmap_t *r1 =
-        roaring_bitmap_of(8, 1, 2, 3, 100, 1000, 10000, 1000000, 20000000);
+        roaring_bitmap_from(1, 2, 3, 100, 1000, 10000, 1000000, 20000000);
     assert_non_null(r1);
 
     uint32_t num = 0;
@@ -1302,7 +1302,7 @@ DEFINE_TEST(test_remove_withrun) {
 
 DEFINE_TEST(test_portable_serialize) {
     roaring_bitmap_t *r1 =
-        roaring_bitmap_of(8, 1, 2, 3, 100, 1000, 10000, 1000000, 20000000);
+        roaring_bitmap_from(1, 2, 3, 100, 1000, 10000, 1000000, 20000000);
     assert_non_null(r1);
 
     uint32_t serialize_len;
@@ -1335,8 +1335,8 @@ DEFINE_TEST(test_portable_serialize) {
     roaring_bitmap_free(r1);
     roaring_bitmap_free(r2);
 
-    r1 = roaring_bitmap_of(6, 2946000, 2997491, 10478289, 10490227, 10502444,
-                           19866827);
+    r1 = roaring_bitmap_from(2946000, 2997491, 10478289, 10490227, 10502444,
+                             19866827);
     expectedsize = roaring_bitmap_portable_size_in_bytes(r1);
     serialized = (char *)malloc(expectedsize);
     serialize_len = roaring_bitmap_portable_serialize(r1, serialized);
@@ -1397,7 +1397,7 @@ DEFINE_TEST(test_portable_serialize) {
 
 DEFINE_TEST(test_serialize) {
     roaring_bitmap_t *r1 =
-        roaring_bitmap_of(8, 1, 2, 3, 100, 1000, 10000, 1000000, 20000000);
+        roaring_bitmap_from(1, 2, 3, 100, 1000, 10000, 1000000, 20000000);
     assert_non_null(r1);
 
     uint32_t serialize_len;
@@ -1466,8 +1466,8 @@ DEFINE_TEST(test_serialize) {
     roaring_bitmap_free(r1);
     roaring_bitmap_free(r2);
 
-    r1 = roaring_bitmap_of(6, 2946000, 2997491, 10478289, 10490227, 10502444,
-                           19866827);
+    r1 = roaring_bitmap_from(2946000, 2997491, 10478289, 10490227, 10502444,
+                             19866827);
 
     serialized = (char *)malloc(roaring_bitmap_size_in_bytes(r1));
     serialize_len = roaring_bitmap_serialize(r1, serialized);
@@ -4531,7 +4531,7 @@ DEFINE_TEST(test_frozen_serialization_max_containers) {
 
 DEFINE_TEST(test_portable_deserialize_frozen) {
     roaring_bitmap_t *r1 =
-        roaring_bitmap_of(8, 1, 2, 3, 100, 1000, 10000, 1000000, 20000000);
+        roaring_bitmap_from(1, 2, 3, 100, 1000, 10000, 1000000, 20000000);
     assert_non_null(r1);
 
     uint32_t serialize_len;
@@ -4563,8 +4563,8 @@ DEFINE_TEST(test_portable_deserialize_frozen) {
     roaring_bitmap_free(r1);
     roaring_bitmap_free(r2);
 
-    r1 = roaring_bitmap_of(6, 2946000, 2997491, 10478289, 10490227, 10502444,
-                           19866827);
+    r1 = roaring_bitmap_from(2946000, 2997491, 10478289, 10490227, 10502444,
+                             19866827);
     expectedsize = roaring_bitmap_portable_size_in_bytes(r1);
     serialized = (char *)malloc(expectedsize);
     serialize_len = roaring_bitmap_portable_serialize(r1, serialized);


### PR DESCRIPTION
Using a macro allows us to count the number of items passed, and avoid having to explicitly pass the count as the first parameter.