### PR TITLE
fix: introduce init functions to avoid warnings.

### DIFF
--- a/include/roaring/art/art.h
+++ b/include/roaring/art/art.h
@@ -139,6 +139,11 @@ typedef struct art_iterator_s {
 } art_iterator_t;
 
 /**
+ * Initialize the iterator to zero.
+ */
+void art_iterator_init(art_iterator_t *iterator);
+
+/**
  * Creates an iterator initialzed to the first or last entry in the ART,
  * depending on `first`. The iterator is not valid if there are no entries in
  * the ART.

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -38,7 +38,7 @@ typedef struct roaring64_bulk_context_s {
 /**
  * Initialize a bulk context to zero.
  */
-void roaring64_bulk_context_init(roaring64_bulk_context_t * context);
+void roaring64_bulk_context_init(roaring64_bulk_context_t *context);
 
 /**
  * Dynamically allocates a new bitmap (initially empty).

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -36,6 +36,11 @@ typedef struct roaring64_bulk_context_s {
 } roaring64_bulk_context_t;
 
 /**
+ * Initialize a bulk context to zero.
+ */
+void roaring64_bulk_context_init(roaring64_bulk_context_t * context);
+
+/**
  * Dynamically allocates a new bitmap (initially empty).
  * Client is responsible for calling `roaring64_bitmap_free()`.
  */

--- a/src/art/art.c
+++ b/src/art/art.c
@@ -40,6 +40,10 @@ namespace roaring {
 namespace internal {
 #endif
 
+void art_iterator_init(art_iterator_t *iterator) {
+    memset(iterator, 0, sizeof(art_iterator_t));
+}
+
 typedef uint8_t art_typecode_t;
 
 // Aliasing with a "leaf" naming so that its purpose is clearer in the context
@@ -1670,7 +1674,8 @@ static bool art_node_iterator_lower_bound(const art_node_t *node,
 }
 
 art_iterator_t art_init_iterator(const art_t *art, bool first) {
-    art_iterator_t iterator = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    art_iterator_t iterator;
+    art_iterator_init(&iterator);
     if (art->root == NULL) {
         return iterator;
     }
@@ -1727,7 +1732,8 @@ bool art_iterator_lower_bound(art_iterator_t *iterator,
 }
 
 art_iterator_t art_lower_bound(const art_t *art, const art_key_chunk_t *key) {
-    art_iterator_t iterator = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    art_iterator_t iterator;
+    art_iterator_init(&iterator);
     if (art->root != NULL) {
         art_node_iterator_lower_bound(art->root, &iterator, key);
     }
@@ -1735,7 +1741,8 @@ art_iterator_t art_lower_bound(const art_t *art, const art_key_chunk_t *key) {
 }
 
 art_iterator_t art_upper_bound(const art_t *art, const art_key_chunk_t *key) {
-    art_iterator_t iterator = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    art_iterator_t iterator;
+    art_iterator_init(&iterator);
     if (art->root != NULL) {
         if (art_node_iterator_lower_bound(art->root, &iterator, key) &&
             art_compare_keys(iterator.key, key) == 0) {

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -21,8 +21,9 @@ namespace roaring {
 namespace api {
 #endif
 
-// TODO: Copy on write.
-// TODO: Error on failed allocation.
+void roaring64_bulk_context_init(roaring64_bulk_context_t *context) {
+    memset(context, 0, sizeof(roaring64_bulk_context_t));
+}
 
 typedef struct roaring64_bitmap_s {
     art_t art;
@@ -224,7 +225,8 @@ roaring64_bitmap_t *roaring64_bitmap_of_ptr(size_t n_args,
 
 roaring64_bitmap_t *roaring64_bitmap_of(size_t n_args, ...) {
     roaring64_bitmap_t *r = roaring64_bitmap_create();
-    roaring64_bulk_context_t context = {0, 0, 0, 0, 0, 0, 0};
+    roaring64_bulk_context_t context;
+    roaring64_bulk_context_init(&context);
     va_list ap;
     va_start(ap, n_args);
     for (size_t i = 0; i < n_args; i++) {
@@ -317,7 +319,8 @@ void roaring64_bitmap_add_many(roaring64_bitmap_t *r, size_t n_args,
         return;
     }
     const uint64_t *end = vals + n_args;
-    roaring64_bulk_context_t context = {0, 0, 0, 0, 0, 0, 0};
+    roaring64_bulk_context_t context;
+    roaring64_bulk_context_init(&context);
     for (const uint64_t *current_val = vals; current_val != end;
          current_val++) {
         roaring64_bitmap_add_bulk(r, &context, *current_val);
@@ -641,7 +644,8 @@ void roaring64_bitmap_remove_many(roaring64_bitmap_t *r, size_t n_args,
         return;
     }
     const uint64_t *end = vals + n_args;
-    roaring64_bulk_context_t context = {0, 0, 0, 0, 0, 0, 0};
+    roaring64_bulk_context_t context;
+    roaring64_bulk_context_init(&context);
     for (const uint64_t *current_val = vals; current_val != end;
          current_val++) {
         roaring64_bitmap_remove_bulk(r, &context, *current_val);


### PR DESCRIPTION
It is difficult to portably initialize structs to zero without a function. It turns out that either C or C++ emits a warning.
