### PR TITLE
fix: introduce macro to initialize to zero structs portably

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -589,6 +589,15 @@ static inline uint32_t croaring_refcount_get(const croaring_refcount_t *val) {
 #define CROARING_DEPRECATED
 #endif  // defined(__GNUC__) || defined(__clang__)
 
+
+// We want to initialize structs to zero portably (C and C++), without
+// warnings. We can do mystruct s = CROARING_ZERO_INITIALIZER;
+#if __cplusplus
+# define CROARING_ZERO_INITIALIZER {}
+#else
+# define CROARING_ZERO_INITIALIZER {0}
+#endif
+
 // We need portability.h to be included first,
 // but we also always want isadetection.h to be
 // included (right after).

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -589,13 +589,14 @@ static inline uint32_t croaring_refcount_get(const croaring_refcount_t *val) {
 #define CROARING_DEPRECATED
 #endif  // defined(__GNUC__) || defined(__clang__)
 
-
 // We want to initialize structs to zero portably (C and C++), without
 // warnings. We can do mystruct s = CROARING_ZERO_INITIALIZER;
 #if __cplusplus
-# define CROARING_ZERO_INITIALIZER {}
+#define CROARING_ZERO_INITIALIZER \
+    {}
 #else
-# define CROARING_ZERO_INITIALIZER {0}
+#define CROARING_ZERO_INITIALIZER \
+    { 0 }
 #endif
 
 // We need portability.h to be included first,

--- a/src/art/art.c
+++ b/src/art/art.c
@@ -1670,7 +1670,7 @@ static bool art_node_iterator_lower_bound(const art_node_t *node,
 }
 
 art_iterator_t art_init_iterator(const art_t *art, bool first) {
-    art_iterator_t iterator = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    art_iterator_t iterator = CROARING_ZERO_INITIALIZER;
     if (art->root == NULL) {
         return iterator;
     }
@@ -1727,7 +1727,7 @@ bool art_iterator_lower_bound(art_iterator_t *iterator,
 }
 
 art_iterator_t art_lower_bound(const art_t *art, const art_key_chunk_t *key) {
-    art_iterator_t iterator = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    art_iterator_t iterator = CROARING_ZERO_INITIALIZER;
     if (art->root != NULL) {
         art_node_iterator_lower_bound(art->root, &iterator, key);
     }
@@ -1735,7 +1735,7 @@ art_iterator_t art_lower_bound(const art_t *art, const art_key_chunk_t *key) {
 }
 
 art_iterator_t art_upper_bound(const art_t *art, const art_key_chunk_t *key) {
-    art_iterator_t iterator = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    art_iterator_t iterator = CROARING_ZERO_INITIALIZER;
     if (art->root != NULL) {
         if (art_node_iterator_lower_bound(art->root, &iterator, key) &&
             art_compare_keys(iterator.key, key) == 0) {

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -199,7 +199,7 @@ roaring_bitmap_t *roaring_bitmap_of(size_t n_args, ...) {
     // todo: could be greatly optimized but we do not expect this call to ever
     // include long lists
     roaring_bitmap_t *answer = roaring_bitmap_create();
-    roaring_bulk_context_t context = {0, 0, 0, 0};
+    roaring_bulk_context_t context = CROARING_ZERO_INITIALIZER;
     va_list ap;
     va_start(ap, n_args);
     for (size_t i = 0; i < n_args; i++) {
@@ -1541,7 +1541,7 @@ roaring_bitmap_t *roaring_bitmap_deserialize(const void *buf) {
         if (bitmap == NULL) {
             return NULL;
         }
-        roaring_bulk_context_t context = {0, 0, 0, 0};
+        roaring_bulk_context_t context = CROARING_ZERO_INITIALIZER;
         for (uint32_t i = 0; i < card; i++) {
             // elems may not be aligned, read with memcpy
             uint32_t elem;
@@ -1584,7 +1584,7 @@ roaring_bitmap_t *roaring_bitmap_deserialize_safe(const void *buf,
         if (bitmap == NULL) {
             return NULL;
         }
-        roaring_bulk_context_t context = {0, 0, 0, 0};
+        roaring_bulk_context_t context = CROARING_ZERO_INITIALIZER;
         for (uint32_t i = 0; i < card; i++) {
             // elems may not be aligned, read with memcpy
             uint32_t elem;

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -227,7 +227,7 @@ roaring64_bitmap_t *roaring64_bitmap_of_ptr(size_t n_args,
 
 roaring64_bitmap_t *roaring64_bitmap_of(size_t n_args, ...) {
     roaring64_bitmap_t *r = roaring64_bitmap_create();
-    roaring64_bulk_context_t context = {0, 0, 0, 0, 0, 0, 0};
+    roaring64_bulk_context_t context = CROARING_ZERO_INITIALIZER;
     va_list ap;
     va_start(ap, n_args);
     for (size_t i = 0; i < n_args; i++) {
@@ -320,7 +320,7 @@ void roaring64_bitmap_add_many(roaring64_bitmap_t *r, size_t n_args,
         return;
     }
     const uint64_t *end = vals + n_args;
-    roaring64_bulk_context_t context = {0, 0, 0, 0, 0, 0, 0};
+    roaring64_bulk_context_t context = CROARING_ZERO_INITIALIZER;
     for (const uint64_t *current_val = vals; current_val != end;
          current_val++) {
         roaring64_bitmap_add_bulk(r, &context, *current_val);
@@ -644,7 +644,7 @@ void roaring64_bitmap_remove_many(roaring64_bitmap_t *r, size_t n_args,
         return;
     }
     const uint64_t *end = vals + n_args;
-    roaring64_bulk_context_t context = {0, 0, 0, 0, 0, 0, 0};
+    roaring64_bulk_context_t context = CROARING_ZERO_INITIALIZER;
     for (const uint64_t *current_val = vals; current_val != end;
          current_val++) {
         roaring64_bitmap_remove_bulk(r, &context, *current_val);


### PR DESCRIPTION
Alternative to https://github.com/RoaringBitmap/CRoaring/pull/631 using macros instead of new functions.

This PR @madscientist's proposal.

