### PR TITLE
Fix r64 contains range when max is divisible by 2^16

### DIFF
--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -396,7 +396,7 @@ bool roaring64_bitmap_contains_range(const roaring64_bitmap_t *r, uint64_t min,
     uint16_t min_low16 = split_key(min, min_high48);
     uint8_t max_high48[ART_KEY_BYTES];
     uint16_t max_low16 = split_key(max, max_high48);
-    uint64_t max_high48_bits = max & 0xFFFFFFFFFFFF0000;
+    uint64_t max_high48_bits = (max - 1) & 0xFFFFFFFFFFFF0000;  // Inclusive
 
     art_iterator_t it = art_lower_bound(&r->art, min_high48);
     if (it.value == NULL || combine_key(it.key, 0) > min) {

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -311,7 +311,7 @@ DEFINE_TEST(test_contains_range) {
         // Range larger than bitmap.
         roaring64_bitmap_t* r = roaring64_bitmap_create();
         roaring64_bitmap_add_range(r, 1, 1 << 16);
-        assert_false(roaring64_bitmap_contains_range(r, 1, (1 << 16)));
+        assert_false(roaring64_bitmap_contains_range(r, 1, (1 << 16) + 1));
         roaring64_bitmap_free(r);
     }
     {
@@ -327,6 +327,24 @@ DEFINE_TEST(test_contains_range) {
         roaring64_bitmap_add(r, 1 << 16);
         assert_false(
             roaring64_bitmap_contains_range(r, 2 << 16, (2 << 16) + 1));
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Range exactly containing the last value in a container range.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        roaring64_bitmap_add(r, (1 << 16) - 1);
+        assert_true(
+            roaring64_bitmap_contains_range(r, (1 << 16) - 1, (1 << 16)));
+        assert_false(
+            roaring64_bitmap_contains_range(r, (1 << 16) - 1, (1 << 16) + 1));
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Range exactly containing the first value in a container range.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        roaring64_bitmap_add(r, (1 << 16));
+        assert_true(
+            roaring64_bitmap_contains_range(r, (1 << 16), (1 << 16) + 1));
         roaring64_bitmap_free(r);
     }
 }


### PR DESCRIPTION
Fixes #571. Added a test.