### PR TITLE
Fix roaring64_bitmap_contains_range when the range starts before the first present container

### DIFF
--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -395,7 +395,7 @@ bool roaring64_bitmap_contains_range(const roaring64_bitmap_t *r, uint64_t min,
     uint64_t max_high48_bits = max & 0xFFFFFFFFFFFF0000;
 
     art_iterator_t it = art_lower_bound(&r->art, min_high48);
-    if (it.value == NULL) {
+    if (it.value == NULL || combine_key(it.key, 0) > min) {
         return false;
     }
     uint64_t prev_high48_bits = min & 0xFFFFFFFFFFFF0000;

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -277,6 +277,7 @@ DEFINE_TEST(test_contains_range) {
         assert_true(roaring64_bitmap_contains_range(r, 1, (1 << 16) + 10));
         assert_true(roaring64_bitmap_contains_range(r, 1, (1 << 16) - 1));
         assert_false(roaring64_bitmap_contains_range(r, 1, (1 << 16) + 11));
+        assert_false(roaring64_bitmap_contains_range(r, 0, (1 << 16) + 10));
         roaring64_bitmap_free(r);
     }
     {
@@ -300,6 +301,21 @@ DEFINE_TEST(test_contains_range) {
         roaring64_bitmap_t* r = roaring64_bitmap_create();
         roaring64_bitmap_add_range(r, 1, 1 << 16);
         assert_false(roaring64_bitmap_contains_range(r, 1, (1 << 16)));
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Range entirely before the bitmap.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        roaring64_bitmap_add(r, 1 << 16);
+        assert_false(roaring64_bitmap_contains_range(r, 1, 10));
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Range entirely after the bitmap.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        roaring64_bitmap_add(r, 1 << 16);
+        assert_false(
+            roaring64_bitmap_contains_range(r, 2 << 16, (2 << 16) + 1));
         roaring64_bitmap_free(r);
     }
 }
@@ -1058,8 +1074,8 @@ DEFINE_TEST(test_flip) {
     }
     {
         // A bitmap with values in all affected containers.
-        roaring64_bitmap_t* r1 = roaring64_bitmap_from(
-            (2 << 16), (3 << 16) + 1, (4 << 16) + 3);
+        roaring64_bitmap_t* r1 =
+            roaring64_bitmap_from((2 << 16), (3 << 16) + 1, (4 << 16) + 3);
         roaring64_bitmap_t* r2 =
             roaring64_bitmap_flip(r1, (2 << 16), (4 << 16) + 4);
         roaring64_bitmap_t* r3 =
@@ -1104,8 +1120,8 @@ DEFINE_TEST(test_flip_inplace) {
     }
     {
         // A bitmap with values in all affected containers.
-        roaring64_bitmap_t* r1 = roaring64_bitmap_from(
-            (2 << 16), (3 << 16) + 1, (4 << 16) + 3);
+        roaring64_bitmap_t* r1 =
+            roaring64_bitmap_from((2 << 16), (3 << 16) + 1, (4 << 16) + 3);
         roaring64_bitmap_flip_inplace(r1, (2 << 16), (4 << 16) + 4);
         roaring64_bitmap_t* r2 =
             roaring64_bitmap_from_range((2 << 16) + 1, (4 << 16) + 3, 1);


### PR DESCRIPTION
Fixes #571. This adds a check for when the iterator position is after the start of the range.

Also added a test.