### PR TITLE
disabling AVX routines under Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ if(ENABLE_ROARING_TESTS AND BASH)
   add_test(amalgamate_demo amalgamate_demo)
 
   add_library(croaring-singleheader-source-lib $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/roaring.c>)
-  set_target_properties(roaring-singleheader-source-lib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS YES)
+  set_target_properties(croaring-singleheader-source-lib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS YES)
   target_include_directories(croaring-singleheader-source-lib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
   add_executable(amalgamate_demo_cpp $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/amalgamation_demo.cpp>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ if(ENABLE_ROARING_TESTS AND BASH)
   add_test(amalgamate_demo amalgamate_demo)
 
   add_library(croaring-singleheader-source-lib $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/roaring.c>)
+  set_target_properties(roaring-singleheader-source-lib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS YES)
   target_include_directories(croaring-singleheader-source-lib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
   add_executable(amalgamate_demo_cpp $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/amalgamation_demo.cpp>)

--- a/src/isadetection.c
+++ b/src/isadetection.c
@@ -48,6 +48,16 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include <stdlib.h>
 
+// Binaries produced by Visual Studio with solely AVX2 routines
+// can compile to AVX-512 thus causing crashes on non-AVX-512 systems.
+// This appears to affect VS 17.8 and 17.9. We disable AVX-512 and AVX2
+// on these systems. It seems that ClangCL is not affected.
+#ifndef __clang__
+#if _MSC_VER >= 1938
+#define ROARING_DISABLE_AVX 1
+#endif  // _MSC_VER >= 1938
+#endif // __clang__
+
 // We need portability.h to be included first, see
 // https://github.com/RoaringBitmap/CRoaring/issues/394
 #include <roaring/portability.h>

--- a/src/isadetection.c
+++ b/src/isadetection.c
@@ -52,6 +52,7 @@ POSSIBILITY OF SUCH DAMAGE.
 // can compile to AVX-512 thus causing crashes on non-AVX-512 systems.
 // This appears to affect VS 17.8 and 17.9. We disable AVX-512 and AVX2
 // on these systems. It seems that ClangCL is not affected.
+// https://github.com/RoaringBitmap/CRoaring/pull/603
 #ifndef __clang__
 #if _MSC_VER >= 1938
 #define ROARING_DISABLE_AVX 1

--- a/src/isadetection.c
+++ b/src/isadetection.c
@@ -56,7 +56,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #if _MSC_VER >= 1938
 #define ROARING_DISABLE_AVX 1
 #endif  // _MSC_VER >= 1938
-#endif // __clang__
+#endif  // __clang__
 
 // We need portability.h to be included first, see
 // https://github.com/RoaringBitmap/CRoaring/issues/394


### PR DESCRIPTION
In Visual Studio's last few C++ compilers (starting with VS 17.8), you can write code that relies solely on AVX2,  and it may compile to AVX-512 instructions. See screenshot.

Related problems were reported to Microsoft by several folks and reportedly fixed in 17.9, but according to our tests, it is not fixed.

This is a critical issue that can lead to crashing software. Unfortunately, you may not see it until you test it on hardware that does not support AVX-512.

Thus, we are disabling AVX optimizations on recent Visual Studio C++ compilers.

![GHmSsjFXIAAjRHe](https://github.com/RoaringBitmap/CRoaring/assets/391987/c04263a9-79f4-4d4a-bff5-3cc749abd821)

Related threads/findings:
[Original find](https://github.com/RoaringBitmap/croaring-rs/pull/128#issuecomment-1918419461)
[Microsoft bug report](https://developercommunity.visualstudio.com/t/Invalid-AVX512-instructions-generated-wh/10521872)