### PR TITLE
Simplify, and optimize roaring64_bitmap_remove_range_closed

### DIFF
--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -645,6 +645,12 @@ DEFINE_TEST(test_remove_range_closed) {
         assert_int_equal(roaring64_bitmap_maximum(r), UINT64_MAX - 6);
         roaring64_bitmap_free(r);
     }
+    {
+        // Remove a huge range
+        roaring64_bitmap_t* r = roaring64_bitmap_from(1, UINT64_MAX - 1);
+        roaring64_bitmap_remove_range_closed(r, 0, UINT64_MAX);
+        roaring64_bitmap_free(r);
+    }
 }
 
 DEFINE_TEST(test_get_cardinality) {


### PR DESCRIPTION
Only visit existing nodes, rather than every possible container in the range

This makes it feasible to use `roaring64_bitmap_remove_range_closed(r, 0, UINT64_MAX)`. Before, this would have taken forever, but now, it takes proportional time to the number of containers to remove.

See #549 (the first checkbox)