### PR TITLE
Fix segfault with roaring64 intersect_with_range and empty bitmap

### DIFF
--- a/src/art/art.c
+++ b/src/art/art.c
@@ -1693,8 +1693,11 @@ bool art_iterator_lower_bound(art_iterator_t *iterator,
         // a valid key. Start from the root.
         iterator->frame = 0;
         iterator->depth = 0;
-        return art_node_iterator_lower_bound(art_iterator_node(iterator),
-                                             iterator, key);
+        art_node_t *root = art_iterator_node(iterator);
+        if (root == NULL) {
+            return false;
+        }
+        return art_node_iterator_lower_bound(root, iterator, key);
     }
     int compare_result =
         art_compare_prefix(iterator->key, 0, key, 0, ART_KEY_BYTES);

--- a/tests/art_unit.cpp
+++ b/tests/art_unit.cpp
@@ -320,6 +320,16 @@ DEFINE_TEST(test_art_iterator_prev) {
 
 DEFINE_TEST(test_art_iterator_lower_bound) {
     {
+        art_t art{NULL};
+        art_iterator_t iterator = art_init_iterator(&art, true);
+        assert_null(iterator.value);
+        assert_false(
+            art_iterator_lower_bound(&iterator, (art_key_chunk_t*)"000000"));
+        assert_false(
+            art_iterator_lower_bound(&iterator, (art_key_chunk_t*)"000001"));
+        art_free(&art);
+    }
+    {
         std::vector<const char*> keys = {
             "000001", "000002", "000003", "000004", "001005",
         };


### PR DESCRIPTION
Fixes #635, and adds some tests

@SLieve, is this the right place to do this? The segfault under valgrind:

```
[ RUN      ] test_intersect_with_range
==648093== Invalid read of size 1
==648093==    at 0x12A894: art_node_iterator_lower_bound (art.c:1633)
==648093==    by 0x12AB9F: art_iterator_lower_bound (art.c:1696)
==648093==    by 0x120D2B: roaring64_iterator_move_equalorlarger (roaring64.c:2087)
==648093==    by 0x11E5DB: roaring64_bitmap_intersect_with_range (roaring64.c:1126)
==648093==    by 0x10F3F7: (anonymous namespace)::test_intersect_with_range(void**) (roaring64_unit.cpp:1058)
==648093==    by 0x15B74B: cmocka_run_one_test_or_fixture (cmocka.c:2801)
==648093==    by 0x15BA3F: cmocka_run_one_tests (cmocka.c:2909)
==648093==    by 0x15BF67: _cmocka_run_group_tests (cmocka.c:3040)
==648093==    by 0x112E17: main (roaring64_unit.cpp:1897)
==648093==  Address 0x1 is not stack'd, malloc'd or (recently) free'd
==648093==
[  ERROR   ] --- Test failed with exception: Segmentation fault(11)
[  FAILED  ] test_intersect_with_range
```

The actual error seems to comes from `art_node_iterator_lower_bound` when passed a NULL node, not sure if this is the right place to guard, or if something lower down in the call chain should handle an empty bitmap better.