### PR TITLE
fix: correct struct init + one array to array comp.

### DIFF
--- a/benchmarks/add_benchmark.c
+++ b/benchmarks/add_benchmark.c
@@ -117,7 +117,7 @@ void run_test(uint32_t spanlen, uint32_t intvlen, double density,
     for (int p = 0; p < num_passes; p++) {
         roaring_bitmap_t *r = roaring_bitmap_create();
         RDTSC_START(cycles_start);
-        roaring_bulk_context_t context = {0};
+        roaring_bulk_context_t context = {0, 0, 0, 0};
         for (int64_t i = 0; i < count; i++) {
             for (uint32_t j = 0; j < intvlen; j++) {
                 roaring_bitmap_add_bulk(r, &context, offsets[i] + j);

--- a/benchmarks/containsmulti_benchmark.c
+++ b/benchmarks/containsmulti_benchmark.c
@@ -19,7 +19,7 @@ void contains_multi_via_contains(roaring_bitmap_t* bm, const uint32_t* values,
 
 void contains_multi_bulk(roaring_bitmap_t* bm, const uint32_t* values,
                          bool* results, const size_t count) {
-    roaring_bulk_context_t context = {0};
+    roaring_bulk_context_t context = {0, 0};
     for (size_t i = 0; i < count; ++i) {
         results[i] = roaring_bitmap_contains_bulk(bm, &context, values[i]);
     }

--- a/src/art/art.c
+++ b/src/art/art.c
@@ -1041,7 +1041,7 @@ static art_indexed_child_t art_node_next_child(const art_node_t *node,
             return art_node256_next_child((art_node256_t *)node, index);
         default:
             assert(false);
-            return (art_indexed_child_t){0};
+            return (art_indexed_child_t){0, 0, 0};
     }
 }
 
@@ -1065,7 +1065,7 @@ static art_indexed_child_t art_node_prev_child(const art_node_t *node,
             return art_node256_prev_child((art_node256_t *)node, index);
         default:
             assert(false);
-            return (art_indexed_child_t){0};
+            return (art_indexed_child_t){0, 0, 0};
     }
 }
 
@@ -1089,7 +1089,7 @@ static art_indexed_child_t art_node_child_at(const art_node_t *node,
             return art_node256_child_at((art_node256_t *)node, index);
         default:
             assert(false);
-            return (art_indexed_child_t){0};
+            return (art_indexed_child_t){0, 0, 0};
     }
 }
 
@@ -1113,7 +1113,7 @@ static art_indexed_child_t art_node_lower_bound(const art_node_t *node,
             return art_node256_lower_bound((art_node256_t *)node, key_chunk);
         default:
             assert(false);
-            return (art_indexed_child_t){0};
+            return (art_indexed_child_t){0, 0, 0};
     }
 }
 
@@ -1670,7 +1670,7 @@ static bool art_node_iterator_lower_bound(const art_node_t *node,
 }
 
 art_iterator_t art_init_iterator(const art_t *art, bool first) {
-    art_iterator_t iterator = {0};
+    art_iterator_t iterator = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     if (art->root == NULL) {
         return iterator;
     }
@@ -1727,7 +1727,7 @@ bool art_iterator_lower_bound(art_iterator_t *iterator,
 }
 
 art_iterator_t art_lower_bound(const art_t *art, const art_key_chunk_t *key) {
-    art_iterator_t iterator = {0};
+    art_iterator_t iterator = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     if (art->root != NULL) {
         art_node_iterator_lower_bound(art->root, &iterator, key);
     }
@@ -1735,7 +1735,7 @@ art_iterator_t art_lower_bound(const art_t *art, const art_key_chunk_t *key) {
 }
 
 art_iterator_t art_upper_bound(const art_t *art, const art_key_chunk_t *key) {
-    art_iterator_t iterator = {0};
+    art_iterator_t iterator = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     if (art->root != NULL) {
         if (art_node_iterator_lower_bound(art->root, &iterator, key) &&
             art_compare_keys(iterator.key, key) == 0) {

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -199,7 +199,7 @@ roaring_bitmap_t *roaring_bitmap_of(size_t n_args, ...) {
     // todo: could be greatly optimized but we do not expect this call to ever
     // include long lists
     roaring_bitmap_t *answer = roaring_bitmap_create();
-    roaring_bulk_context_t context = {0};
+    roaring_bulk_context_t context = {0, 0, 0, 0};
     va_list ap;
     va_start(ap, n_args);
     for (size_t i = 0; i < n_args; i++) {
@@ -1561,7 +1561,7 @@ roaring_bitmap_t *roaring_bitmap_deserialize(const void *buf) {
         if (bitmap == NULL) {
             return NULL;
         }
-        roaring_bulk_context_t context = {0};
+        roaring_bulk_context_t context = {0, 0, 0, 0};
         for (uint32_t i = 0; i < card; i++) {
             // elems may not be aligned, read with memcpy
             uint32_t elem;
@@ -1604,7 +1604,7 @@ roaring_bitmap_t *roaring_bitmap_deserialize_safe(const void *buf,
         if (bitmap == NULL) {
             return NULL;
         }
-        roaring_bulk_context_t context = {0};
+        roaring_bulk_context_t context = {0, 0, 0, 0};
         for (uint32_t i = 0; i < card; i++) {
             // elems may not be aligned, read with memcpy
             uint32_t elem;

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -224,7 +224,7 @@ roaring64_bitmap_t *roaring64_bitmap_of_ptr(size_t n_args,
 
 roaring64_bitmap_t *roaring64_bitmap_of(size_t n_args, ...) {
     roaring64_bitmap_t *r = roaring64_bitmap_create();
-    roaring64_bulk_context_t context = {0};
+    roaring64_bulk_context_t context = {};
     va_list ap;
     va_start(ap, n_args);
     for (size_t i = 0; i < n_args; i++) {
@@ -317,7 +317,7 @@ void roaring64_bitmap_add_many(roaring64_bitmap_t *r, size_t n_args,
         return;
     }
     const uint64_t *end = vals + n_args;
-    roaring64_bulk_context_t context = {0};
+    roaring64_bulk_context_t context = {};
     for (const uint64_t *current_val = vals; current_val != end;
          current_val++) {
         roaring64_bitmap_add_bulk(r, &context, *current_val);
@@ -456,7 +456,7 @@ bool roaring64_bitmap_contains_bulk(const roaring64_bitmap_t *r,
     uint8_t high48[ART_KEY_BYTES];
     uint16_t low16 = split_key(val, high48);
 
-    if (context->leaf == NULL || context->high_bytes != high48) {
+    if (context->leaf == NULL || art_compare_keys(context->high_bytes, high48) != 0) {
         // We're not positioned anywhere yet or the high bits of the key
         // differ.
         leaf_t *leaf = (leaf_t *)art_find(&r->art, high48);
@@ -640,7 +640,7 @@ void roaring64_bitmap_remove_many(roaring64_bitmap_t *r, size_t n_args,
         return;
     }
     const uint64_t *end = vals + n_args;
-    roaring64_bulk_context_t context = {0};
+    roaring64_bulk_context_t context = {0, 0, 0, 0, 0, 0, 0};
     for (const uint64_t *current_val = vals; current_val != end;
          current_val++) {
         roaring64_bitmap_remove_bulk(r, &context, *current_val);
@@ -1968,7 +1968,7 @@ bool roaring64_bitmap_iterate(const roaring64_bitmap_t *r,
 
 void roaring64_bitmap_to_uint64_array(const roaring64_bitmap_t *r,
                                       uint64_t *out) {
-    roaring64_iterator_t it = {0};
+    roaring64_iterator_t it; // gets initialized in the next line
     roaring64_iterator_init_at(r, &it, /*first=*/true);
     roaring64_iterator_read(&it, out, UINT64_MAX);
 }

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -224,7 +224,7 @@ roaring64_bitmap_t *roaring64_bitmap_of_ptr(size_t n_args,
 
 roaring64_bitmap_t *roaring64_bitmap_of(size_t n_args, ...) {
     roaring64_bitmap_t *r = roaring64_bitmap_create();
-    roaring64_bulk_context_t context = {};
+    roaring64_bulk_context_t context = {0, 0, 0, 0, 0, 0, 0};
     va_list ap;
     va_start(ap, n_args);
     for (size_t i = 0; i < n_args; i++) {
@@ -317,7 +317,7 @@ void roaring64_bitmap_add_many(roaring64_bitmap_t *r, size_t n_args,
         return;
     }
     const uint64_t *end = vals + n_args;
-    roaring64_bulk_context_t context = {};
+    roaring64_bulk_context_t context = {0, 0, 0, 0, 0, 0, 0};
     for (const uint64_t *current_val = vals; current_val != end;
          current_val++) {
         roaring64_bitmap_add_bulk(r, &context, *current_val);
@@ -456,7 +456,8 @@ bool roaring64_bitmap_contains_bulk(const roaring64_bitmap_t *r,
     uint8_t high48[ART_KEY_BYTES];
     uint16_t low16 = split_key(val, high48);
 
-    if (context->leaf == NULL || art_compare_keys(context->high_bytes, high48) != 0) {
+    if (context->leaf == NULL ||
+        art_compare_keys(context->high_bytes, high48) != 0) {
         // We're not positioned anywhere yet or the high bits of the key
         // differ.
         leaf_t *leaf = (leaf_t *)art_find(&r->art, high48);
@@ -1968,7 +1969,7 @@ bool roaring64_bitmap_iterate(const roaring64_bitmap_t *r,
 
 void roaring64_bitmap_to_uint64_array(const roaring64_bitmap_t *r,
                                       uint64_t *out) {
-    roaring64_iterator_t it; // gets initialized in the next line
+    roaring64_iterator_t it;  // gets initialized in the next line
     roaring64_iterator_init_at(r, &it, /*first=*/true);
     roaring64_iterator_read(&it, out, UINT64_MAX);
 }

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -139,7 +139,7 @@ DEFINE_TEST(range_contains) {
 
 DEFINE_TEST(contains_bulk) {
     roaring_bitmap_t *bm = roaring_bitmap_create();
-    roaring_bulk_context_t context = {0};
+    roaring_bulk_context_t context = {0, 0};
 
     // Ensure checking an empty bitmap is okay
     assert_true(!roaring_bitmap_contains_bulk(bm, &context, 0));
@@ -176,7 +176,7 @@ DEFINE_TEST(contains_bulk) {
     size_t test_count = sizeof(values) / sizeof(values[0]);
 
     for (size_t i = 0; i < test_count; i++) {
-        roaring_bulk_context_t empty_context = {0};
+        roaring_bulk_context_t empty_context = {};
         bool expected_contains = roaring_bitmap_contains(bm, values[i]);
         assert_true(expected_contains == roaring_bitmap_contains_bulk(
                                              bm, &empty_context, values[i]));
@@ -1055,7 +1055,7 @@ DEFINE_TEST(test_addremove) {
 
 DEFINE_TEST(test_addremove_bulk) {
     roaring_bitmap_t *bm = roaring_bitmap_create();
-    roaring_bulk_context_t context = {0};
+    roaring_bulk_context_t context = {0, 0};
     for (uint32_t value = 33057; value < 147849; value += 8) {
         roaring_bitmap_add_bulk(bm, &context, value);
     }

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -139,7 +139,7 @@ DEFINE_TEST(range_contains) {
 
 DEFINE_TEST(contains_bulk) {
     roaring_bitmap_t *bm = roaring_bitmap_create();
-    roaring_bulk_context_t context = {0, 0};
+    roaring_bulk_context_t context = {0, 0, 0, 0};
 
     // Ensure checking an empty bitmap is okay
     assert_true(!roaring_bitmap_contains_bulk(bm, &context, 0));
@@ -176,7 +176,7 @@ DEFINE_TEST(contains_bulk) {
     size_t test_count = sizeof(values) / sizeof(values[0]);
 
     for (size_t i = 0; i < test_count; i++) {
-        roaring_bulk_context_t empty_context = {};
+        roaring_bulk_context_t empty_context = {0, 0, 0, 0};
         bool expected_contains = roaring_bitmap_contains(bm, values[i]);
         assert_true(expected_contains == roaring_bitmap_contains_bulk(
                                              bm, &empty_context, values[i]));
@@ -1055,7 +1055,7 @@ DEFINE_TEST(test_addremove) {
 
 DEFINE_TEST(test_addremove_bulk) {
     roaring_bitmap_t *bm = roaring_bitmap_create();
-    roaring_bulk_context_t context = {0, 0};
+    roaring_bulk_context_t context = {0, 0, 0, 0};
     for (uint32_t value = 33057; value < 147849; value += 8) {
         roaring_bitmap_add_bulk(bm, &context, value);
     }


### PR DESCRIPTION
Mostly nitpicking but one change is significant...

This expression looks wrong...
```
context->high_bytes != high48
```

I am not sure what an array-to-array comparison does in C.