### PR TITLE
fix C4576 compilation error when compiling CRoaring in C++ on Windows

### DIFF
--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -5,15 +5,14 @@
 #ifdef __cplusplus
 extern "C" {
 // In Windows MSVC C++ compiler, (type){init} does not compile,
-// it causes C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
-// The correct syntax is type{init}
+// it causes C4576: a parenthesized type followed by an initializer list is a
+// non-standard explicit type conversion syntax The correct syntax is type{init}
 #define ROARING_INIT_ROARING_CONTAINER_ITERATOR_T roaring_container_iterator_t
 namespace roaring {
 namespace internal {
 #else
 #define ROARING_INIT_ROARING_CONTAINER_ITERATOR_T (roaring_container_iterator_t)
 #endif
-
 
 static inline uint32_t minimum_uint32(uint32_t a, uint32_t b) {
     return (a < b) ? a : b;

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -4,9 +4,16 @@
 
 #ifdef __cplusplus
 extern "C" {
+// In Windows MSVC C++ compiler, (type){init} does not compile,
+// it causes C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
+// The correct syntax is type{init}
+#define ROARING_INIT_ROARING_CONTAINER_ITERATOR_T roaring_container_iterator_t
 namespace roaring {
 namespace internal {
+#else
+#define ROARING_INIT_ROARING_CONTAINER_ITERATOR_T (roaring_container_iterator_t)
 #endif
+
 
 static inline uint32_t minimum_uint32(uint32_t a, uint32_t b) {
     return (a < b) ? a : b;
@@ -296,28 +303,28 @@ roaring_container_iterator_t container_init_iterator(const container_t *c,
             // word is non-zero
             int32_t index = wordindex * 64 + roaring_trailing_zeroes(word);
             *value = index;
-            return (roaring_container_iterator_t){
+            return ROARING_INIT_ROARING_CONTAINER_ITERATOR_T{
                 .index = index,
             };
         }
         case ARRAY_CONTAINER_TYPE: {
             const array_container_t *ac = const_CAST_array(c);
             *value = ac->array[0];
-            return (roaring_container_iterator_t){
+            return ROARING_INIT_ROARING_CONTAINER_ITERATOR_T{
                 .index = 0,
             };
         }
         case RUN_CONTAINER_TYPE: {
             const run_container_t *rc = const_CAST_run(c);
             *value = rc->runs[0].value;
-            return (roaring_container_iterator_t){
+            return ROARING_INIT_ROARING_CONTAINER_ITERATOR_T{
                 .index = 0,
             };
         }
         default:
             assert(false);
             roaring_unreachable;
-            return (roaring_container_iterator_t){0};
+            return ROARING_INIT_ROARING_CONTAINER_ITERATOR_T{0};
     }
 }
 
@@ -336,7 +343,7 @@ roaring_container_iterator_t container_init_iterator_last(const container_t *c,
             int32_t index =
                 wordindex * 64 + (63 - roaring_leading_zeroes(word));
             *value = index;
-            return (roaring_container_iterator_t){
+            return ROARING_INIT_ROARING_CONTAINER_ITERATOR_T{
                 .index = index,
             };
         }
@@ -344,7 +351,7 @@ roaring_container_iterator_t container_init_iterator_last(const container_t *c,
             const array_container_t *ac = const_CAST_array(c);
             int32_t index = ac->cardinality - 1;
             *value = ac->array[index];
-            return (roaring_container_iterator_t){
+            return ROARING_INIT_ROARING_CONTAINER_ITERATOR_T{
                 .index = index,
             };
         }
@@ -353,14 +360,14 @@ roaring_container_iterator_t container_init_iterator_last(const container_t *c,
             int32_t run_index = rc->n_runs - 1;
             const rle16_t *last_run = &rc->runs[run_index];
             *value = last_run->value + last_run->length;
-            return (roaring_container_iterator_t){
+            return ROARING_INIT_ROARING_CONTAINER_ITERATOR_T{
                 .index = run_index,
             };
         }
         default:
             assert(false);
             roaring_unreachable;
-            return (roaring_container_iterator_t){0};
+            return ROARING_INIT_ROARING_CONTAINER_ITERATOR_T{0};
     }
 }
 
@@ -705,3 +712,5 @@ bool container_iterator_read_into_uint64(const container_t *c, uint8_t typecode,
 }
 }  // extern "C" { namespace roaring { namespace internal {
 #endif
+
+#undef ROARING_INIT_ROARING_CONTAINER_ITERATOR_T


### PR DESCRIPTION
Compiling CRoaring on Windows (tried on Windows 2019 in CI for roaring-node) causes a compilation error due to the use of (cast){initializer} used in C roaring source code.

(roaring_container_iterator_t){ ... } does not compile in Visual Studio when compiling in C++,
it fails with C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax

For reference, https://github.com/SalvatorePreviti/roaring-node/actions/runs/8102601181/job/22145475666

I think the solution is to replace (roaring_container_iterator_t){ ... } with roaring_container_iterator_t{ ... } depending if compiling for C or C++.

This PR defines a macro in containers.c that is (roaring_container_iterator_t) when compiling in C and roaring_container_iterator_t when compiling in C++

issue https://github.com/RoaringBitmap/CRoaring/issues/599