### PR TITLE
Correct commit hash of format commit for blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Ran clang-format on the entire repo.
-fd112ff5799e265fe172b3d28ff17388af108eb7
+37c0388f475dd42275661127917795c75f73bc50


### PR DESCRIPTION
Since the PR was squashed into one commit, the commit hash in .git-blame-ignore-revs was incorrect.

