### PR TITLE
Mark `sum_value` in roaring_statistics_t as deprecated

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -36,8 +36,8 @@ DEMOCPP="amalgamation_demo.cpp"
 #
 ALL_PUBLIC_H="
 $SCRIPTPATH/include/roaring/roaring_version.h
-$SCRIPTPATH/include/roaring/roaring_types.h
 $SCRIPTPATH/include/roaring/portability.h
+$SCRIPTPATH/include/roaring/roaring_types.h
 $SCRIPTPATH/include/roaring/bitset/bitset.h
 $SCRIPTPATH/include/roaring/roaring.h
 $SCRIPTPATH/include/roaring/memory.h

--- a/include/roaring/roaring_types.h
+++ b/include/roaring/roaring_types.h
@@ -8,6 +8,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <roaring/portability.h>
+
 #ifdef __cplusplus
 extern "C" {
 namespace roaring {
@@ -89,6 +91,8 @@ typedef struct roaring_statistics_s {
         max_value; /* the maximal value, undefined if cardinality is zero */
     uint32_t
         min_value; /* the minimal value, undefined if cardinality is zero */
+
+    CROARING_DEPRECATED
     uint64_t sum_value; /* deprecated always zero */
 
     uint64_t cardinality; /* total number of values stored in the bitmap */


### PR DESCRIPTION
Use CROARING_DEPRECATED to mark deprecated field in statistics