### PR TITLE
r64: allow _move_equalorlarger to move from beyond the ends of the bitmap

### DIFF
--- a/src/art/art.c
+++ b/src/art/art.c
@@ -1681,6 +1681,14 @@ bool art_iterator_prev(art_iterator_t *iterator) {
 
 bool art_iterator_lower_bound(art_iterator_t *iterator,
                               const art_key_chunk_t *key) {
+    if (iterator->value == NULL) {
+        // We're beyond the end / start of the ART so the iterator does not have
+        // a valid key. Start from the root.
+        iterator->frame = 0;
+        iterator->depth = 0;
+        return art_node_iterator_lower_bound(art_iterator_node(iterator),
+                                             iterator, key);
+    }
     int compare_result =
         art_compare_prefix(iterator->key, 0, key, 0, ART_KEY_BYTES);
     // Move up until we have an equal prefix, after which we can do a normal

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -2016,15 +2016,12 @@ bool roaring64_iterator_previous(roaring64_iterator_t *it) {
 
 bool roaring64_iterator_move_equalorlarger(roaring64_iterator_t *it,
                                            uint64_t val) {
-    if (it->art_it.value == NULL) {
-        return (it->has_value = false);
-    }
-
     uint8_t val_high48[ART_KEY_BYTES];
     uint16_t val_low16 = split_key(val, val_high48);
-    if (it->high48 != (val & 0xFFFFFFFFFFFF0000)) {
-        // The ART iterator is before or after the high48 bits of `val`, so we
-        // need to move to a leaf with a key equal or greater.
+    if (!it->has_value || it->high48 != (val & 0xFFFFFFFFFFFF0000)) {
+        // The ART iterator is before or after the high48 bits of `val` (or
+        // beyond the ART altogether), so we need to move to a leaf with a key
+        // equal or greater.
         if (!art_iterator_lower_bound(&it->art_it, val_high48)) {
             // Only smaller keys found.
             it->saturated_forward = true;

--- a/tests/art_unit.cpp
+++ b/tests/art_unit.cpp
@@ -389,6 +389,28 @@ DEFINE_TEST(test_art_iterator_lower_bound) {
                 art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key));
             assert_key_eq(iterator.key, (art_key_chunk_t*)keys[0]);
         }
+        {
+            // Check that we can go backward from after the end.
+            const char* key = "000300";
+            assert_true(
+                art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key));
+            assert_key_eq(iterator.key, (art_key_chunk_t*)keys[2]);
+            assert_false(art_iterator_next(&iterator));
+            assert_true(
+                art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key));
+            assert_key_eq(iterator.key, (art_key_chunk_t*)keys[2]);
+        }
+        {
+            // Check that we can go forward from before the start.
+            const char* key = "000100";
+            assert_true(
+                art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key));
+            assert_key_eq(iterator.key, (art_key_chunk_t*)keys[0]);
+            assert_false(art_iterator_prev(&iterator));
+            assert_true(
+                art_iterator_lower_bound(&iterator, (art_key_chunk_t*)key));
+            assert_key_eq(iterator.key, (art_key_chunk_t*)keys[0]);
+        }
 
         art_free(&art);
     }

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -1687,10 +1687,23 @@ DEFINE_TEST(test_iterator_move_equalorlarger) {
     assert_true(roaring64_iterator_previous(it));
     assert_int_equal(roaring64_iterator_value(it), (1ULL << 36));
 
+    // Check that we can move even after the last entry.
+    assert_false(roaring64_iterator_advance(it));
+    assert_true(roaring64_iterator_move_equalorlarger(it, (1ULL << 36)));
+    assert_true(roaring64_iterator_has_value(it));
+    assert_int_equal(roaring64_iterator_value(it), (1ULL << 36));
+
     // Check that we can move backward using move_equalorlarger.
     assert_true(roaring64_iterator_move_equalorlarger(it, (1ULL << 35) - 1));
     assert_true(roaring64_iterator_has_value(it));
     assert_int_equal(roaring64_iterator_value(it), (1ULL << 35));
+
+    // Check that we can move even before the first entry.
+    assert_true(roaring64_iterator_previous(it));
+    assert_false(roaring64_iterator_previous(it));
+    assert_true(roaring64_iterator_move_equalorlarger(it, 0));
+    assert_true(roaring64_iterator_has_value(it));
+    assert_int_equal(roaring64_iterator_value(it), 0);
 
     roaring64_iterator_free(it);
     roaring64_bitmap_free(r);


### PR DESCRIPTION
Fixes #594. Previously `roaring64_iterator_move_equalorlarger` would only return a valid result if the iterator was positioned within the bitmap. With this, the iterator is allowed to start outside the bitmap.