### PR TITLE
Remove `-Wmodule-import-in-extern-c` warnings

### DIFF
--- a/include/roaring/memory.h
+++ b/include/roaring/memory.h
@@ -1,11 +1,11 @@
 #ifndef INCLUDE_ROARING_MEMORY_H_
 #define INCLUDE_ROARING_MEMORY_H_
 
+#include <stddef.h>  // for size_t
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stddef.h>  // for size_t
 
 typedef void* (*roaring_malloc_p)(size_t);
 typedef void* (*roaring_realloc_p)(void*, size_t);


### PR DESCRIPTION
When using [clang modules][1] (not C++ modules) #including stuff within `extern "C"` blocks causes warnings. Remove said warnings by moving the #include. See this [StackOverflow question][2] for an idea of what the warning looks like.


[1]: https://clang.llvm.org/docs/Modules.html
[2]: https://stackoverflow.com/questions/77113501/xcode-15-compile-error-import-of-c-module-zlib-appears-within-extern-c-la

Before submitting this PR, run `tools/clang-format.sh` on your changes. See the "Contributing" section in the README for details.

