### PR TITLE
roaring64: Don't crash on roaring64_bitmap_free(NULL)

### DIFF
--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -148,6 +148,9 @@ roaring64_bitmap_t *roaring64_bitmap_create(void) {
 }
 
 void roaring64_bitmap_free(roaring64_bitmap_t *r) {
+    if (!r) {
+        return;
+    }
     art_iterator_t it = art_init_iterator(&r->art, /*first=*/true);
     while (it.value != NULL) {
         leaf_t *leaf = (leaf_t *)it.value;


### PR DESCRIPTION
Before submitting this PR, run `tools/clang-format.sh` on your changes. See the "Contributing" section in the README for details.

