### PR TITLE
r64: Increase number of frames in ART iterator

### DIFF
--- a/include/roaring/art/art.h
+++ b/include/roaring/art/art.h
@@ -132,7 +132,10 @@ typedef struct art_iterator_s {
 
     uint8_t depth;  // Key depth
     uint8_t frame;  // Node depth
-    art_iterator_frame_t frames[ART_KEY_BYTES];
+
+    // State for each node in the ART the iterator has travelled from the root.
+    // This is `ART_KEY_BYTES + 1` because it includes state for the leaf too.
+    art_iterator_frame_t frames[ART_KEY_BYTES + 1];
 } art_iterator_t;
 
 /**

--- a/tests/art_unit.cpp
+++ b/tests/art_unit.cpp
@@ -212,58 +212,110 @@ DEFINE_TEST(test_art_is_empty) {
 }
 
 DEFINE_TEST(test_art_iterator_next) {
-    std::vector<std::array<uint8_t, 6>> keys;
-    std::vector<Value> values;
-    std::vector<size_t> sizes = {4, 16, 48, 256};
-    for (size_t i = 0; i < sizes.size(); i++) {
-        uint8_t size = static_cast<uint8_t>(sizes[i]);
-        for (size_t j = 0; j < size; j++) {
-            keys.push_back(
-                {0, 0, 0, static_cast<uint8_t>(i), static_cast<uint8_t>(j)});
-            values.push_back({static_cast<uint64_t>(i) * j});
+    {
+        // ART with multiple node sizes.
+        std::vector<std::array<uint8_t, 6>> keys;
+        std::vector<Value> values;
+        std::vector<size_t> sizes = {4, 16, 48, 256};
+        for (size_t i = 0; i < sizes.size(); i++) {
+            uint8_t size = static_cast<uint8_t>(sizes[i]);
+            for (size_t j = 0; j < size; j++) {
+                keys.push_back({0, 0, 0, static_cast<uint8_t>(i),
+                                static_cast<uint8_t>(j)});
+                values.push_back({static_cast<uint64_t>(i) * j});
+            }
         }
-    }
-    art_t art{NULL};
-    for (size_t i = 0; i < keys.size(); ++i) {
-        art_insert(&art, (art_key_chunk_t*)keys[i].data(), &values[i]);
-        assert_art_valid(&art);
-    }
+        art_t art{NULL};
+        for (size_t i = 0; i < keys.size(); ++i) {
+            art_insert(&art, (art_key_chunk_t*)keys[i].data(), &values[i]);
+            assert_art_valid(&art);
+        }
 
-    art_iterator_t iterator = art_init_iterator(&art, true);
-    size_t i = 0;
-    do {
-        assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i].data());
-        assert_true(iterator.value == &values[i]);
-        ++i;
-    } while (art_iterator_next(&iterator));
-    art_free(&art);
+        art_iterator_t iterator = art_init_iterator(&art, true);
+        size_t i = 0;
+        do {
+            assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i].data());
+            assert_true(iterator.value == &values[i]);
+            ++i;
+        } while (art_iterator_next(&iterator));
+        art_free(&art);
+    }
+    {
+        // Max-depth ART.
+        std::vector<std::array<uint8_t, 6>> keys{
+            {0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 1, 0},
+            {0, 0, 0, 1, 0, 0}, {0, 0, 1, 0, 0, 0}, {0, 1, 0, 0, 0, 0},
+            {1, 0, 0, 0, 0, 0},
+        };
+        std::vector<Value> values = {{0, 1, 2, 3, 4, 5, 6}};
+        art_t art{NULL};
+        for (size_t i = 0; i < keys.size(); ++i) {
+            art_insert(&art, (art_key_chunk_t*)keys[i].data(), &values[i]);
+            assert_art_valid(&art);
+        }
+
+        art_iterator_t iterator = art_init_iterator(&art, true);
+        size_t i = 0;
+        do {
+            assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i].data());
+            assert_true(iterator.value == &values[i]);
+            ++i;
+        } while (art_iterator_next(&iterator));
+        art_free(&art);
+    }
 }
 
 DEFINE_TEST(test_art_iterator_prev) {
-    std::vector<std::array<uint8_t, 6>> keys;
-    std::vector<Value> values;
-    std::vector<size_t> sizes = {4, 16, 48, 256};
-    for (size_t i = 0; i < sizes.size(); i++) {
-        uint8_t size = static_cast<uint8_t>(sizes[i]);
-        for (size_t j = 0; j < size; j++) {
-            keys.push_back(
-                {0, 0, 0, static_cast<uint8_t>(i), static_cast<uint8_t>(j)});
-            values.push_back({static_cast<uint64_t>(i) * j});
+    {
+        // ART with multiple node sizes.
+        std::vector<std::array<uint8_t, 6>> keys;
+        std::vector<Value> values;
+        std::vector<size_t> sizes = {4, 16, 48, 256};
+        for (size_t i = 0; i < sizes.size(); i++) {
+            uint8_t size = static_cast<uint8_t>(sizes[i]);
+            for (size_t j = 0; j < size; j++) {
+                keys.push_back({0, 0, 0, static_cast<uint8_t>(i),
+                                static_cast<uint8_t>(j)});
+                values.push_back({static_cast<uint64_t>(i) * j});
+            }
         }
-    }
-    art_t art{NULL};
-    for (size_t i = 0; i < keys.size(); ++i) {
-        art_insert(&art, (art_key_chunk_t*)keys[i].data(), &values[i]);
-        assert_art_valid(&art);
-    }
+        art_t art{NULL};
+        for (size_t i = 0; i < keys.size(); ++i) {
+            art_insert(&art, (art_key_chunk_t*)keys[i].data(), &values[i]);
+            assert_art_valid(&art);
+        }
 
-    art_iterator_t iterator = art_init_iterator(&art, /*first=*/false);
-    size_t i = keys.size() - 1;
-    do {
-        assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i].data());
-        --i;
-    } while (art_iterator_prev(&iterator));
-    art_free(&art);
+        art_iterator_t iterator = art_init_iterator(&art, /*first=*/false);
+        size_t i = keys.size() - 1;
+        do {
+            assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i].data());
+            --i;
+        } while (art_iterator_prev(&iterator));
+        art_free(&art);
+    }
+    {
+        // Max-depth ART.
+        std::vector<std::array<uint8_t, 6>> keys{
+            {0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 1, 0},
+            {0, 0, 0, 1, 0, 0}, {0, 0, 1, 0, 0, 0}, {0, 1, 0, 0, 0, 0},
+            {1, 0, 0, 0, 0, 0},
+        };
+        std::vector<Value> values = {{0, 1, 2, 3, 4, 5, 6}};
+        art_t art{NULL};
+        for (size_t i = 0; i < keys.size(); ++i) {
+            art_insert(&art, (art_key_chunk_t*)keys[i].data(), &values[i]);
+            assert_art_valid(&art);
+        }
+
+        art_iterator_t iterator = art_init_iterator(&art, /*first=*/false);
+        size_t i = keys.size() - 1;
+        do {
+            assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i].data());
+            assert_true(iterator.value == &values[i]);
+            --i;
+        } while (art_iterator_prev(&iterator));
+        art_free(&art);
+    }
 }
 
 DEFINE_TEST(test_art_iterator_lower_bound) {

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -648,17 +648,28 @@ DEFINE_TEST(test_remove_range_closed) {
 }
 
 DEFINE_TEST(test_get_cardinality) {
-    roaring64_bitmap_t* r = roaring64_bitmap_create();
+    {
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
 
-    roaring64_bitmap_add(r, 0);
-    roaring64_bitmap_add(r, 100000);
-    roaring64_bitmap_add(r, 100001);
-    roaring64_bitmap_add(r, 100002);
-    roaring64_bitmap_add(r, 200000);
+        roaring64_bitmap_add(r, 0);
+        roaring64_bitmap_add(r, 100000);
+        roaring64_bitmap_add(r, 100001);
+        roaring64_bitmap_add(r, 100002);
+        roaring64_bitmap_add(r, 200000);
 
-    assert_int_equal(roaring64_bitmap_get_cardinality(r), 5);
+        assert_int_equal(roaring64_bitmap_get_cardinality(r), 5);
 
-    roaring64_bitmap_free(r);
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Max depth ART.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        for (int i = 0; i < 7; ++i) {
+            roaring64_bitmap_add(r, 1ULL << (i * 8 + 8));
+        }
+        assert_int_equal(roaring64_bitmap_get_cardinality(r), 7);
+        roaring64_bitmap_free(r);
+    }
 }
 
 DEFINE_TEST(test_range_cardinality) {


### PR DESCRIPTION
Fixes #593. With a max-depth ART, it's possible to have the following node structure, where `N4 = Node4`, `L = Leaf`:

```
N4 --> N4 --> N4 --> N4 --> N4 --> N4 --> L
   \-> L  \-> L  \-> L  \-> L  \-> L  \-> L
```

ART iterators carry around a frame per node in the path to the leaf, including the leaf. This can therefore result in 7 frames: one for each differing key byte, plus the leaf node itself.
To handle this case we therefore need 7 iterator frames rather than 6.

