### PR TITLE
r64 iterator: allow moving backward with move_equalorlarger

### DIFF
--- a/include/roaring/art/art.h
+++ b/include/roaring/art/art.h
@@ -149,8 +149,6 @@ bool art_iterator_prev(art_iterator_t *iterator);
 
 /**
  * Moves the iterator forward to a key equal to or greater than the given key.
- * Assumes the given key is greater or equal to the current position of the
- * iterator.
  */
 bool art_iterator_lower_bound(art_iterator_t *iterator,
                               const art_key_chunk_t *key);

--- a/src/art/art.c
+++ b/src/art/art.c
@@ -1508,12 +1508,17 @@ bool art_iterator_lower_bound(art_iterator_t *iterator,
                               const art_key_chunk_t *key) {
     int compare_result =
         art_compare_prefix(iterator->key, 0, key, 0, ART_KEY_BYTES);
-    // Move up until we have an equal or greater prefix, after which we can do a
-    // normal lower bound search.
-    while (compare_result < 0) {
+    // Move up until we have an equal prefix, after which we can do a normal
+    // lower bound search.
+    while (compare_result != 0) {
         if (!art_iterator_up(iterator)) {
-            // Only smaller keys found.
-            return art_iterator_invalid_loc(iterator);
+            if (compare_result < 0) {
+                // Only smaller keys found.
+                return art_iterator_invalid_loc(iterator);
+            } else {
+                return art_node_init_iterator(art_iterator_node(iterator),
+                                              iterator, true);
+            }
         }
         // Since we're only moving up, we can keep comparing against the
         // iterator key.

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -2015,9 +2015,9 @@ bool roaring64_iterator_move_equalorlarger(roaring64_iterator_t *it,
 
     uint8_t val_high48[ART_KEY_BYTES];
     uint16_t val_low16 = split_key(val, val_high48);
-    if (it->high48 < (val & 0xFFFFFFFFFFFF0000)) {
-        // The ART iterator is before the high48 bits of `val`, so we need to
-        // move to a leaf with a key equal or greater.
+    if (it->high48 != (val & 0xFFFFFFFFFFFF0000)) {
+        // The ART iterator is before or after the high48 bits of `val`, so we
+        // need to move to a leaf with a key equal or greater.
         if (!art_iterator_lower_bound(&it->art_it, val_high48)) {
             // Only smaller keys found.
             it->saturated_forward = true;

--- a/tests/art_unit.cpp
+++ b/tests/art_unit.cpp
@@ -282,9 +282,18 @@ DEFINE_TEST(test_art_iterator_lower_bound) {
             art_insert(&art, (art_key_chunk_t*)keys[i], &values[i]);
         }
         art_iterator_t iterator = art_init_iterator(&art, true);
-        const char* key = "000002";
-        assert_true(art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key));
+
+        const char* key1 = "000002";
+        assert_true(
+            art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key1));
         assert_key_eq(iterator.key, (art_key_chunk_t*)keys[1]);
+
+        // Check that we can go backward within a node's children.
+        const char* key2 = "000001";
+        assert_true(
+            art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key2));
+        assert_key_eq(iterator.key, (art_key_chunk_t*)keys[0]);
+
         art_free(&art);
     }
     {
@@ -297,9 +306,45 @@ DEFINE_TEST(test_art_iterator_lower_bound) {
             art_insert(&art, (art_key_chunk_t*)keys[i], &values[i]);
         }
         art_iterator_t iterator = art_init_iterator(&art, true);
-        const char* key = "000201";
-        assert_true(art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key));
-        assert_key_eq(iterator.key, (art_key_chunk_t*)keys[2]);
+
+        {
+            const char* key = "000201";
+            assert_true(
+                art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key));
+            assert_key_eq(iterator.key, (art_key_chunk_t*)keys[2]);
+        }
+        {
+            // Check that we can go backward.
+            const char* key = "000099";
+            assert_true(
+                art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key));
+            assert_key_eq(iterator.key, (art_key_chunk_t*)keys[0]);
+        }
+
+        art_free(&art);
+    }
+    {
+        // Lower bound search with only a single leaf.
+        const char* key1 = "000001";
+        Value value{1};
+        art_t art{NULL};
+        art_insert(&art, (art_key_chunk_t*)key1, &value);
+
+        art_iterator_t iterator = art_init_iterator(&art, true);
+
+        assert_true(
+            art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key1));
+        assert_key_eq(iterator.key, (art_key_chunk_t*)key1);
+
+        const char* key2 = "000000";
+        assert_true(
+            art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key2));
+        assert_key_eq(iterator.key, (art_key_chunk_t*)key1);
+
+        const char* key3 = "000002";
+        assert_false(
+            art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key3));
+
         art_free(&art);
     }
 }

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -1470,6 +1470,11 @@ DEFINE_TEST(test_iterator_move_equalorlarger) {
     assert_true(roaring64_iterator_previous(it));
     assert_int_equal(roaring64_iterator_value(it), (1ULL << 36));
 
+    // Check that we can move backward using move_equalorlarger.
+    assert_true(roaring64_iterator_move_equalorlarger(it, (1ULL << 35) - 1));
+    assert_true(roaring64_iterator_has_value(it));
+    assert_int_equal(roaring64_iterator_value(it), (1ULL << 35));
+
     roaring64_iterator_free(it);
     roaring64_bitmap_free(r);
 }


### PR DESCRIPTION
Fixes #575. This adds the ability to move backward to both the ART iterator and the roaring64 iterator.

