### PR TITLE
various fixes to macros

### DIFF
--- a/include/roaring/array_util.h
+++ b/include/roaring/array_util.h
@@ -1,5 +1,5 @@
-#ifndef ARRAY_UTIL_H
-#define ARRAY_UTIL_H
+#ifndef CROARING_ARRAY_UTIL_H
+#define CROARING_ARRAY_UTIL_H
 
 #include <stddef.h>  // for size_t
 #include <stdint.h>

--- a/include/roaring/bitset/bitset.h
+++ b/include/roaring/bitset/bitset.h
@@ -178,12 +178,14 @@ size_t bitset_difference_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
 
 /* compute the symmetric difference in-place (to b1), return true if successful,
  * to generate a new bitset first call bitset_copy */
-bool bitset_inplace_symmetric_difference(bitset_t *CROARING_CBITSET_RESTRICT b1,
-                                         const bitset_t *CROARING_CBITSET_RESTRICT b2);
+bool bitset_inplace_symmetric_difference(
+    bitset_t *CROARING_CBITSET_RESTRICT b1,
+    const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* compute the size of the symmetric difference  */
-size_t bitset_symmetric_difference_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
-                                         const bitset_t *CROARING_CBITSET_RESTRICT b2);
+size_t bitset_symmetric_difference_count(
+    const bitset_t *CROARING_CBITSET_RESTRICT b1,
+    const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* iterate over the set bits
  like so :

--- a/include/roaring/bitset/bitset.h
+++ b/include/roaring/bitset/bitset.h
@@ -1,12 +1,12 @@
-#ifndef CBITSET_BITSET_H
-#define CBITSET_BITSET_H
+#ifndef CROARING_CBITSET_BITSET_H
+#define CROARING_CBITSET_BITSET_H
 
 // For compatibility with MSVC with the use of `restrict`
 #if (__STDC_VERSION__ >= 199901L) || \
     (defined(__GNUC__) && defined(__STDC_VERSION__))
-#define CBITSET_RESTRICT restrict
+#define CROARING_CBITSET_RESTRICT restrict
 #else
-#define CBITSET_RESTRICT
+#define CROARING_CBITSET_RESTRICT
 #endif  // (__STDC_VERSION__ >= 199901L) || (defined(__GNUC__) &&
         // defined(__STDC_VERSION__ ))
 
@@ -25,7 +25,7 @@ namespace api {
 #endif
 
 struct bitset_s {
-    uint64_t *CBITSET_RESTRICT array;
+    uint64_t *CROARING_CBITSET_RESTRICT array;
     /* For simplicity and performance, we prefer to have a size and a capacity
      * that is a multiple of 64 bits. Thus we only track the size and the
      * capacity in terms of 64-bit words allocated */
@@ -139,51 +139,51 @@ size_t bitset_maximum(const bitset_t *bitset);
 
 /* compute the union in-place (to b1), returns true if successful, to generate a
  * new bitset first call bitset_copy */
-bool bitset_inplace_union(bitset_t *CBITSET_RESTRICT b1,
-                          const bitset_t *CBITSET_RESTRICT b2);
+bool bitset_inplace_union(bitset_t *CROARING_CBITSET_RESTRICT b1,
+                          const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* report the size of the union (without materializing it) */
-size_t bitset_union_count(const bitset_t *CBITSET_RESTRICT b1,
-                          const bitset_t *CBITSET_RESTRICT b2);
+size_t bitset_union_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                          const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* compute the intersection in-place (to b1), to generate a new bitset first
  * call bitset_copy */
-void bitset_inplace_intersection(bitset_t *CBITSET_RESTRICT b1,
-                                 const bitset_t *CBITSET_RESTRICT b2);
+void bitset_inplace_intersection(bitset_t *CROARING_CBITSET_RESTRICT b1,
+                                 const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* report the size of the intersection (without materializing it) */
-size_t bitset_intersection_count(const bitset_t *CBITSET_RESTRICT b1,
-                                 const bitset_t *CBITSET_RESTRICT b2);
+size_t bitset_intersection_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                                 const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* returns true if the bitsets contain no common elements */
-bool bitsets_disjoint(const bitset_t *CBITSET_RESTRICT b1,
-                      const bitset_t *CBITSET_RESTRICT b2);
+bool bitsets_disjoint(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                      const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* returns true if the bitsets contain any common elements */
-bool bitsets_intersect(const bitset_t *CBITSET_RESTRICT b1,
-                       const bitset_t *CBITSET_RESTRICT b2);
+bool bitsets_intersect(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                       const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* returns true if b1 contains all of the set bits of b2 */
-bool bitset_contains_all(const bitset_t *CBITSET_RESTRICT b1,
-                         const bitset_t *CBITSET_RESTRICT b2);
+bool bitset_contains_all(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                         const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* compute the difference in-place (to b1), to generate a new bitset first call
  * bitset_copy */
-void bitset_inplace_difference(bitset_t *CBITSET_RESTRICT b1,
-                               const bitset_t *CBITSET_RESTRICT b2);
+void bitset_inplace_difference(bitset_t *CROARING_CBITSET_RESTRICT b1,
+                               const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* compute the size of the difference */
-size_t bitset_difference_count(const bitset_t *CBITSET_RESTRICT b1,
-                               const bitset_t *CBITSET_RESTRICT b2);
+size_t bitset_difference_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                               const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* compute the symmetric difference in-place (to b1), return true if successful,
  * to generate a new bitset first call bitset_copy */
-bool bitset_inplace_symmetric_difference(bitset_t *CBITSET_RESTRICT b1,
-                                         const bitset_t *CBITSET_RESTRICT b2);
+bool bitset_inplace_symmetric_difference(bitset_t *CROARING_CBITSET_RESTRICT b1,
+                                         const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* compute the size of the symmetric difference  */
-size_t bitset_symmetric_difference_count(const bitset_t *CBITSET_RESTRICT b1,
-                                         const bitset_t *CBITSET_RESTRICT b2);
+size_t bitset_symmetric_difference_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                                         const bitset_t *CROARING_CBITSET_RESTRICT b2);
 
 /* iterate over the set bits
  like so :

--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -1,5 +1,5 @@
-#ifndef BITSET_UTIL_H
-#define BITSET_UTIL_H
+#ifndef CROARING_BITSET_UTIL_H
+#define CROARING_BITSET_UTIL_H
 
 #include <stdint.h>
 
@@ -383,7 +383,7 @@ inline static uint64_t avx2_harley_seal_popcount256(const __m256i *data,
 }
 CROARING_UNTARGET_AVX2
 
-#define AVXPOPCNTFNC(opname, avx_intrinsic)                                    \
+#define CROARING_AVXPOPCNTFNC(opname, avx_intrinsic)                                    \
     static inline uint64_t avx2_harley_seal_popcount256_##opname(              \
         const __m256i *data1, const __m256i *data2, const uint64_t size) {     \
         __m256i total = _mm256_setzero_si256();                                \
@@ -564,27 +564,27 @@ CROARING_UNTARGET_AVX2
     }
 
 CROARING_TARGET_AVX2
-AVXPOPCNTFNC(or, _mm256_or_si256)
+CROARING_AVXPOPCNTFNC(or, _mm256_or_si256)
 CROARING_UNTARGET_AVX2
 
 CROARING_TARGET_AVX2
-AVXPOPCNTFNC(union, _mm256_or_si256)
+CROARING_AVXPOPCNTFNC(union, _mm256_or_si256)
 CROARING_UNTARGET_AVX2
 
 CROARING_TARGET_AVX2
-AVXPOPCNTFNC(and, _mm256_and_si256)
+CROARING_AVXPOPCNTFNC(and, _mm256_and_si256)
 CROARING_UNTARGET_AVX2
 
 CROARING_TARGET_AVX2
-AVXPOPCNTFNC(intersection, _mm256_and_si256)
+CROARING_AVXPOPCNTFNC(intersection, _mm256_and_si256)
 CROARING_UNTARGET_AVX2
 
 CROARING_TARGET_AVX2
-AVXPOPCNTFNC(xor, _mm256_xor_si256)
+CROARING_AVXPOPCNTFNC(xor, _mm256_xor_si256)
 CROARING_UNTARGET_AVX2
 
 CROARING_TARGET_AVX2
-AVXPOPCNTFNC(andnot, _mm256_andnot_si256)
+CROARING_AVXPOPCNTFNC(andnot, _mm256_andnot_si256)
 CROARING_UNTARGET_AVX2
 
 #define VPOPCNT_AND_ADD(ptr, i, accu)                                  \
@@ -631,7 +631,7 @@ static inline uint64_t avx512_vpopcount(const __m512i *data,
 CROARING_UNTARGET_AVX512
 #endif
 
-#define AVXPOPCNTFNC512(opname, avx_intrinsic)                                \
+#define CROARING_AVXPOPCNTFNC512(opname, avx_intrinsic)                                \
     static inline uint64_t avx512_harley_seal_popcount512_##opname(           \
         const __m512i *data1, const __m512i *data2, const uint64_t size) {    \
         __m512i total = _mm512_setzero_si512();                               \
@@ -693,12 +693,12 @@ CROARING_UNTARGET_AVX512
 
 #if CROARING_COMPILER_SUPPORTS_AVX512
 CROARING_TARGET_AVX512
-AVXPOPCNTFNC512(or, _mm512_or_si512)
-AVXPOPCNTFNC512(union, _mm512_or_si512)
-AVXPOPCNTFNC512(and, _mm512_and_si512)
-AVXPOPCNTFNC512(intersection, _mm512_and_si512)
-AVXPOPCNTFNC512(xor, _mm512_xor_si512)
-AVXPOPCNTFNC512(andnot, _mm512_andnot_si512)
+CROARING_AVXPOPCNTFNC512(or, _mm512_or_si512)
+CROARING_AVXPOPCNTFNC512(union, _mm512_or_si512)
+CROARING_AVXPOPCNTFNC512(and, _mm512_and_si512)
+CROARING_AVXPOPCNTFNC512(intersection, _mm512_and_si512)
+CROARING_AVXPOPCNTFNC512(xor, _mm512_xor_si512)
+CROARING_AVXPOPCNTFNC512(andnot, _mm512_andnot_si512)
 CROARING_UNTARGET_AVX512
 #endif
 /***

--- a/include/roaring/bitset_util.h
+++ b/include/roaring/bitset_util.h
@@ -383,7 +383,7 @@ inline static uint64_t avx2_harley_seal_popcount256(const __m256i *data,
 }
 CROARING_UNTARGET_AVX2
 
-#define CROARING_AVXPOPCNTFNC(opname, avx_intrinsic)                                    \
+#define CROARING_AVXPOPCNTFNC(opname, avx_intrinsic)                           \
     static inline uint64_t avx2_harley_seal_popcount256_##opname(              \
         const __m256i *data1, const __m256i *data2, const uint64_t size) {     \
         __m256i total = _mm256_setzero_si256();                                \
@@ -631,7 +631,7 @@ static inline uint64_t avx512_vpopcount(const __m512i *data,
 CROARING_UNTARGET_AVX512
 #endif
 
-#define CROARING_AVXPOPCNTFNC512(opname, avx_intrinsic)                                \
+#define CROARING_AVXPOPCNTFNC512(opname, avx_intrinsic)                       \
     static inline uint64_t avx512_harley_seal_popcount512_##opname(           \
         const __m512i *data1, const __m512i *data2, const uint64_t size) {    \
         __m512i total = _mm512_setzero_si512();                               \

--- a/include/roaring/containers/run.h
+++ b/include/roaring/containers/run.h
@@ -45,10 +45,10 @@ struct rle16_s {
 typedef struct rle16_s rle16_t;
 
 #ifdef __cplusplus
-#define MAKE_RLE16(val, len) \
+#define CROARING_MAKE_RLE16(val, len) \
     { (uint16_t)(val), (uint16_t)(len) }  // no tagged structs until c++20
 #else
-#define MAKE_RLE16(val, len) \
+#define CROARING_MAKE_RLE16(val, len) \
     (rle16_t) { .value = (uint16_t)(val), .length = (uint16_t)(len) }
 #endif
 
@@ -360,7 +360,7 @@ static inline void run_container_append_value(run_container_t *run,
                                               rle16_t *previousrl) {
     const uint32_t previousend = previousrl->value + previousrl->length;
     if (val > previousend + 1) {  // we add a new one
-        *previousrl = MAKE_RLE16(val, 0);
+        *previousrl = CROARING_MAKE_RLE16(val, 0);
         run->runs[run->n_runs] = *previousrl;
         run->n_runs++;
     } else if (val == previousend + 1) {  // we merge
@@ -375,7 +375,7 @@ static inline void run_container_append_value(run_container_t *run,
  */
 static inline rle16_t run_container_append_value_first(run_container_t *run,
                                                        uint16_t val) {
-    rle16_t newrle = MAKE_RLE16(val, 0);
+    rle16_t newrle = CROARING_MAKE_RLE16(val, 0);
     run->runs[run->n_runs] = newrle;
     run->n_runs++;
     return newrle;

--- a/include/roaring/misc/configreport.h
+++ b/include/roaring/misc/configreport.h
@@ -5,8 +5,8 @@
  * and croaring_hardware_support() & ROARING_SUPPORTS_AVX2 *may* trigger an
  * additional call to dynamic_croaring_detect_supported_architectures().
  */
-#ifndef INCLUDE_MISC_CONFIGREPORT_H_
-#define INCLUDE_MISC_CONFIGREPORT_H_
+#ifndef CROARING_INCLUDE_MISC_CONFIGREPORT_H_
+#define CROARING_INCLUDE_MISC_CONFIGREPORT_H_
 
 #include <stddef.h>  // for size_t
 #include <stdint.h>
@@ -237,4 +237,4 @@ static inline void tellmeall() {
 }  // extern "C" { namespace roaring { namespace misc {
 #endif
 
-#endif /* INCLUDE_MISC_CONFIGREPORT_H_ */
+#endif /* CROARING_INCLUDE_MISC_CONFIGREPORT_H_ */

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -437,12 +437,13 @@ static inline int roaring_hamming(uint64_t x) {
 #define croaring_htobe64(x) OSSwapInt64(x)
 
 #elif defined(__has_include) && \
-    __has_include(<byteswap.h>)  && (defined(__linux__) || defined(__FreeBSD__)) // CROARING_IS_BIG_ENDIAN
+    __has_include(              \
+        <byteswap.h>)  && (defined(__linux__) || defined(__FreeBSD__))  // CROARING_IS_BIG_ENDIAN
 #include <byteswap.h>
 #if defined(__linux__)
-#define croaring_htobe64(x)  bswap_64(x)
+#define croaring_htobe64(x) bswap_64(x)
 #elif defined(__FreeBSD__)
-#define croaring_htobe64(x)  bswap64(x)
+#define croaring_htobe64(x) bswap64(x)
 #else
 #warning "Unknown platform, report as an error"
 #endif

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -13,8 +13,8 @@
  * to ever interact with.
  */
 
-#ifndef INCLUDE_PORTABILITY_H_
-#define INCLUDE_PORTABILITY_H_
+#ifndef CROARING_INCLUDE_PORTABILITY_H_
+#define CROARING_INCLUDE_PORTABILITY_H_
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
@@ -437,9 +437,15 @@ static inline int roaring_hamming(uint64_t x) {
 #define croaring_htobe64(x) OSSwapInt64(x)
 
 #elif defined(__has_include) && \
-    __has_include(<byteswap.h>)  // CROARING_IS_BIG_ENDIAN
+    __has_include(<byteswap.h>)  && (defined(__linux__) || defined(__FreeBSD__)) // CROARING_IS_BIG_ENDIAN
 #include <byteswap.h>
-#define croaring_htobe64(x) __bswap_64(x)
+#if defined(__linux__)
+#define croaring_htobe64(x)  bswap_64(x)
+#elif defined(__FreeBSD__)
+#define croaring_htobe64(x)  bswap64(x)
+#else
+#warning "Unknown platform, report as an error"
+#endif
 
 #else  // CROARING_IS_BIG_ENDIAN
 // Gets compiled to bswap or equivalent on most compilers.

--- a/src/art/art.c
+++ b/src/art/art.c
@@ -24,10 +24,10 @@
 // deallocation of the ART, we know not to free the leaves without having to
 // dereference the leaf pointers.
 //
-// All internal operations on leaves should use CROARING_CAST_LEAF before using the leaf.
-// The only places that use CROARING_SET_LEAF are locations where a field is directly
-// assigned to a leaf pointer. After using CROARING_SET_LEAF, the leaf should be treated
-// as a node of unknown type.
+// All internal operations on leaves should use CROARING_CAST_LEAF before using
+// the leaf. The only places that use CROARING_SET_LEAF are locations where a
+// field is directly assigned to a leaf pointer. After using CROARING_SET_LEAF,
+// the leaf should be treated as a node of unknown type.
 #define CROARING_IS_LEAF(p) (((uintptr_t)(p) & 1))
 #define CROARING_SET_LEAF(p) ((art_node_t *)((uintptr_t)(p) | 1))
 #define CROARING_CAST_LEAF(p) ((art_leaf_t *)((void *)((uintptr_t)(p) & ~1)))
@@ -89,7 +89,8 @@ typedef struct art_node16_s {
 } art_node16_t;
 
 // Node48: key[i] corresponds with children[key[i]] if key[i] !=
-// CROARING_ART_NODE48_EMPTY_VAL. Keys are naturally sorted due to direct indexing.
+// CROARING_ART_NODE48_EMPTY_VAL. Keys are naturally sorted due to direct
+// indexing.
 typedef struct art_node48_s {
     art_inner_node_t base;
     uint8_t count;
@@ -115,7 +116,9 @@ typedef struct art_indexed_child_s {
     art_key_chunk_t key_chunk;
 } art_indexed_child_t;
 
-static inline bool art_is_leaf(const art_node_t *node) { return CROARING_IS_LEAF(node); }
+static inline bool art_is_leaf(const art_node_t *node) {
+    return CROARING_IS_LEAF(node);
+}
 
 static void art_leaf_populate(art_leaf_t *leaf, const art_key_chunk_t key[]) {
     memcpy(leaf->key, key, ART_KEY_BYTES);
@@ -159,7 +162,8 @@ static art_node_t *art_node256_insert(art_node256_t *node, art_node_t *child,
 static art_node4_t *art_node4_create(const art_key_chunk_t prefix[],
                                      uint8_t prefix_size) {
     art_node4_t *node = (art_node4_t *)roaring_malloc(sizeof(art_node4_t));
-    art_init_inner_node(&node->base, CROARING_ART_NODE4_TYPE, prefix, prefix_size);
+    art_init_inner_node(&node->base, CROARING_ART_NODE4_TYPE, prefix,
+                        prefix_size);
     node->count = 0;
     return node;
 }
@@ -363,7 +367,8 @@ static bool art_node4_internal_validate(const art_node4_t *node,
 static art_node16_t *art_node16_create(const art_key_chunk_t prefix[],
                                        uint8_t prefix_size) {
     art_node16_t *node = (art_node16_t *)roaring_malloc(sizeof(art_node16_t));
-    art_init_inner_node(&node->base, CROARING_ART_NODE16_TYPE, prefix, prefix_size);
+    art_init_inner_node(&node->base, CROARING_ART_NODE16_TYPE, prefix,
+                        prefix_size);
     node->count = 0;
     return node;
 }
@@ -546,7 +551,8 @@ static bool art_node16_internal_validate(const art_node16_t *node,
 static art_node48_t *art_node48_create(const art_key_chunk_t prefix[],
                                        uint8_t prefix_size) {
     art_node48_t *node = (art_node48_t *)roaring_malloc(sizeof(art_node48_t));
-    art_init_inner_node(&node->base, CROARING_ART_NODE48_TYPE, prefix, prefix_size);
+    art_init_inner_node(&node->base, CROARING_ART_NODE48_TYPE, prefix,
+                        prefix_size);
     node->count = 0;
     node->available_children = CROARING_NODE48_AVAILABLE_CHILDREN_MASK;
     for (size_t i = 0; i < 256; ++i) {
@@ -759,7 +765,8 @@ static art_node256_t *art_node256_create(const art_key_chunk_t prefix[],
                                          uint8_t prefix_size) {
     art_node256_t *node =
         (art_node256_t *)roaring_malloc(sizeof(art_node256_t));
-    art_init_inner_node(&node->base, CROARING_ART_NODE256_TYPE, prefix, prefix_size);
+    art_init_inner_node(&node->base, CROARING_ART_NODE256_TYPE, prefix,
+                        prefix_size);
     node->count = 0;
     for (size_t i = 0; i < 256; ++i) {
         node->children[i] = NULL;

--- a/src/art/art.c
+++ b/src/art/art.c
@@ -6,14 +6,14 @@
 #include <roaring/memory.h>
 #include <roaring/portability.h>
 
-#define ART_NODE4_TYPE 0
-#define ART_NODE16_TYPE 1
-#define ART_NODE48_TYPE 2
-#define ART_NODE256_TYPE 3
-#define ART_NUM_TYPES 4
+#define CROARING_ART_NODE4_TYPE 0
+#define CROARING_ART_NODE16_TYPE 1
+#define CROARING_ART_NODE48_TYPE 2
+#define CROARING_ART_NODE256_TYPE 3
+#define CROARING_ART_NUM_TYPES 4
 
 // Node48 placeholder value to indicate no child is present at this key index.
-#define ART_NODE48_EMPTY_VAL 48
+#define CROARING_ART_NODE48_EMPTY_VAL 48
 
 // We use the least significant bit of node pointers to indicate whether a node
 // is a leaf or an inner node. This is never surfaced to the user.
@@ -24,15 +24,15 @@
 // deallocation of the ART, we know not to free the leaves without having to
 // dereference the leaf pointers.
 //
-// All internal operations on leaves should use CAST_LEAF before using the leaf.
-// The only places that use SET_LEAF are locations where a field is directly
-// assigned to a leaf pointer. After using SET_LEAF, the leaf should be treated
+// All internal operations on leaves should use CROARING_CAST_LEAF before using the leaf.
+// The only places that use CROARING_SET_LEAF are locations where a field is directly
+// assigned to a leaf pointer. After using CROARING_SET_LEAF, the leaf should be treated
 // as a node of unknown type.
-#define IS_LEAF(p) (((uintptr_t)(p) & 1))
-#define SET_LEAF(p) ((art_node_t *)((uintptr_t)(p) | 1))
-#define CAST_LEAF(p) ((art_leaf_t *)((void *)((uintptr_t)(p) & ~1)))
+#define CROARING_IS_LEAF(p) (((uintptr_t)(p) & 1))
+#define CROARING_SET_LEAF(p) ((art_node_t *)((uintptr_t)(p) | 1))
+#define CROARING_CAST_LEAF(p) ((art_leaf_t *)((void *)((uintptr_t)(p) & ~1)))
 
-#define NODE48_AVAILABLE_CHILDREN_MASK ((UINT64_C(1) << 48) - 1)
+#define CROARING_NODE48_AVAILABLE_CHILDREN_MASK ((UINT64_C(1) << 48) - 1)
 
 #ifdef __cplusplus
 extern "C" {
@@ -89,7 +89,7 @@ typedef struct art_node16_s {
 } art_node16_t;
 
 // Node48: key[i] corresponds with children[key[i]] if key[i] !=
-// ART_NODE48_EMPTY_VAL. Keys are naturally sorted due to direct indexing.
+// CROARING_ART_NODE48_EMPTY_VAL. Keys are naturally sorted due to direct indexing.
 typedef struct art_node48_s {
     art_inner_node_t base;
     uint8_t count;
@@ -115,7 +115,7 @@ typedef struct art_indexed_child_s {
     art_key_chunk_t key_chunk;
 } art_indexed_child_t;
 
-static inline bool art_is_leaf(const art_node_t *node) { return IS_LEAF(node); }
+static inline bool art_is_leaf(const art_node_t *node) { return CROARING_IS_LEAF(node); }
 
 static void art_leaf_populate(art_leaf_t *leaf, const art_key_chunk_t key[]) {
     memcpy(leaf->key, key, ART_KEY_BYTES);
@@ -159,7 +159,7 @@ static art_node_t *art_node256_insert(art_node256_t *node, art_node_t *child,
 static art_node4_t *art_node4_create(const art_key_chunk_t prefix[],
                                      uint8_t prefix_size) {
     art_node4_t *node = (art_node4_t *)roaring_malloc(sizeof(art_node4_t));
-    art_init_inner_node(&node->base, ART_NODE4_TYPE, prefix, prefix_size);
+    art_init_inner_node(&node->base, CROARING_ART_NODE4_TYPE, prefix, prefix_size);
     node->count = 0;
     return node;
 }
@@ -363,7 +363,7 @@ static bool art_node4_internal_validate(const art_node4_t *node,
 static art_node16_t *art_node16_create(const art_key_chunk_t prefix[],
                                        uint8_t prefix_size) {
     art_node16_t *node = (art_node16_t *)roaring_malloc(sizeof(art_node16_t));
-    art_init_inner_node(&node->base, ART_NODE16_TYPE, prefix, prefix_size);
+    art_init_inner_node(&node->base, CROARING_ART_NODE16_TYPE, prefix, prefix_size);
     node->count = 0;
     return node;
 }
@@ -546,18 +546,18 @@ static bool art_node16_internal_validate(const art_node16_t *node,
 static art_node48_t *art_node48_create(const art_key_chunk_t prefix[],
                                        uint8_t prefix_size) {
     art_node48_t *node = (art_node48_t *)roaring_malloc(sizeof(art_node48_t));
-    art_init_inner_node(&node->base, ART_NODE48_TYPE, prefix, prefix_size);
+    art_init_inner_node(&node->base, CROARING_ART_NODE48_TYPE, prefix, prefix_size);
     node->count = 0;
-    node->available_children = NODE48_AVAILABLE_CHILDREN_MASK;
+    node->available_children = CROARING_NODE48_AVAILABLE_CHILDREN_MASK;
     for (size_t i = 0; i < 256; ++i) {
-        node->keys[i] = ART_NODE48_EMPTY_VAL;
+        node->keys[i] = CROARING_ART_NODE48_EMPTY_VAL;
     }
     return node;
 }
 
 static void art_free_node48(art_node48_t *node) {
     uint64_t used_children =
-        (node->available_children) ^ NODE48_AVAILABLE_CHILDREN_MASK;
+        (node->available_children) ^ CROARING_NODE48_AVAILABLE_CHILDREN_MASK;
     while (used_children != 0) {
         // We checked above that used_children is not zero
         uint8_t child_idx = roaring_trailing_zeroes(used_children);
@@ -570,7 +570,7 @@ static void art_free_node48(art_node48_t *node) {
 static inline art_node_t *art_node48_find_child(const art_node48_t *node,
                                                 art_key_chunk_t key) {
     uint8_t val_idx = node->keys[key];
-    if (val_idx != ART_NODE48_EMPTY_VAL) {
+    if (val_idx != CROARING_ART_NODE48_EMPTY_VAL) {
         return node->children[val_idx];
     }
     return NULL;
@@ -592,7 +592,7 @@ static art_node_t *art_node48_insert(art_node48_t *node, art_node_t *child,
         art_node256_create(node->base.prefix, node->base.prefix_size);
     for (size_t i = 0; i < 256; ++i) {
         uint8_t val_idx = node->keys[i];
-        if (val_idx != ART_NODE48_EMPTY_VAL) {
+        if (val_idx != CROARING_ART_NODE48_EMPTY_VAL) {
             art_node256_insert(new_node, node->children[val_idx], i);
         }
     }
@@ -603,10 +603,10 @@ static art_node_t *art_node48_insert(art_node48_t *node, art_node_t *child,
 static inline art_node_t *art_node48_erase(art_node48_t *node,
                                            uint8_t key_chunk) {
     uint8_t val_idx = node->keys[key_chunk];
-    if (val_idx == ART_NODE48_EMPTY_VAL) {
+    if (val_idx == CROARING_ART_NODE48_EMPTY_VAL) {
         return (art_node_t *)node;
     }
-    node->keys[key_chunk] = ART_NODE48_EMPTY_VAL;
+    node->keys[key_chunk] = CROARING_ART_NODE48_EMPTY_VAL;
     node->available_children |= UINT64_C(1) << val_idx;
     node->count--;
     if (node->count > 16) {
@@ -617,7 +617,7 @@ static inline art_node_t *art_node48_erase(art_node48_t *node,
         art_node16_create(node->base.prefix, node->base.prefix_size);
     for (size_t i = 0; i < 256; ++i) {
         val_idx = node->keys[i];
-        if (val_idx != ART_NODE48_EMPTY_VAL) {
+        if (val_idx != CROARING_ART_NODE48_EMPTY_VAL) {
             art_node16_insert(new_node, node->children[val_idx], i);
         }
     }
@@ -629,7 +629,7 @@ static inline void art_node48_replace(art_node48_t *node,
                                       art_key_chunk_t key_chunk,
                                       art_node_t *new_child) {
     uint8_t val_idx = node->keys[key_chunk];
-    assert(val_idx != ART_NODE48_EMPTY_VAL);
+    assert(val_idx != CROARING_ART_NODE48_EMPTY_VAL);
     node->children[val_idx] = new_child;
 }
 
@@ -638,7 +638,7 @@ static inline art_indexed_child_t art_node48_next_child(
     art_indexed_child_t indexed_child;
     index++;
     for (size_t i = index; i < 256; ++i) {
-        if (node->keys[i] != ART_NODE48_EMPTY_VAL) {
+        if (node->keys[i] != CROARING_ART_NODE48_EMPTY_VAL) {
             indexed_child.index = i;
             indexed_child.child = node->children[node->keys[i]];
             indexed_child.key_chunk = i;
@@ -657,7 +657,7 @@ static inline art_indexed_child_t art_node48_prev_child(
     index--;
     art_indexed_child_t indexed_child;
     for (int i = index; i >= 0; --i) {
-        if (node->keys[i] != ART_NODE48_EMPTY_VAL) {
+        if (node->keys[i] != CROARING_ART_NODE48_EMPTY_VAL) {
             indexed_child.index = i;
             indexed_child.child = node->children[node->keys[i]];
             indexed_child.key_chunk = i;
@@ -685,7 +685,7 @@ static inline art_indexed_child_t art_node48_lower_bound(
     art_node48_t *node, art_key_chunk_t key_chunk) {
     art_indexed_child_t indexed_child;
     for (size_t i = key_chunk; i < 256; ++i) {
-        if (node->keys[i] != ART_NODE48_EMPTY_VAL) {
+        if (node->keys[i] != CROARING_ART_NODE48_EMPTY_VAL) {
             indexed_child.index = i;
             indexed_child.child = node->children[node->keys[i]];
             indexed_child.key_chunk = i;
@@ -707,7 +707,7 @@ static bool art_node48_internal_validate(const art_node48_t *node,
     uint64_t used_children = 0;
     for (int i = 0; i < 256; ++i) {
         uint8_t child_idx = node->keys[i];
-        if (child_idx != ART_NODE48_EMPTY_VAL) {
+        if (child_idx != CROARING_ART_NODE48_EMPTY_VAL) {
             if (used_children & (UINT64_C(1) << child_idx)) {
                 return art_validate_fail(
                     &validator, "Node48 keys point to the same child index");
@@ -721,7 +721,7 @@ static bool art_node48_internal_validate(const art_node48_t *node,
         }
     }
     uint64_t expected_used_children =
-        (node->available_children) ^ NODE48_AVAILABLE_CHILDREN_MASK;
+        (node->available_children) ^ CROARING_NODE48_AVAILABLE_CHILDREN_MASK;
     if (used_children != expected_used_children) {
         return art_validate_fail(
             &validator,
@@ -744,7 +744,7 @@ static bool art_node48_internal_validate(const art_node48_t *node,
 
     validator.depth++;
     for (int i = 0; i < 256; ++i) {
-        if (node->keys[i] != ART_NODE48_EMPTY_VAL) {
+        if (node->keys[i] != CROARING_ART_NODE48_EMPTY_VAL) {
             validator.current_key[validator.depth - 1] = i;
             if (!art_internal_validate_at(node->children[node->keys[i]],
                                           validator)) {
@@ -759,7 +759,7 @@ static art_node256_t *art_node256_create(const art_key_chunk_t prefix[],
                                          uint8_t prefix_size) {
     art_node256_t *node =
         (art_node256_t *)roaring_malloc(sizeof(art_node256_t));
-    art_init_inner_node(&node->base, ART_NODE256_TYPE, prefix, prefix_size);
+    art_init_inner_node(&node->base, CROARING_ART_NODE256_TYPE, prefix, prefix_size);
     node->count = 0;
     for (size_t i = 0; i < 256; ++i) {
         node->children[i] = NULL;
@@ -915,13 +915,13 @@ static bool art_node256_internal_validate(const art_node256_t *node,
 static art_node_t *art_find_child(const art_inner_node_t *node,
                                   art_key_chunk_t key_chunk) {
     switch (art_get_type(node)) {
-        case ART_NODE4_TYPE:
+        case CROARING_ART_NODE4_TYPE:
             return art_node4_find_child((art_node4_t *)node, key_chunk);
-        case ART_NODE16_TYPE:
+        case CROARING_ART_NODE16_TYPE:
             return art_node16_find_child((art_node16_t *)node, key_chunk);
-        case ART_NODE48_TYPE:
+        case CROARING_ART_NODE48_TYPE:
             return art_node48_find_child((art_node48_t *)node, key_chunk);
-        case ART_NODE256_TYPE:
+        case CROARING_ART_NODE256_TYPE:
             return art_node256_find_child((art_node256_t *)node, key_chunk);
         default:
             assert(false);
@@ -933,16 +933,16 @@ static art_node_t *art_find_child(const art_inner_node_t *node,
 static void art_replace(art_inner_node_t *node, art_key_chunk_t key_chunk,
                         art_node_t *new_child) {
     switch (art_get_type(node)) {
-        case ART_NODE4_TYPE:
+        case CROARING_ART_NODE4_TYPE:
             art_node4_replace((art_node4_t *)node, key_chunk, new_child);
             break;
-        case ART_NODE16_TYPE:
+        case CROARING_ART_NODE16_TYPE:
             art_node16_replace((art_node16_t *)node, key_chunk, new_child);
             break;
-        case ART_NODE48_TYPE:
+        case CROARING_ART_NODE48_TYPE:
             art_node48_replace((art_node48_t *)node, key_chunk, new_child);
             break;
-        case ART_NODE256_TYPE:
+        case CROARING_ART_NODE256_TYPE:
             art_node256_replace((art_node256_t *)node, key_chunk, new_child);
             break;
         default:
@@ -955,13 +955,13 @@ static void art_replace(art_inner_node_t *node, art_key_chunk_t key_chunk,
 static art_node_t *art_node_erase(art_inner_node_t *node,
                                   art_key_chunk_t key_chunk) {
     switch (art_get_type(node)) {
-        case ART_NODE4_TYPE:
+        case CROARING_ART_NODE4_TYPE:
             return art_node4_erase((art_node4_t *)node, key_chunk);
-        case ART_NODE16_TYPE:
+        case CROARING_ART_NODE16_TYPE:
             return art_node16_erase((art_node16_t *)node, key_chunk);
-        case ART_NODE48_TYPE:
+        case CROARING_ART_NODE48_TYPE:
             return art_node48_erase((art_node48_t *)node, key_chunk);
-        case ART_NODE256_TYPE:
+        case CROARING_ART_NODE256_TYPE:
             return art_node256_erase((art_node256_t *)node, key_chunk);
         default:
             assert(false);
@@ -974,15 +974,15 @@ static art_node_t *art_node_erase(art_inner_node_t *node,
 static art_node_t *art_node_insert_leaf(art_inner_node_t *node,
                                         art_key_chunk_t key_chunk,
                                         art_leaf_t *leaf) {
-    art_node_t *child = (art_node_t *)(SET_LEAF(leaf));
+    art_node_t *child = (art_node_t *)(CROARING_SET_LEAF(leaf));
     switch (art_get_type(node)) {
-        case ART_NODE4_TYPE:
+        case CROARING_ART_NODE4_TYPE:
             return art_node4_insert((art_node4_t *)node, child, key_chunk);
-        case ART_NODE16_TYPE:
+        case CROARING_ART_NODE16_TYPE:
             return art_node16_insert((art_node16_t *)node, child, key_chunk);
-        case ART_NODE48_TYPE:
+        case CROARING_ART_NODE48_TYPE:
             return art_node48_insert((art_node48_t *)node, child, key_chunk);
-        case ART_NODE256_TYPE:
+        case CROARING_ART_NODE256_TYPE:
             return art_node256_insert((art_node256_t *)node, child, key_chunk);
         default:
             assert(false);
@@ -997,16 +997,16 @@ static void art_free_node(art_node_t *node) {
         return;
     }
     switch (art_get_type((art_inner_node_t *)node)) {
-        case ART_NODE4_TYPE:
+        case CROARING_ART_NODE4_TYPE:
             art_free_node4((art_node4_t *)node);
             break;
-        case ART_NODE16_TYPE:
+        case CROARING_ART_NODE16_TYPE:
             art_free_node16((art_node16_t *)node);
             break;
-        case ART_NODE48_TYPE:
+        case CROARING_ART_NODE48_TYPE:
             art_free_node48((art_node48_t *)node);
             break;
-        case ART_NODE256_TYPE:
+        case CROARING_ART_NODE256_TYPE:
             art_free_node256((art_node256_t *)node);
             break;
         default:
@@ -1024,13 +1024,13 @@ static art_indexed_child_t art_node_next_child(const art_node_t *node,
         return indexed_child;
     }
     switch (art_get_type((art_inner_node_t *)node)) {
-        case ART_NODE4_TYPE:
+        case CROARING_ART_NODE4_TYPE:
             return art_node4_next_child((art_node4_t *)node, index);
-        case ART_NODE16_TYPE:
+        case CROARING_ART_NODE16_TYPE:
             return art_node16_next_child((art_node16_t *)node, index);
-        case ART_NODE48_TYPE:
+        case CROARING_ART_NODE48_TYPE:
             return art_node48_next_child((art_node48_t *)node, index);
-        case ART_NODE256_TYPE:
+        case CROARING_ART_NODE256_TYPE:
             return art_node256_next_child((art_node256_t *)node, index);
         default:
             assert(false);
@@ -1048,13 +1048,13 @@ static art_indexed_child_t art_node_prev_child(const art_node_t *node,
         return indexed_child;
     }
     switch (art_get_type((art_inner_node_t *)node)) {
-        case ART_NODE4_TYPE:
+        case CROARING_ART_NODE4_TYPE:
             return art_node4_prev_child((art_node4_t *)node, index);
-        case ART_NODE16_TYPE:
+        case CROARING_ART_NODE16_TYPE:
             return art_node16_prev_child((art_node16_t *)node, index);
-        case ART_NODE48_TYPE:
+        case CROARING_ART_NODE48_TYPE:
             return art_node48_prev_child((art_node48_t *)node, index);
-        case ART_NODE256_TYPE:
+        case CROARING_ART_NODE256_TYPE:
             return art_node256_prev_child((art_node256_t *)node, index);
         default:
             assert(false);
@@ -1072,13 +1072,13 @@ static art_indexed_child_t art_node_child_at(const art_node_t *node,
         return indexed_child;
     }
     switch (art_get_type((art_inner_node_t *)node)) {
-        case ART_NODE4_TYPE:
+        case CROARING_ART_NODE4_TYPE:
             return art_node4_child_at((art_node4_t *)node, index);
-        case ART_NODE16_TYPE:
+        case CROARING_ART_NODE16_TYPE:
             return art_node16_child_at((art_node16_t *)node, index);
-        case ART_NODE48_TYPE:
+        case CROARING_ART_NODE48_TYPE:
             return art_node48_child_at((art_node48_t *)node, index);
-        case ART_NODE256_TYPE:
+        case CROARING_ART_NODE256_TYPE:
             return art_node256_child_at((art_node256_t *)node, index);
         default:
             assert(false);
@@ -1096,13 +1096,13 @@ static art_indexed_child_t art_node_lower_bound(const art_node_t *node,
         return indexed_child;
     }
     switch (art_get_type((art_inner_node_t *)node)) {
-        case ART_NODE4_TYPE:
+        case CROARING_ART_NODE4_TYPE:
             return art_node4_lower_bound((art_node4_t *)node, key_chunk);
-        case ART_NODE16_TYPE:
+        case CROARING_ART_NODE16_TYPE:
             return art_node16_lower_bound((art_node16_t *)node, key_chunk);
-        case ART_NODE48_TYPE:
+        case CROARING_ART_NODE48_TYPE:
             return art_node48_lower_bound((art_node48_t *)node, key_chunk);
-        case ART_NODE256_TYPE:
+        case CROARING_ART_NODE256_TYPE:
             return art_node256_lower_bound((art_node256_t *)node, key_chunk);
         default:
             assert(false);
@@ -1153,7 +1153,7 @@ static uint8_t art_common_prefix(const art_key_chunk_t key1[],
 static art_node_t *art_insert_at(art_node_t *node, const art_key_chunk_t key[],
                                  uint8_t depth, art_leaf_t *new_leaf) {
     if (art_is_leaf(node)) {
-        art_leaf_t *leaf = CAST_LEAF(node);
+        art_leaf_t *leaf = CROARING_CAST_LEAF(node);
         uint8_t common_prefix = art_common_prefix(
             leaf->key, depth, ART_KEY_BYTES, key, depth, ART_KEY_BYTES);
 
@@ -1233,7 +1233,7 @@ static art_erase_result_t art_erase_at(art_node_t *node,
     result.value_erased = NULL;
 
     if (art_is_leaf(node)) {
-        art_leaf_t *leaf = CAST_LEAF(node);
+        art_leaf_t *leaf = CROARING_CAST_LEAF(node);
         uint8_t common_prefix = art_common_prefix(leaf->key, 0, ART_KEY_BYTES,
                                                   key, 0, ART_KEY_BYTES);
         if (common_prefix != ART_KEY_BYTES) {
@@ -1298,7 +1298,7 @@ static art_val_t *art_find_at(const art_node_t *node,
         // Include both the prefix and the child key chunk in the depth.
         depth += inner_node->prefix_size + 1;
     }
-    art_leaf_t *leaf = CAST_LEAF(node);
+    art_leaf_t *leaf = CROARING_CAST_LEAF(node);
     if (depth >= ART_KEY_BYTES) {
         return (art_val_t *)leaf;
     }
@@ -1317,16 +1317,16 @@ size_t art_size_in_bytes_at(const art_node_t *node) {
     }
     size_t size = 0;
     switch (art_get_type((art_inner_node_t *)node)) {
-        case ART_NODE4_TYPE: {
+        case CROARING_ART_NODE4_TYPE: {
             size += sizeof(art_node4_t);
         } break;
-        case ART_NODE16_TYPE: {
+        case CROARING_ART_NODE16_TYPE: {
             size += sizeof(art_node16_t);
         } break;
-        case ART_NODE48_TYPE: {
+        case CROARING_ART_NODE48_TYPE: {
             size += sizeof(art_node48_t);
         } break;
-        case ART_NODE256_TYPE: {
+        case CROARING_ART_NODE256_TYPE: {
             size += sizeof(art_node256_t);
         } break;
         default:
@@ -1347,16 +1347,16 @@ static void art_node_print_type(const art_node_t *node) {
         return;
     }
     switch (art_get_type((art_inner_node_t *)node)) {
-        case ART_NODE4_TYPE:
+        case CROARING_ART_NODE4_TYPE:
             printf("Node4");
             return;
-        case ART_NODE16_TYPE:
+        case CROARING_ART_NODE16_TYPE:
             printf("Node16");
             return;
-        case ART_NODE48_TYPE:
+        case CROARING_ART_NODE48_TYPE:
             printf("Node48");
             return;
-        case ART_NODE256_TYPE:
+        case CROARING_ART_NODE256_TYPE:
             printf("Node256");
             return;
         default:
@@ -1368,7 +1368,7 @@ static void art_node_print_type(const art_node_t *node) {
 void art_node_printf(const art_node_t *node, uint8_t depth) {
     if (art_is_leaf(node)) {
         printf("{ type: Leaf, key: ");
-        art_leaf_t *leaf = CAST_LEAF(node);
+        art_leaf_t *leaf = CROARING_CAST_LEAF(node);
         for (size_t i = 0; i < ART_KEY_BYTES; ++i) {
             printf("%02x", leaf->key[i]);
         }
@@ -1395,7 +1395,7 @@ void art_node_printf(const art_node_t *node, uint8_t depth) {
     printf("\n");
 
     switch (art_get_type(inner_node)) {
-        case ART_NODE4_TYPE: {
+        case CROARING_ART_NODE4_TYPE: {
             art_node4_t *node4 = (art_node4_t *)node;
             for (uint8_t i = 0; i < node4->count; ++i) {
                 printf("%*s", depth, "");
@@ -1403,7 +1403,7 @@ void art_node_printf(const art_node_t *node, uint8_t depth) {
                 art_node_printf(node4->children[i], depth);
             }
         } break;
-        case ART_NODE16_TYPE: {
+        case CROARING_ART_NODE16_TYPE: {
             art_node16_t *node16 = (art_node16_t *)node;
             for (uint8_t i = 0; i < node16->count; ++i) {
                 printf("%*s", depth, "");
@@ -1411,10 +1411,10 @@ void art_node_printf(const art_node_t *node, uint8_t depth) {
                 art_node_printf(node16->children[i], depth);
             }
         } break;
-        case ART_NODE48_TYPE: {
+        case CROARING_ART_NODE48_TYPE: {
             art_node48_t *node48 = (art_node48_t *)node;
             for (int i = 0; i < 256; ++i) {
-                if (node48->keys[i] != ART_NODE48_EMPTY_VAL) {
+                if (node48->keys[i] != CROARING_ART_NODE48_EMPTY_VAL) {
                     printf("%*s", depth, "");
                     printf("key: %02x ", i);
                     printf("child: %02x ", node48->keys[i]);
@@ -1422,7 +1422,7 @@ void art_node_printf(const art_node_t *node, uint8_t depth) {
                 }
             }
         } break;
-        case ART_NODE256_TYPE: {
+        case CROARING_ART_NODE256_TYPE: {
             art_node256_t *node256 = (art_node256_t *)node;
             for (int i = 0; i < 256; ++i) {
                 if (node256->children[i] != NULL) {
@@ -1445,7 +1445,7 @@ void art_insert(art_t *art, const art_key_chunk_t *key, art_val_t *val) {
     art_leaf_t *leaf = (art_leaf_t *)val;
     art_leaf_populate(leaf, key);
     if (art->root == NULL) {
-        art->root = (art_node_t *)SET_LEAF(leaf);
+        art->root = (art_node_t *)CROARING_SET_LEAF(leaf);
         return;
     }
     art->root = art_insert_at(art->root, key, 0, leaf);
@@ -1503,7 +1503,7 @@ static inline art_node_t *art_iterator_node(art_iterator_t *iterator) {
 // true for convenience.
 static inline bool art_iterator_valid_loc(art_iterator_t *iterator,
                                           art_leaf_t *leaf) {
-    iterator->frames[iterator->frame].node = SET_LEAF(leaf);
+    iterator->frames[iterator->frame].node = CROARING_SET_LEAF(leaf);
     iterator->frames[iterator->frame].index_in_node = 0;
     memcpy(iterator->key, leaf->key, ART_KEY_BYTES);
     iterator->value = (art_val_t *)leaf;
@@ -1592,7 +1592,7 @@ static bool art_node_init_iterator(const art_node_t *node,
     // We're at a leaf.
     iterator->frames[iterator->frame].node = (art_node_t *)node;
     iterator->frames[iterator->frame].index_in_node = 0;  // Should not matter.
-    return art_iterator_valid_loc(iterator, CAST_LEAF(node));
+    return art_iterator_valid_loc(iterator, CROARING_CAST_LEAF(node));
 }
 
 bool art_iterator_move(art_iterator_t *iterator, bool forward) {
@@ -1652,7 +1652,7 @@ static bool art_node_iterator_lower_bound(const art_node_t *node,
         art_iterator_down(iterator, inner_node, indexed_child.index);
         node = indexed_child.child;
     }
-    art_leaf_t *leaf = CAST_LEAF(node);
+    art_leaf_t *leaf = CROARING_CAST_LEAF(node);
     if (art_compare_keys(leaf->key, key) >= 0) {
         // Leaf has an equal or larger key.
         return art_iterator_valid_loc(iterator, leaf);
@@ -1806,7 +1806,7 @@ static bool art_internal_validate_at(const art_node_t *node,
         return art_validate_fail(&validator, "node is null");
     }
     if (art_is_leaf(node)) {
-        art_leaf_t *leaf = CAST_LEAF(node);
+        art_leaf_t *leaf = CROARING_CAST_LEAF(node);
         if (art_compare_prefix(leaf->key, 0, validator.current_key, 0,
                                validator.depth) != 0) {
             return art_validate_fail(
@@ -1832,25 +1832,25 @@ static bool art_internal_validate_at(const art_node_t *node,
         validator.depth += inner_node->prefix_size;
 
         switch (inner_node->typecode) {
-            case ART_NODE4_TYPE:
+            case CROARING_ART_NODE4_TYPE:
                 if (!art_node4_internal_validate((art_node4_t *)inner_node,
                                                  validator)) {
                     return false;
                 }
                 break;
-            case ART_NODE16_TYPE:
+            case CROARING_ART_NODE16_TYPE:
                 if (!art_node16_internal_validate((art_node16_t *)inner_node,
                                                   validator)) {
                     return false;
                 }
                 break;
-            case ART_NODE48_TYPE:
+            case CROARING_ART_NODE48_TYPE:
                 if (!art_node48_internal_validate((art_node48_t *)inner_node,
                                                   validator)) {
                     return false;
                 }
                 break;
-            case ART_NODE256_TYPE:
+            case CROARING_ART_NODE256_TYPE:
                 if (!art_node256_internal_validate((art_node256_t *)inner_node,
                                                    validator)) {
                     return false;

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -415,8 +415,9 @@ size_t bitset_difference_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
     return answer;
 }
 
-bool bitset_inplace_symmetric_difference(bitset_t *CROARING_CBITSET_RESTRICT b1,
-                                         const bitset_t *CROARING_CBITSET_RESTRICT b2) {
+bool bitset_inplace_symmetric_difference(
+    bitset_t *CROARING_CBITSET_RESTRICT b1,
+    const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
     size_t k = 0;
@@ -432,8 +433,9 @@ bool bitset_inplace_symmetric_difference(bitset_t *CROARING_CBITSET_RESTRICT b1,
     return true;
 }
 
-size_t bitset_symmetric_difference_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
-                                         const bitset_t *CROARING_CBITSET_RESTRICT b2) {
+size_t bitset_symmetric_difference_count(
+    const bitset_t *CROARING_CBITSET_RESTRICT b1,
+    const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
     size_t k = 0;

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -200,8 +200,8 @@ size_t bitset_count(const bitset_t *bitset) {
     return card;
 }
 
-bool bitset_inplace_union(bitset_t *CBITSET_RESTRICT b1,
-                          const bitset_t *CBITSET_RESTRICT b2) {
+bool bitset_inplace_union(bitset_t *CROARING_CBITSET_RESTRICT b1,
+                          const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
     for (size_t k = 0; k < minlength; ++k) {
@@ -267,8 +267,8 @@ size_t bitset_maximum(const bitset_t *bitset) {
 /* Returns true if bitsets share no common elements, false otherwise.
  *
  * Performs early-out if common element found. */
-bool bitsets_disjoint(const bitset_t *CBITSET_RESTRICT b1,
-                      const bitset_t *CBITSET_RESTRICT b2) {
+bool bitsets_disjoint(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                      const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
 
@@ -282,8 +282,8 @@ bool bitsets_disjoint(const bitset_t *CBITSET_RESTRICT b1,
  * disjoint.
  *
  * Performs early-out if common element found. */
-bool bitsets_intersect(const bitset_t *CBITSET_RESTRICT b1,
-                       const bitset_t *CBITSET_RESTRICT b2) {
+bool bitsets_intersect(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                       const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
 
@@ -307,8 +307,8 @@ static bool any_bits_set(const bitset_t *b, size_t starting_loc) {
 /* Returns true if b1 has all of b2's bits set.
  *
  * Performs early out if a bit is found in b2 that is not found in b1. */
-bool bitset_contains_all(const bitset_t *CBITSET_RESTRICT b1,
-                         const bitset_t *CBITSET_RESTRICT b2) {
+bool bitset_contains_all(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                         const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t min_size = b1->arraysize;
     if (b1->arraysize > b2->arraysize) {
         min_size = b2->arraysize;
@@ -325,8 +325,8 @@ bool bitset_contains_all(const bitset_t *CBITSET_RESTRICT b1,
     return true;
 }
 
-size_t bitset_union_count(const bitset_t *CBITSET_RESTRICT b1,
-                          const bitset_t *CBITSET_RESTRICT b2) {
+size_t bitset_union_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                          const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t answer = 0;
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
@@ -366,8 +366,8 @@ size_t bitset_union_count(const bitset_t *CBITSET_RESTRICT b1,
     return answer;
 }
 
-void bitset_inplace_intersection(bitset_t *CBITSET_RESTRICT b1,
-                                 const bitset_t *CBITSET_RESTRICT b2) {
+void bitset_inplace_intersection(bitset_t *CROARING_CBITSET_RESTRICT b1,
+                                 const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
     size_t k = 0;
@@ -379,8 +379,8 @@ void bitset_inplace_intersection(bitset_t *CBITSET_RESTRICT b1,
     }
 }
 
-size_t bitset_intersection_count(const bitset_t *CBITSET_RESTRICT b1,
-                                 const bitset_t *CBITSET_RESTRICT b2) {
+size_t bitset_intersection_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                                 const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t answer = 0;
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
@@ -390,8 +390,8 @@ size_t bitset_intersection_count(const bitset_t *CBITSET_RESTRICT b1,
     return answer;
 }
 
-void bitset_inplace_difference(bitset_t *CBITSET_RESTRICT b1,
-                               const bitset_t *CBITSET_RESTRICT b2) {
+void bitset_inplace_difference(bitset_t *CROARING_CBITSET_RESTRICT b1,
+                               const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
     size_t k = 0;
@@ -400,8 +400,8 @@ void bitset_inplace_difference(bitset_t *CBITSET_RESTRICT b1,
     }
 }
 
-size_t bitset_difference_count(const bitset_t *CBITSET_RESTRICT b1,
-                               const bitset_t *CBITSET_RESTRICT b2) {
+size_t bitset_difference_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                               const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
     size_t k = 0;
@@ -415,8 +415,8 @@ size_t bitset_difference_count(const bitset_t *CBITSET_RESTRICT b1,
     return answer;
 }
 
-bool bitset_inplace_symmetric_difference(bitset_t *CBITSET_RESTRICT b1,
-                                         const bitset_t *CBITSET_RESTRICT b2) {
+bool bitset_inplace_symmetric_difference(bitset_t *CROARING_CBITSET_RESTRICT b1,
+                                         const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
     size_t k = 0;
@@ -432,8 +432,8 @@ bool bitset_inplace_symmetric_difference(bitset_t *CBITSET_RESTRICT b1,
     return true;
 }
 
-size_t bitset_symmetric_difference_count(const bitset_t *CBITSET_RESTRICT b1,
-                                         const bitset_t *CBITSET_RESTRICT b2) {
+size_t bitset_symmetric_difference_count(const bitset_t *CROARING_CBITSET_RESTRICT b1,
+                                         const bitset_t *CROARING_CBITSET_RESTRICT b2) {
     size_t minlength =
         b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
     size_t k = 0;

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -252,8 +252,8 @@ bool bitset_container_intersect(const bitset_container_t *src_1,
 }
 
 #if CROARING_IS_X64
-#ifndef WORDS_IN_AVX2_REG
-#define WORDS_IN_AVX2_REG sizeof(__m256i) / sizeof(uint64_t)
+#ifndef CROARING_WORDS_IN_AVX2_REG
+#define CROARING_WORDS_IN_AVX2_REG sizeof(__m256i) / sizeof(uint64_t)
 #endif
 #ifndef WORDS_IN_AVX512_REG
 #define WORDS_IN_AVX512_REG sizeof(__m512i) / sizeof(uint64_t)
@@ -284,7 +284,7 @@ int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
         if (support & ROARING_SUPPORTS_AVX2) {
             return (int)avx2_harley_seal_popcount256(
                 (const __m256i *)bitset->words,
-                BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));
+                BITSET_CONTAINER_SIZE_IN_WORDS / (CROARING_WORDS_IN_AVX2_REG));
         } else {
             return _scalar_bitset_container_compute_cardinality(bitset);
         }
@@ -333,7 +333,7 @@ int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
 
 #if CROARING_IS_X64
 
-#define BITSET_CONTAINER_FN_REPEAT 8
+#define CROARING_BITSET_CONTAINER_FN_REPEAT 8
 #ifndef WORDS_IN_AVX512_REG
 #define WORDS_IN_AVX512_REG sizeof(__m512i) / sizeof(uint64_t)
 #endif  // WORDS_IN_AVX512_REG
@@ -341,7 +341,7 @@ int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
 /* Computes a binary operation (eg union) on bitset1 and bitset2 and write the
    result to bitsetout */
 // clang-format off
-#define AVX512_BITSET_CONTAINER_FN1(before, opname, opsymbol, avx_intrinsic,   \
+#define CROARING_AVX512_BITSET_CONTAINER_FN1(before, opname, opsymbol, avx_intrinsic,   \
                                 neon_intrinsic, after)                         \
   static inline int _avx512_bitset_container_##opname##_nocard(                \
       const bitset_container_t *src_1, const bitset_container_t *src_2,        \
@@ -395,7 +395,7 @@ int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
     return dst->cardinality;                                            \
   }
 
-#define AVX512_BITSET_CONTAINER_FN2(before, opname, opsymbol, avx_intrinsic,           \
+#define CROARING_AVX512_BITSET_CONTAINER_FN2(before, opname, opsymbol, avx_intrinsic,           \
                                 neon_intrinsic, after)                                 \
   /* next, a version that updates cardinality*/                                        \
   static inline int _avx512_bitset_container_##opname(const bitset_container_t *src_1, \
@@ -409,7 +409,7 @@ int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
     return dst->cardinality;                                                            \
   }
 
-#define AVX512_BITSET_CONTAINER_FN3(before, opname, opsymbol, avx_intrinsic,            \
+#define CROARING_AVX512_BITSET_CONTAINER_FN3(before, opname, opsymbol, avx_intrinsic,            \
                                 neon_intrinsic, after)                                  \
   /* next, a version that just computes the cardinality*/                               \
   static inline int _avx512_bitset_container_##opname##_justcard(                       \
@@ -424,85 +424,85 @@ int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
 // we duplicate the function because other containers use the "or" term, makes API more consistent
 #if CROARING_COMPILER_SUPPORTS_AVX512
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, or,    |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, or,    |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, union, |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, union, |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 
 // we duplicate the function because other containers use the "intersection" term, makes API more consistent
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, and,          &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, and,          &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, intersection, &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, intersection, &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, xor,    ^,  _mm512_xor_si512,    veorq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, xor,    ^,  _mm512_xor_si512,    veorq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, andnot, &~, _mm512_andnot_si512, vbicq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX512, andnot, &~, _mm512_andnot_si512, vbicq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 
 // we duplicate the function because other containers use the "or" term, makes API more consistent
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, or,    |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, or,    |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, union, |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, union, |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 
 // we duplicate the function because other containers use the "intersection" term, makes API more consistent
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, and,          &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, and,          &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, intersection, &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, intersection, &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, xor,    ^,  _mm512_xor_si512,    veorq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, xor,    ^,  _mm512_xor_si512,    veorq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, andnot, &~, _mm512_andnot_si512, vbicq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX512, andnot, &~, _mm512_andnot_si512, vbicq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 
 // we duplicate the function because other containers use the "or" term, makes API more consistent
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, or,    |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, or,    |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, union, |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, union, |, _mm512_or_si512, vorrq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 
 // we duplicate the function because other containers use the "intersection" term, makes API more consistent
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, and,          &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, and,          &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, intersection, &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, intersection, &, _mm512_and_si512, vandq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, xor,    ^,  _mm512_xor_si512,    veorq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, xor,    ^,  _mm512_xor_si512,    veorq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 CROARING_TARGET_AVX512
-AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, andnot, &~, _mm512_andnot_si512, vbicq_u64, CROARING_UNTARGET_AVX512)
+CROARING_AVX512_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX512, andnot, &~, _mm512_andnot_si512, vbicq_u64, CROARING_UNTARGET_AVX512)
 CROARING_UNTARGET_AVX512
 #endif // CROARING_COMPILER_SUPPORTS_AVX512
 
-#ifndef WORDS_IN_AVX2_REG
-#define WORDS_IN_AVX2_REG sizeof(__m256i) / sizeof(uint64_t)
-#endif // WORDS_IN_AVX2_REG
-#define LOOP_SIZE                    \
+#ifndef CROARING_WORDS_IN_AVX2_REG
+#define CROARING_WORDS_IN_AVX2_REG sizeof(__m256i) / sizeof(uint64_t)
+#endif // CROARING_WORDS_IN_AVX2_REG
+#define CROARING_LOOP_SIZE                    \
     BITSET_CONTAINER_SIZE_IN_WORDS / \
-        ((WORDS_IN_AVX2_REG)*BITSET_CONTAINER_FN_REPEAT)
+        ((CROARING_WORDS_IN_AVX2_REG)*CROARING_BITSET_CONTAINER_FN_REPEAT)
 
 /* Computes a binary operation (eg union) on bitset1 and bitset2 and write the
    result to bitsetout */
 // clang-format off
-#define AVX_BITSET_CONTAINER_FN1(before, opname, opsymbol, avx_intrinsic,               \
+#define CROARING_AVX_BITSET_CONTAINER_FN1(before, opname, opsymbol, avx_intrinsic,               \
                                 neon_intrinsic, after)                                \
   static inline int _avx2_bitset_container_##opname##_nocard(                                \
       const bitset_container_t *src_1, const bitset_container_t *src_2,        \
@@ -513,7 +513,7 @@ CROARING_UNTARGET_AVX512
     uint8_t *out = (uint8_t *)dst->words;                                      \
     const int innerloop = 8;                                                   \
     for (size_t i = 0;                                                         \
-         i < BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG);             \
+         i < BITSET_CONTAINER_SIZE_IN_WORDS / (CROARING_WORDS_IN_AVX2_REG);             \
          i += innerloop) {                                                     \
       __m256i A1, A2, AO;                                                      \
       A1 = _mm256_lddqu_si256((const __m256i *)(words_1));                     \
@@ -556,7 +556,7 @@ CROARING_UNTARGET_AVX512
     return dst->cardinality;                                                   \
   }
 
-#define AVX_BITSET_CONTAINER_FN2(before, opname, opsymbol, avx_intrinsic,               \
+#define CROARING_AVX_BITSET_CONTAINER_FN2(before, opname, opsymbol, avx_intrinsic,               \
                                 neon_intrinsic, after)                                \
   /* next, a version that updates cardinality*/                                \
   static inline int _avx2_bitset_container_##opname(const bitset_container_t *src_1,         \
@@ -567,11 +567,11 @@ CROARING_UNTARGET_AVX512
     __m256i *out = (__m256i *)dst->words;                                      \
     dst->cardinality = (int32_t)avx2_harley_seal_popcount256andstore_##opname( \
         words_2, words_1, out,                                                 \
-        BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));                 \
+        BITSET_CONTAINER_SIZE_IN_WORDS / (CROARING_WORDS_IN_AVX2_REG));                 \
     return dst->cardinality;                                                   \
   }                                                                            \
 
-#define AVX_BITSET_CONTAINER_FN3(before, opname, opsymbol, avx_intrinsic,               \
+#define CROARING_AVX_BITSET_CONTAINER_FN3(before, opname, opsymbol, avx_intrinsic,               \
                                 neon_intrinsic, after)                                \
   /* next, a version that just computes the cardinality*/                      \
   static inline int _avx2_bitset_container_##opname##_justcard(                              \
@@ -579,77 +579,77 @@ CROARING_UNTARGET_AVX512
     const __m256i *__restrict__ data1 = (const __m256i *)src_1->words;         \
     const __m256i *__restrict__ data2 = (const __m256i *)src_2->words;         \
     return (int)avx2_harley_seal_popcount256_##opname(                         \
-        data2, data1, BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));   \
+        data2, data1, BITSET_CONTAINER_SIZE_IN_WORDS / (CROARING_WORDS_IN_AVX2_REG));   \
   }
 
 
 // we duplicate the function because other containers use the "or" term, makes API more consistent
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, or,    |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, or,    |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, union, |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, union, |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 
 // we duplicate the function because other containers use the "intersection" term, makes API more consistent
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, and,          &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, and,          &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, intersection, &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, intersection, &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, xor,    ^,  _mm256_xor_si256,    veorq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, xor,    ^,  _mm256_xor_si256,    veorq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, andnot, &~, _mm256_andnot_si256, vbicq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN1(CROARING_TARGET_AVX2, andnot, &~, _mm256_andnot_si256, vbicq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 
 // we duplicate the function because other containers use the "or" term, makes API more consistent
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, or,    |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, or,    |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, union, |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, union, |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 
 // we duplicate the function because other containers use the "intersection" term, makes API more consistent
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, and,          &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, and,          &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, intersection, &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, intersection, &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, xor,    ^,  _mm256_xor_si256,    veorq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, xor,    ^,  _mm256_xor_si256,    veorq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, andnot, &~, _mm256_andnot_si256, vbicq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN2(CROARING_TARGET_AVX2, andnot, &~, _mm256_andnot_si256, vbicq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 
 // we duplicate the function because other containers use the "or" term, makes API more consistent
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, or,    |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, or,    |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, union, |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, union, |, _mm256_or_si256, vorrq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 
 // we duplicate the function because other containers use the "intersection" term, makes API more consistent
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, and,          &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, and,          &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, intersection, &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, intersection, &, _mm256_and_si256, vandq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, xor,    ^,  _mm256_xor_si256,    veorq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, xor,    ^,  _mm256_xor_si256,    veorq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 CROARING_TARGET_AVX2
-AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, andnot, &~, _mm256_andnot_si256, vbicq_u64, CROARING_UNTARGET_AVX2)
+CROARING_AVX_BITSET_CONTAINER_FN3(CROARING_TARGET_AVX2, andnot, &~, _mm256_andnot_si256, vbicq_u64, CROARING_UNTARGET_AVX2)
 CROARING_UNTARGET_AVX2
 
 
@@ -711,7 +711,7 @@ SCALAR_BITSET_CONTAINER_FN(xor,    ^,  _mm256_xor_si256,    veorq_u64)
 SCALAR_BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
 
 #if CROARING_COMPILER_SUPPORTS_AVX512
-#define BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)   \
+#define CROARING_BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)   \
   int bitset_container_##opname(const bitset_container_t *src_1,               \
                                 const bitset_container_t *src_2,               \
                                 bitset_container_t *dst) {                     \
@@ -754,7 +754,7 @@ SCALAR_BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
 #else // CROARING_COMPILER_SUPPORTS_AVX512
 
 
-#define BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)   \
+#define CROARING_BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)   \
   int bitset_container_##opname(const bitset_container_t *src_1,               \
                                 const bitset_container_t *src_2,               \
                                 bitset_container_t *dst) {                     \
@@ -786,7 +786,7 @@ SCALAR_BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
 
 #elif defined(CROARING_USENEON)
 
-#define BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)  \
+#define CROARING_BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)  \
 int bitset_container_##opname(const bitset_container_t *src_1,                \
                               const bitset_container_t *src_2,                \
                               bitset_container_t *dst) {                      \
@@ -874,7 +874,7 @@ int bitset_container_##opname##_justcard(const bitset_container_t *src_1,     \
 
 #else
 
-#define BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)  \
+#define CROARING_BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)  \
 int bitset_container_##opname(const bitset_container_t *src_1,            \
                               const bitset_container_t *src_2,            \
                               bitset_container_t *dst) {                  \
@@ -922,15 +922,15 @@ int bitset_container_##opname##_justcard(const bitset_container_t *src_1, \
 #endif // CROARING_IS_X64
 
 // we duplicate the function because other containers use the "or" term, makes API more consistent
-BITSET_CONTAINER_FN(or,    |, _mm256_or_si256, vorrq_u64)
-BITSET_CONTAINER_FN(union, |, _mm256_or_si256, vorrq_u64)
+CROARING_BITSET_CONTAINER_FN(or,    |, _mm256_or_si256, vorrq_u64)
+CROARING_BITSET_CONTAINER_FN(union, |, _mm256_or_si256, vorrq_u64)
 
 // we duplicate the function because other containers use the "intersection" term, makes API more consistent
-BITSET_CONTAINER_FN(and,          &, _mm256_and_si256, vandq_u64)
-BITSET_CONTAINER_FN(intersection, &, _mm256_and_si256, vandq_u64)
+CROARING_BITSET_CONTAINER_FN(and,          &, _mm256_and_si256, vandq_u64)
+CROARING_BITSET_CONTAINER_FN(intersection, &, _mm256_and_si256, vandq_u64)
 
-BITSET_CONTAINER_FN(xor,    ^,  _mm256_xor_si256,    veorq_u64)
-BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
+CROARING_BITSET_CONTAINER_FN(xor,    ^,  _mm256_xor_si256,    veorq_u64)
+CROARING_BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
 // clang-format On
 
 

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -302,7 +302,7 @@ int run_array_container_andnot(const run_container_t *src_1,
             if (end <= xstart) {
                 // output the first run
                 answer->runs[answer->n_runs++] =
-                    MAKE_RLE16(start, end - start - 1);
+                    CROARING_MAKE_RLE16(start, end - start - 1);
                 rlepos++;
                 if (rlepos < src_1->n_runs) {
                     start = src_1->runs[rlepos].value;
@@ -317,7 +317,7 @@ int run_array_container_andnot(const run_container_t *src_1,
             } else {
                 if (start < xstart) {
                     answer->runs[answer->n_runs++] =
-                        MAKE_RLE16(start, xstart - start - 1);
+                        CROARING_MAKE_RLE16(start, xstart - start - 1);
                 }
                 if (xstart + 1 < end) {
                     start = xstart + 1;
@@ -331,7 +331,7 @@ int run_array_container_andnot(const run_container_t *src_1,
             }
         }
         if (rlepos < src_1->n_runs) {
-            answer->runs[answer->n_runs++] = MAKE_RLE16(start, end - start - 1);
+            answer->runs[answer->n_runs++] = CROARING_MAKE_RLE16(start, end - start - 1);
             rlepos++;
             if (rlepos < src_1->n_runs) {
                 memcpy(answer->runs + answer->n_runs, src_1->runs + rlepos,

--- a/src/containers/mixed_andnot.c
+++ b/src/containers/mixed_andnot.c
@@ -331,7 +331,8 @@ int run_array_container_andnot(const run_container_t *src_1,
             }
         }
         if (rlepos < src_1->n_runs) {
-            answer->runs[answer->n_runs++] = CROARING_MAKE_RLE16(start, end - start - 1);
+            answer->runs[answer->n_runs++] =
+                CROARING_MAKE_RLE16(start, end - start - 1);
             rlepos++;
             if (rlepos < src_1->n_runs) {
                 memcpy(answer->runs + answer->n_runs, src_1->runs + rlepos,

--- a/src/containers/mixed_negation.c
+++ b/src/containers/mixed_negation.c
@@ -326,7 +326,7 @@ int run_container_negation_range_inplace(run_container_t *src,
     }
 
     // as with Java implementation, use locals to give self a buffer of depth 1
-    rle16_t buffered = MAKE_RLE16(0, 0);
+    rle16_t buffered = CROARING_MAKE_RLE16(0, 0);
     rle16_t next = buffered;
     if (k < my_nbr_runs) buffered = src->runs[k];
 

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -595,7 +595,7 @@ void run_container_andnot(const run_container_t *src_1,
     while ((rlepos1 < src_1->n_runs) && (rlepos2 < src_2->n_runs)) {
         if (end <= start2) {
             // output the first run
-            dst->runs[dst->n_runs++] = MAKE_RLE16(start, end - start - 1);
+            dst->runs[dst->n_runs++] = CROARING_MAKE_RLE16(start, end - start - 1);
             rlepos1++;
             if (rlepos1 < src_1->n_runs) {
                 start = src_1->runs[rlepos1].value;
@@ -611,7 +611,7 @@ void run_container_andnot(const run_container_t *src_1,
         } else {
             if (start < start2) {
                 dst->runs[dst->n_runs++] =
-                    MAKE_RLE16(start, start2 - start - 1);
+                    CROARING_MAKE_RLE16(start, start2 - start - 1);
             }
             if (end2 < end) {
                 start = end2;
@@ -625,7 +625,7 @@ void run_container_andnot(const run_container_t *src_1,
         }
     }
     if (rlepos1 < src_1->n_runs) {
-        dst->runs[dst->n_runs++] = MAKE_RLE16(start, end - start - 1);
+        dst->runs[dst->n_runs++] = CROARING_MAKE_RLE16(start, end - start - 1);
         rlepos1++;
         if (rlepos1 < src_1->n_runs) {
             memcpy(dst->runs + dst->n_runs, src_1->runs + rlepos1,
@@ -827,7 +827,7 @@ void run_container_smart_append_exclusive(run_container_t *src,
 
     if (!src->n_runs ||
         (start > (old_end = last_run->value + last_run->length + 1))) {
-        *appended_last_run = MAKE_RLE16(start, length);
+        *appended_last_run = CROARING_MAKE_RLE16(start, length);
         src->n_runs++;
         return;
     }
@@ -841,10 +841,10 @@ void run_container_smart_append_exclusive(run_container_t *src,
     if (start == last_run->value) {
         // wipe out previous
         if (new_end < old_end) {
-            *last_run = MAKE_RLE16(new_end, old_end - new_end - 1);
+            *last_run = CROARING_MAKE_RLE16(new_end, old_end - new_end - 1);
             return;
         } else if (new_end > old_end) {
-            *last_run = MAKE_RLE16(old_end, new_end - old_end - 1);
+            *last_run = CROARING_MAKE_RLE16(old_end, new_end - old_end - 1);
             return;
         } else {
             src->n_runs--;
@@ -853,10 +853,10 @@ void run_container_smart_append_exclusive(run_container_t *src,
     }
     last_run->length = start - last_run->value - 1;
     if (new_end < old_end) {
-        *appended_last_run = MAKE_RLE16(new_end, old_end - new_end - 1);
+        *appended_last_run = CROARING_MAKE_RLE16(new_end, old_end - new_end - 1);
         src->n_runs++;
     } else if (new_end > old_end) {
-        *appended_last_run = MAKE_RLE16(old_end, new_end - old_end - 1);
+        *appended_last_run = CROARING_MAKE_RLE16(old_end, new_end - old_end - 1);
         src->n_runs++;
     }
 }

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -595,7 +595,8 @@ void run_container_andnot(const run_container_t *src_1,
     while ((rlepos1 < src_1->n_runs) && (rlepos2 < src_2->n_runs)) {
         if (end <= start2) {
             // output the first run
-            dst->runs[dst->n_runs++] = CROARING_MAKE_RLE16(start, end - start - 1);
+            dst->runs[dst->n_runs++] =
+                CROARING_MAKE_RLE16(start, end - start - 1);
             rlepos1++;
             if (rlepos1 < src_1->n_runs) {
                 start = src_1->runs[rlepos1].value;
@@ -853,10 +854,12 @@ void run_container_smart_append_exclusive(run_container_t *src,
     }
     last_run->length = start - last_run->value - 1;
     if (new_end < old_end) {
-        *appended_last_run = CROARING_MAKE_RLE16(new_end, old_end - new_end - 1);
+        *appended_last_run =
+            CROARING_MAKE_RLE16(new_end, old_end - new_end - 1);
         src->n_runs++;
     } else if (new_end > old_end) {
-        *appended_last_run = CROARING_MAKE_RLE16(old_end, new_end - old_end - 1);
+        *appended_last_run =
+            CROARING_MAKE_RLE16(old_end, new_end - old_end - 1);
         src->n_runs++;
     }
 }

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -1591,7 +1591,7 @@ static int run_negation_range_tests(int k, int h, int start_offset, int r_start,
             // run_container_append does not dynamically increase its
             // array
             run_container_append_first(RI,
-                                       MAKE_RLE16(offsetx, actual_runlen - 1));
+                                       CROARING_MAKE_RLE16(offsetx, actual_runlen - 1));
             if (++runlen == k) runlen = h;  // wrap after k-1 back to h.
         }
     }
@@ -1669,7 +1669,7 @@ static int run_negation_range_tests_simpler(int k, int h, int start_offset,
                 actual_runlen = (1 << 16) - offsetx;
 
             run_container_append_first(RI,
-                                       MAKE_RLE16(offsetx, actual_runlen - 1));
+                                       CROARING_MAKE_RLE16(offsetx, actual_runlen - 1));
             if (++runlen == k) runlen = h;
         }
     }

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -1590,8 +1590,8 @@ static int run_negation_range_tests(int k, int h, int start_offset, int r_start,
 
             // run_container_append does not dynamically increase its
             // array
-            run_container_append_first(RI,
-                                       CROARING_MAKE_RLE16(offsetx, actual_runlen - 1));
+            run_container_append_first(
+                RI, CROARING_MAKE_RLE16(offsetx, actual_runlen - 1));
             if (++runlen == k) runlen = h;  // wrap after k-1 back to h.
         }
     }
@@ -1668,8 +1668,8 @@ static int run_negation_range_tests_simpler(int k, int h, int start_offset,
             if (offsetx + actual_runlen > (1 << 16))
                 actual_runlen = (1 << 16) - offsetx;
 
-            run_container_append_first(RI,
-                                       CROARING_MAKE_RLE16(offsetx, actual_runlen - 1));
+            run_container_append_first(
+                RI, CROARING_MAKE_RLE16(offsetx, actual_runlen - 1));
             if (++runlen == k) runlen = h;
         }
     }

--- a/tests/threads_unit.cpp
+++ b/tests/threads_unit.cpp
@@ -47,14 +47,14 @@ bool run_threads_unit_tests() {
     roaring_bitmap_t *r3 = roaring_bitmap_copy(r1);
     roaring_bitmap_set_copy_on_write(r3, true);
 
-    roaring_bitmap_t * r1a = roaring_bitmap_copy(r1);
-    roaring_bitmap_t * r1b = roaring_bitmap_copy(r1);
+    roaring_bitmap_t *r1a = roaring_bitmap_copy(r1);
+    roaring_bitmap_t *r1b = roaring_bitmap_copy(r1);
 
-    roaring_bitmap_t * r2a = roaring_bitmap_copy(r2);
-    roaring_bitmap_t * r2b = roaring_bitmap_copy(r2);
+    roaring_bitmap_t *r2a = roaring_bitmap_copy(r2);
+    roaring_bitmap_t *r2b = roaring_bitmap_copy(r2);
 
-    roaring_bitmap_t * r3a = roaring_bitmap_copy(r3);
-    roaring_bitmap_t * r3b = roaring_bitmap_copy(r3);
+    roaring_bitmap_t *r3a = roaring_bitmap_copy(r3);
+    roaring_bitmap_t *r3b = roaring_bitmap_copy(r3);
 
     roaring_bitmap_t *rarray1[3] = {r1a, r2a, r3a};
     roaring_bitmap_t *rarray2[3] = {r1b, r2b, r3b};


### PR DESCRIPTION
This issues with our macros: mostly lack of prefixing, but also a build issue reported by @dg0yt due to a missing byteswapping function.