### PR TITLE
Improve consistency in the C++ interface

### DIFF
--- a/benchmarks/containsmulti_benchmark.c
+++ b/benchmarks/containsmulti_benchmark.c
@@ -8,6 +8,7 @@
 
 #include "benchmark.h"
 #include "numbersfromtextfiles.h"
+#include "portability.h"
 #include "random.h"
 
 void contains_multi_via_contains(roaring_bitmap_t* bm, const uint32_t* values,
@@ -19,7 +20,7 @@ void contains_multi_via_contains(roaring_bitmap_t* bm, const uint32_t* values,
 
 void contains_multi_bulk(roaring_bitmap_t* bm, const uint32_t* values,
                          bool* results, const size_t count) {
-    roaring_bulk_context_t context = {0, 0, 0, 0};
+    roaring_bulk_context_t context = CROARING_ZERO_INITIALIZER;
     for (size_t i = 0; i < count; ++i) {
         results[i] = roaring_bitmap_contains_bulk(bm, &context, values[i]);
     }

--- a/benchmarks/containsmulti_benchmark.c
+++ b/benchmarks/containsmulti_benchmark.c
@@ -19,7 +19,7 @@ void contains_multi_via_contains(roaring_bitmap_t* bm, const uint32_t* values,
 
 void contains_multi_bulk(roaring_bitmap_t* bm, const uint32_t* values,
                          bool* results, const size_t count) {
-    roaring_bulk_context_t context = {0, 0};
+    roaring_bulk_context_t context = {0, 0, 0, 0};
     for (size_t i = 0; i < count; ++i) {
         results[i] = roaring_bitmap_contains_bulk(bm, &context, values[i]);
     }

--- a/cpp/roaring.hh
+++ b/cpp/roaring.hh
@@ -7,6 +7,7 @@ A C++ header for Roaring Bitmaps.
 #include <algorithm>
 #include <cstdarg>
 #include <initializer_list>
+#include <limits>
 #include <new>
 #include <stdexcept>
 #include <string>
@@ -39,7 +40,10 @@ A C++ header for Roaring Bitmaps.
 
 namespace roaring {
 
-class RoaringSetBitForwardIterator;
+class RoaringSetBitBiDirectionalIterator;
+
+/** DEPRECATED, use `RoaringSetBitBiDirectionalIterator`. */
+using RoaringSetBitForwardIterator = RoaringSetBitBiDirectionalIterator;
 
 /**
  * A bit of context usable with `*Bulk()` functions.
@@ -92,6 +96,16 @@ class Roaring {
     }
 
     /**
+     * Construct a roaring object by taking control of a malloc()'d C struct.
+     *
+     * Passing a NULL pointer is unsafe.
+     * The pointer to the C struct will be invalid after the call.
+     */
+    explicit Roaring(roaring_bitmap_t *s) noexcept : roaring(*s) {
+        roaring_free(s);  // deallocate the passed-in pointer
+    }
+
+    /**
      * Copy constructor.
      * It may throw std::runtime_error if there is insufficient memory.
      */
@@ -119,16 +133,6 @@ class Roaring {
     }
 
     /**
-     * Construct a roaring object by taking control of a malloc()'d C struct.
-     *
-     * Passing a NULL pointer is unsafe.
-     * The pointer to the C struct will be invalid after the call.
-     */
-    explicit Roaring(roaring_bitmap_t *s) noexcept : roaring(*s) {
-        roaring_free(s);  // deallocate the passed-in pointer
-    }
-
-    /**
      * Construct a bitmap from a list of uint32_t values.
      */
     static Roaring bitmapOf(size_t n, ...) {
@@ -140,6 +144,44 @@ class Roaring {
         }
         va_end(vl);
         return ans;
+    }
+
+    /**
+     * Copies the content of the provided bitmap, and
+     * discard the current content.
+     * It may throw std::runtime_error if there is insufficient memory.
+     */
+    Roaring &operator=(const Roaring &r) {
+        if (!api::roaring_bitmap_overwrite(&roaring, &r.roaring)) {
+            ROARING_TERMINATE("failed memory alloc in assignment");
+        }
+        api::roaring_bitmap_set_copy_on_write(
+            &roaring, api::roaring_bitmap_get_copy_on_write(&r.roaring));
+        return *this;
+    }
+
+    /**
+     * Moves the content of the provided bitmap, and
+     * discard the current content.
+     */
+    Roaring &operator=(Roaring &&r) noexcept {
+        api::roaring_bitmap_clear(&roaring);  // free this class's allocations
+
+        // !!! See notes in the Move Constructor regarding roaring_bitmap_move()
+        //
+        roaring = r.roaring;
+        api::roaring_bitmap_init_cleared(&r.roaring);
+
+        return *this;
+    }
+
+    /**
+     * Assignment from an initializer list.
+     */
+    Roaring &operator=(std::initializer_list<uint32_t> l) {
+        // Delegate to move assignment operator
+        *this = Roaring(l);
+        return *this;
     }
 
     /**
@@ -243,6 +285,11 @@ class Roaring {
     }
 
     /**
+     * Clears the bitmap.
+     */
+    void clear() { api::roaring_bitmap_clear(&roaring); }
+
+    /**
      * Return the largest value (if not empty)
      */
     uint32_t maximum() const noexcept {
@@ -270,63 +317,9 @@ class Roaring {
         return api::roaring_bitmap_contains_range(&roaring, x, y);
     }
 
-    /**
-     * Destructor.  By contract, calling roaring_bitmap_clear() is enough to
-     * release all auxiliary memory used by the structure.
-     */
-    ~Roaring() {
-        if (!(roaring.high_low_container.flags & ROARING_FLAG_FROZEN)) {
-            api::roaring_bitmap_clear(&roaring);
-        } else {
-            // The roaring member variable copies the `roaring_bitmap_t` and
-            // nested `roaring_array_t` structures by value and is freed in the
-            // constructor, however the underlying memory arena used for the
-            // container data is not freed with it. Here we derive the arena
-            // pointer from the second arena allocation in
-            // `roaring_bitmap_frozen_view` and free it as well.
-            roaring_bitmap_free(
-                (roaring_bitmap_t *)((char *)
-                                         roaring.high_low_container.containers -
-                                     sizeof(roaring_bitmap_t)));
-        }
-    }
-
-    /**
-     * Copies the content of the provided bitmap, and
-     * discard the current content.
-     * It may throw std::runtime_error if there is insufficient memory.
-     */
-    Roaring &operator=(const Roaring &r) {
-        if (!api::roaring_bitmap_overwrite(&roaring, &r.roaring)) {
-            ROARING_TERMINATE("failed memory alloc in assignment");
-        }
-        api::roaring_bitmap_set_copy_on_write(
-            &roaring, api::roaring_bitmap_get_copy_on_write(&r.roaring));
-        return *this;
-    }
-
-    /**
-     * Moves the content of the provided bitmap, and
-     * discard the current content.
-     */
-    Roaring &operator=(Roaring &&r) noexcept {
-        api::roaring_bitmap_clear(&roaring);  // free this class's allocations
-
-        // !!! See notes in the Move Constructor regarding roaring_bitmap_move()
-        //
-        roaring = r.roaring;
-        api::roaring_bitmap_init_cleared(&r.roaring);
-
-        return *this;
-    }
-
-    /**
-     * Assignment from an initializer list.
-     */
-    Roaring &operator=(std::initializer_list<uint32_t> l) {
-        // Delegate to move assignment operator
-        *this = Roaring(l);
-        return *this;
+    bool containsRangeClosed(const uint32_t x,
+                             const uint32_t y) const noexcept {
+        return api::roaring_bitmap_contains_range_closed(&roaring, x, y);
     }
 
     /**
@@ -394,6 +387,16 @@ class Roaring {
     }
 
     /**
+     * Returns true if the bitmap is full (cardinality is uint32_t max + 1).
+     * we put std::numeric_limits<>::max/min in parentheses
+     * to avoid a clash with the Windows.h header under Windows.
+     */
+    bool isFull() const noexcept {
+        return api::roaring_bitmap_get_cardinality(&roaring) ==
+               ((uint64_t)(std::numeric_limits<uint32_t>::max)()) + 1;
+    }
+
+    /**
      * Returns true if the bitmap is subset of the other.
      */
     bool isSubset(const Roaring &r) const noexcept {
@@ -443,8 +446,8 @@ class Roaring {
      * [range_start, range_end]. Areas outside the interval are unchanged.
      */
     void flipClosed(uint32_t range_start, uint32_t range_end) noexcept {
-        api::roaring_bitmap_flip_inplace(&roaring, range_start,
-                                         uint64_t(range_end) + 1);
+        api::roaring_bitmap_flip_inplace_closed(&roaring, range_start,
+                                                range_end);
     }
 
     /**
@@ -868,7 +871,30 @@ class Roaring {
         return ans;
     }
 
-    typedef RoaringSetBitForwardIterator const_iterator;
+    /**
+     * Destructor.  By contract, calling roaring_bitmap_clear() is enough to
+     * release all auxiliary memory used by the structure.
+     */
+    ~Roaring() {
+        if (!(roaring.high_low_container.flags & ROARING_FLAG_FROZEN)) {
+            api::roaring_bitmap_clear(&roaring);
+        } else {
+            // The roaring member variable copies the `roaring_bitmap_t` and
+            // nested `roaring_array_t` structures by value and is freed in the
+            // constructor, however the underlying memory arena used for the
+            // container data is not freed with it. Here we derive the arena
+            // pointer from the second arena allocation in
+            // `roaring_bitmap_frozen_view` and free it as well.
+            roaring_bitmap_free(
+                (roaring_bitmap_t *)((char *)
+                                         roaring.high_low_container.containers -
+                                     sizeof(roaring_bitmap_t)));
+        }
+    }
+
+    friend class RoaringSetBitBiDirectionalIterator;
+    typedef RoaringSetBitBiDirectionalIterator const_iterator;
+    typedef RoaringSetBitBiDirectionalIterator const_bidirectional_iterator;
 
     /**
      * Returns an iterator that can be used to access the position of the set
@@ -893,14 +919,26 @@ class Roaring {
 /**
  * Used to go through the set bits. Not optimally fast, but convenient.
  */
-class RoaringSetBitForwardIterator final {
+class RoaringSetBitBiDirectionalIterator final {
    public:
-    typedef std::forward_iterator_tag iterator_category;
+    typedef std::bidirectional_iterator_tag iterator_category;
     typedef uint32_t *pointer;
     typedef uint32_t &reference_type;
     typedef uint32_t value_type;
     typedef int32_t difference_type;
-    typedef RoaringSetBitForwardIterator type_of_iterator;
+    typedef RoaringSetBitBiDirectionalIterator type_of_iterator;
+
+    explicit RoaringSetBitBiDirectionalIterator(const Roaring &parent,
+                                                bool exhausted = false) {
+        if (exhausted) {
+            i.parent = &parent.roaring;
+            i.container_index = INT32_MAX;
+            i.has_value = false;
+            i.current_value = UINT32_MAX;
+        } else {
+            api::roaring_iterator_init(&parent.roaring, &i);
+        }
+    }
 
     /**
      * Provides the location of the set bit.
@@ -931,22 +969,28 @@ class RoaringSetBitForwardIterator final {
         return i.current_value >= *o;
     }
 
-    /**
-     * Move the iterator to the first value >= val.
-     */
-    void equalorlarger(uint32_t val) {
-        api::roaring_uint32_iterator_move_equalorlarger(&i, val);
-    }
-
     type_of_iterator &operator++() {  // ++i, must returned inc. value
         api::roaring_uint32_iterator_advance(&i);
         return *this;
     }
 
     type_of_iterator operator++(int) {  // i++, must return orig. value
-        RoaringSetBitForwardIterator orig(*this);
+        RoaringSetBitBiDirectionalIterator orig(*this);
         api::roaring_uint32_iterator_advance(&i);
         return orig;
+    }
+
+    /**
+     * Move the iterator to the first value >= val.
+     * Return true if there is such a value.
+     */
+    bool move_equalorlarger(value_type val) {
+        return api::roaring_uint32_iterator_move_equalorlarger(&i, val);
+    }
+
+    /** DEPRECATED, use `move_equalorlarger`.*/
+    CROARING_DEPRECATED void equalorlarger(uint32_t val) {
+        api::roaring_uint32_iterator_move_equalorlarger(&i, val);
     }
 
     type_of_iterator &operator--() {  // prefix --
@@ -955,29 +999,17 @@ class RoaringSetBitForwardIterator final {
     }
 
     type_of_iterator operator--(int) {  // postfix --
-        RoaringSetBitForwardIterator orig(*this);
+        RoaringSetBitBiDirectionalIterator orig(*this);
         api::roaring_uint32_iterator_previous(&i);
         return orig;
     }
 
-    bool operator==(const RoaringSetBitForwardIterator &o) const {
+    bool operator==(const RoaringSetBitBiDirectionalIterator &o) const {
         return i.current_value == *o && i.has_value == o.i.has_value;
     }
 
-    bool operator!=(const RoaringSetBitForwardIterator &o) const {
+    bool operator!=(const RoaringSetBitBiDirectionalIterator &o) const {
         return i.current_value != *o || i.has_value != o.i.has_value;
-    }
-
-    explicit RoaringSetBitForwardIterator(const Roaring &parent,
-                                          bool exhausted = false) {
-        if (exhausted) {
-            i.parent = &parent.roaring;
-            i.container_index = INT32_MAX;
-            i.has_value = false;
-            i.current_value = UINT32_MAX;
-        } else {
-            api::roaring_iterator_init(&parent.roaring, &i);
-        }
     }
 
     api::roaring_uint32_iterator_t
@@ -985,12 +1017,12 @@ class RoaringSetBitForwardIterator final {
               // analyzers.
 };
 
-inline RoaringSetBitForwardIterator Roaring::begin() const {
-    return RoaringSetBitForwardIterator(*this);
+inline RoaringSetBitBiDirectionalIterator Roaring::begin() const {
+    return RoaringSetBitBiDirectionalIterator(*this);
 }
 
-inline RoaringSetBitForwardIterator &Roaring::end() const {
-    static RoaringSetBitForwardIterator e(*this, true);
+inline RoaringSetBitBiDirectionalIterator &Roaring::end() const {
+    static RoaringSetBitBiDirectionalIterator e(*this, true);
     return e;
 }
 

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -1708,6 +1708,9 @@ class Roaring64Map {
 
 /**
  * Used to go through the set bits. Not optimally fast, but convenient.
+ *
+ * strongly recommend not to implicitly construct this iterator:
+ * implicit construction may be prohibited in the future.
  */
 class Roaring64MapSetBitBiDirectionalIterator {
    public:
@@ -1718,8 +1721,8 @@ class Roaring64MapSetBitBiDirectionalIterator {
     typedef int64_t difference_type;
     typedef Roaring64MapSetBitBiDirectionalIterator type_of_iterator;
 
-    explicit Roaring64MapSetBitBiDirectionalIterator(const Roaring64Map &parent,
-                                                     bool exhausted = false)
+    Roaring64MapSetBitBiDirectionalIterator(const Roaring64Map &parent,
+                                            bool exhausted = false)
         : p(&parent.roarings) {
         if (exhausted || parent.roarings.empty()) {
             map_iter = p->cend();

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -840,8 +840,6 @@ class Roaring64Map {
             });
     }
 
-    // TODO: implement `rangeUint64Array`
-
     /**
      * Return true if the two bitmaps contain the same elements.
      */

--- a/cpp/roaring64map.hh
+++ b/cpp/roaring64map.hh
@@ -1709,8 +1709,7 @@ class Roaring64Map {
 /**
  * Used to go through the set bits. Not optimally fast, but convenient.
  *
- * strongly recommend not to implicitly construct this iterator:
- * implicit construction may be prohibited in the future.
+ * Recommend to explicitly construct this iterator.
  */
 class Roaring64MapSetBitBiDirectionalIterator {
    public:

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -387,7 +387,9 @@ void roaring_bitmap_add_range_closed(roaring_bitmap_t *r, uint32_t min,
  */
 inline void roaring_bitmap_add_range(roaring_bitmap_t *r, uint64_t min,
                                      uint64_t max) {
-    if (max <= min || min > (uint64_t)UINT32_MAX + 1) return;
+    if (max <= min || min > (uint64_t)UINT32_MAX + 1) {
+        return;
+    }
     roaring_bitmap_add_range_closed(r, (uint32_t)min, (uint32_t)(max - 1));
 }
 
@@ -407,7 +409,9 @@ void roaring_bitmap_remove_range_closed(roaring_bitmap_t *r, uint32_t min,
  */
 inline void roaring_bitmap_remove_range(roaring_bitmap_t *r, uint64_t min,
                                         uint64_t max) {
-    if (max <= min || min > (uint64_t)UINT32_MAX + 1) return;
+    if (max <= min || min > (uint64_t)UINT32_MAX + 1) {
+        return;
+    }
     roaring_bitmap_remove_range_closed(r, (uint32_t)min, (uint32_t)(max - 1));
 }
 

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -387,7 +387,7 @@ void roaring_bitmap_add_range_closed(roaring_bitmap_t *r, uint32_t min,
  */
 inline void roaring_bitmap_add_range(roaring_bitmap_t *r, uint64_t min,
                                      uint64_t max) {
-    if (max <= min) return;
+    if (max <= min || min > (uint64_t)UINT32_MAX + 1) return;
     roaring_bitmap_add_range_closed(r, (uint32_t)min, (uint32_t)(max - 1));
 }
 
@@ -407,7 +407,7 @@ void roaring_bitmap_remove_range_closed(roaring_bitmap_t *r, uint32_t min,
  */
 inline void roaring_bitmap_remove_range(roaring_bitmap_t *r, uint64_t min,
                                         uint64_t max) {
-    if (max <= min) return;
+    if (max <= min || min > (uint64_t)UINT32_MAX + 1) return;
     roaring_bitmap_remove_range_closed(r, (uint32_t)min, (uint32_t)(max - 1));
 }
 
@@ -474,6 +474,12 @@ uint64_t roaring_bitmap_range_cardinality(const roaring_bitmap_t *r,
                                           uint64_t range_start,
                                           uint64_t range_end);
 
+/**
+ * Returns the number of elements in the range [range_start, range_end].
+ */
+uint64_t roaring_bitmap_range_cardinality_closed(const roaring_bitmap_t *r,
+                                                 uint32_t range_start,
+                                                 uint32_t range_end);
 /**
  * Returns true if the bitmap is empty (cardinality is zero).
  */

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -436,6 +436,14 @@ bool roaring_bitmap_contains_range(const roaring_bitmap_t *r,
                                    uint64_t range_start, uint64_t range_end);
 
 /**
+ * Check whether a range of values from range_start (included)
+ * to range_end (included) is present
+ */
+bool roaring_bitmap_contains_range_closed(const roaring_bitmap_t *r,
+                                          uint32_t range_start,
+                                          uint32_t range_end);
+
+/**
  * Check if an items is present, using context from a previous insert or search
  * for speed optimization.
  *
@@ -851,6 +859,14 @@ roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *r1,
                                       uint64_t range_start, uint64_t range_end);
 
 /**
+ * Compute the negation of the bitmap in the interval [range_start, range_end].
+ * The number of negated values is range_end - range_start + 1.
+ * Areas outside the range are passed through unchanged.
+ */
+roaring_bitmap_t *roaring_bitmap_flip_closed(const roaring_bitmap_t *x1,
+                                             uint32_t range_start,
+                                             uint32_t range_end);
+/**
  * compute (in place) the negation of the roaring bitmap within a specified
  * interval: [range_start, range_end). The number of negated values is
  * range_end - range_start.
@@ -858,6 +874,16 @@ roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *r1,
  */
 void roaring_bitmap_flip_inplace(roaring_bitmap_t *r1, uint64_t range_start,
                                  uint64_t range_end);
+
+/**
+ * compute (in place) the negation of the roaring bitmap within a specified
+ * interval: [range_start, range_end]. The number of negated values is
+ * range_end - range_start + 1.
+ * Areas outside the range are passed through unchanged.
+ */
+void roaring_bitmap_flip_inplace_closed(roaring_bitmap_t *r1,
+                                        uint32_t range_start,
+                                        uint32_t range_end);
 
 /**
  * Selects the element at index 'rank' where the smallest element is at index 0.

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -2013,8 +2013,9 @@ static void inplace_fully_flip_container(roaring_array_t *x1_arr, uint16_t hb) {
 roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *x1,
                                       uint64_t range_start,
                                       uint64_t range_end) {
-    if (range_start >= range_end || range_start > (uint64_t)UINT32_MAX + 1)
+    if (range_start >= range_end || range_start > (uint64_t)UINT32_MAX + 1) {
         return roaring_bitmap_copy(x1);
+    }
     return roaring_bitmap_flip_closed(x1, (uint32_t)range_start,
                                       (uint32_t)(range_end - 1));
 }
@@ -2073,8 +2074,9 @@ roaring_bitmap_t *roaring_bitmap_flip_closed(const roaring_bitmap_t *x1,
 
 void roaring_bitmap_flip_inplace(roaring_bitmap_t *x1, uint64_t range_start,
                                  uint64_t range_end) {
-    if (range_start >= range_end || range_start > (uint64_t)UINT32_MAX + 1)
+    if (range_start >= range_end || range_start > (uint64_t)UINT32_MAX + 1) {
         return;
+    }
     roaring_bitmap_flip_inplace_closed(x1, (uint32_t)range_start,
                                        (uint32_t)(range_end - 1));
 }
@@ -2847,8 +2849,9 @@ bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val) {
  */
 bool roaring_bitmap_contains_range(const roaring_bitmap_t *r,
                                    uint64_t range_start, uint64_t range_end) {
-    if (range_start >= range_end || range_start > (uint64_t)UINT32_MAX + 1)
+    if (range_start >= range_end || range_start > (uint64_t)UINT32_MAX + 1) {
         return true;
+    }
     return roaring_bitmap_contains_range_closed(r, (uint32_t)range_start,
                                                 (uint32_t)(range_end - 1));
 }
@@ -2860,10 +2863,12 @@ bool roaring_bitmap_contains_range(const roaring_bitmap_t *r,
 bool roaring_bitmap_contains_range_closed(const roaring_bitmap_t *r,
                                           uint32_t range_start,
                                           uint32_t range_end) {
-    if (range_start > range_end)
-        return true;  // empty range are always contained!
-    if (range_end == range_start)
+    if (range_start > range_end) {
+        return true;
+    }  // empty range are always contained!
+    if (range_end == range_start) {
         return roaring_bitmap_contains(r, (uint32_t)range_start);
+    }
     uint16_t hb_rs = (uint16_t)(range_start >> 16);
     uint16_t hb_re = (uint16_t)(range_end >> 16);
     const int32_t span = hb_re - hb_rs;

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -2005,11 +2006,17 @@ static void inplace_fully_flip_container(roaring_array_t *x1_arr, uint16_t hb) {
 roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *x1,
                                       uint64_t range_start,
                                       uint64_t range_end) {
-    if (range_start >= range_end) {
+    if (range_start >= range_end || range_start > (uint64_t)UINT_MAX + 1)
         return roaring_bitmap_copy(x1);
-    }
-    if (range_end >= UINT64_C(0x100000000)) {
-        range_end = UINT64_C(0x100000000);
+    return roaring_bitmap_flip_closed(x1, (uint32_t)range_start,
+                                      (uint32_t)(range_end - 1));
+}
+
+roaring_bitmap_t *roaring_bitmap_flip_closed(const roaring_bitmap_t *x1,
+                                             uint32_t range_start,
+                                             uint32_t range_end) {
+    if (range_start > range_end) {
+        return roaring_bitmap_copy(x1);
     }
 
     roaring_bitmap_t *ans = roaring_bitmap_create();
@@ -2017,8 +2024,8 @@ roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *x1,
 
     uint16_t hb_start = (uint16_t)(range_start >> 16);
     const uint16_t lb_start = (uint16_t)range_start;  // & 0xFFFF;
-    uint16_t hb_end = (uint16_t)((range_end - 1) >> 16);
-    const uint16_t lb_end = (uint16_t)(range_end - 1);  // & 0xFFFF;
+    uint16_t hb_end = (uint16_t)(range_end >> 16);
+    const uint16_t lb_end = (uint16_t)range_end;  // & 0xFFFF;
 
     ra_append_copies_until(&ans->high_low_container, &x1->high_low_container,
                            hb_start, is_cow(x1));
@@ -2059,17 +2066,23 @@ roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *x1,
 
 void roaring_bitmap_flip_inplace(roaring_bitmap_t *x1, uint64_t range_start,
                                  uint64_t range_end) {
-    if (range_start >= range_end) {
+    if (range_start >= range_end || range_start > (uint64_t)UINT_MAX + 1)
+        return;
+    roaring_bitmap_flip_inplace_closed(x1, (uint32_t)range_start,
+                                       (uint32_t)(range_end - 1));
+}
+
+void roaring_bitmap_flip_inplace_closed(roaring_bitmap_t *x1,
+                                        uint32_t range_start,
+                                        uint32_t range_end) {
+    if (range_start > range_end) {
         return;  // empty range
-    }
-    if (range_end >= UINT64_C(0x100000000)) {
-        range_end = UINT64_C(0x100000000);
     }
 
     uint16_t hb_start = (uint16_t)(range_start >> 16);
     const uint16_t lb_start = (uint16_t)range_start;
-    uint16_t hb_end = (uint16_t)((range_end - 1) >> 16);
-    const uint16_t lb_end = (uint16_t)(range_end - 1);
+    uint16_t hb_end = (uint16_t)(range_end >> 16);
+    const uint16_t lb_end = (uint16_t)range_end;
 
     if (hb_start == hb_end) {
         inplace_flip_container(&x1->high_low_container, hb_start, lb_start,
@@ -2827,15 +2840,25 @@ bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val) {
  */
 bool roaring_bitmap_contains_range(const roaring_bitmap_t *r,
                                    uint64_t range_start, uint64_t range_end) {
-    if (range_end >= UINT64_C(0x100000000)) {
-        range_end = UINT64_C(0x100000000);
-    }
-    if (range_start >= range_end)
+    if (range_start >= range_end || range_start > (uint64_t)UINT_MAX + 1)
+        return true;
+    return roaring_bitmap_contains_range_closed(r, (uint32_t)range_start,
+                                                (uint32_t)(range_end - 1));
+}
+
+/**
+ * Check whether a range of values from range_start (included) to range_end
+ * (included) is present
+ */
+bool roaring_bitmap_contains_range_closed(const roaring_bitmap_t *r,
+                                          uint32_t range_start,
+                                          uint32_t range_end) {
+    if (range_start > range_end)
         return true;  // empty range are always contained!
-    if (range_end - range_start == 1)
+    if (range_end == range_start)
         return roaring_bitmap_contains(r, (uint32_t)range_start);
     uint16_t hb_rs = (uint16_t)(range_start >> 16);
-    uint16_t hb_re = (uint16_t)((range_end - 1) >> 16);
+    uint16_t hb_re = (uint16_t)(range_end >> 16);
     const int32_t span = hb_re - hb_rs;
     const int32_t hlc_sz = ra_get_size(&r->high_low_container);
     if (hlc_sz < span + 1) {
@@ -2847,7 +2870,7 @@ bool roaring_bitmap_contains_range(const roaring_bitmap_t *r,
         return false;
     }
     const uint32_t lb_rs = range_start & 0xFFFF;
-    const uint32_t lb_re = ((range_end - 1) & 0xFFFF) + 1;
+    const uint32_t lb_re = (range_end & 0xFFFF) + 1;
     uint8_t type;
     container_t *c =
         ra_get_container_at_index(&r->high_low_container, (uint16_t)is, &type);

--- a/tests/cpp_example2.cpp
+++ b/tests/cpp_example2.cpp
@@ -102,7 +102,7 @@ int main() {
     const uint32_t manyvalues[] = {2, 3, 4, 7, 8};
     Roaring rogue(5, manyvalues);
     Roaring::const_iterator j = rogue.begin();
-    j.equalorlarger(4);  // *j == 4
+    j.move_equalorlarger(4);  // *j == 4
 
     return EXIT_SUCCESS;
 }

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -422,7 +422,7 @@ void test_example_cpp(bool copy_on_write) {
     const uint32_t manyvalues[] = {2, 3, 4, 7, 8};
     Roaring rogue(5, manyvalues);
     Roaring::const_iterator j = rogue.begin();
-    j.equalorlarger(4);
+    j.move_equalorlarger(4);
     assert_true(*j == 4);
 
     // test move constructor
@@ -1295,11 +1295,11 @@ DEFINE_TEST(test_cpp_move_64) {
     }
 
     Roaring64Map::const_iterator i(roaring);
-    i.move(123ULL);
+    i.move_equalorlarger(123ULL);
     assert_true(*i == 123ULL);
-    i.move(0xAFFFFFFF8ULL);
+    i.move_equalorlarger(0xAFFFFFFF8ULL);
     assert_true(*i == 0xFFFFFFFFFULL);
-    assert_false(i.move(0xFFFFFFFFFFULL));
+    assert_false(i.move_equalorlarger(0xFFFFFFFFFFULL));
 }
 
 DEFINE_TEST(test_cpp_bidirectional_iterator_64) {
@@ -2153,7 +2153,7 @@ DEFINE_TEST(test_cpp_copy_map_iterator_to_different_map) {
     Roaring64Map m2{10, 20, 30, 40};
     auto it = m1.begin();
     it = m2.begin();
-    it.move(21);
+    it.move_equalorlarger(21);
     int n = 0;
     for (; it != m2.end(); ++it, ++n) {
     }

--- a/tests/roaring_checked.hh
+++ b/tests/roaring_checked.hh
@@ -670,14 +670,14 @@ class Roaring {
         return ans;
     }
 
-    typedef roaring::RoaringSetBitForwardIterator const_iterator;
+    typedef roaring::RoaringSetBitBiDirectionalIterator const_iterator;
 
     const_iterator begin() const {
-        return roaring::RoaringSetBitForwardIterator(plain);
+        return roaring::RoaringSetBitBiDirectionalIterator(plain);
     }
 
     const_iterator &end() const {
-        static roaring::RoaringSetBitForwardIterator e(plain, true);
+        static roaring::RoaringSetBitBiDirectionalIterator e(plain, true);
         return e;
     }
 };


### PR DESCRIPTION
These changes aim to improve the consistency of the C++ API between the 32-bit version and the 64-bit version.

Related issues: #629 

Changes:

- Rename `RoaringSetBitForwardIterator` to `RoaringSetBitBiDirectionalIterator` (the old one is now deprecated).
- Add methods: `Roaring::clear` `Roaring::isFull` `Roaring::containsRangeClosed`.
- Revise `move_equalorlarger` methods in iterators.
- Add the `api::roaring_bitmap_flip_inplace_closed` method.
- Add the `api::roaring_bitmap_contains_range_closed` method.
- Add the `api::roaring_bitmap_flip_closed` method.
- Add the `api::roaring_bitmap_range_cardinality_closed` method.
- Other minor changes.

If merged, only the following methods remain that are only implemented in the 32-bit version(in class `Roaring`) but not in the 64-bit version(in class `Roaring64Map`):

- [ ]  `containsRange`
- [ ]  `rangeUint64Array`
- [ ]  `and_cardinality`
- [ ]  `or_cardinality`
- [ ]  `andnot_cardinality`
- [ ]  `xor_cardinality`
- [ ]  `jaccard_index`
- [ ]  `rank_many`

Also, the methods mentioned in #549 need to be further implemented.
