### PR TITLE
Only ignore amalgamation files at the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -321,11 +321,12 @@ paket-files/
 __pycache__/
 *.pyc
 
-amalgamation_demo
-amalgamation_demo.c
-amalgamation_demo.cpp
-roaring.c
-roaring.h
-roaring.hh
+# Exclude amalgamation created files
+/amalgamation_demo
+/amalgamation_demo.c
+/amalgamation_demo.cpp
+/roaring.c
+/roaring.h
+/roaring.hh
 
 #############END VISUAL STUDIO##############


### PR DESCRIPTION
Currently, the gitignore tries to ignore src/roaring.c

This actually only works in git because git only considers the gitignore when it would _add_ a file to be tracked, changes to existing files already in git are tracked regardless of what's in .gitignore.

Fixes #637