### PR TITLE
import roaring.h from the right place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,12 +74,12 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/roaring.pc" DESTINATION ${CMAKE_INSTA
 
 add_library(roaring-headers INTERFACE)
 target_include_directories(roaring-headers INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/roaring>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCDIR}>)
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 add_library(roaring-headers-cpp INTERFACE)
 target_include_directories(roaring-headers-cpp INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cpp>
-   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCDIR}>)
+   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 ####
 ### Some users want the C++ header files to be installed as well.
@@ -93,7 +93,7 @@ install(TARGETS roaring-headers roaring-headers-cpp
    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-   INCLUDES DESTINATION ${CMAKE_INSTALL_INCDIR})
+   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 include(CTest)
 
 ##################################

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -1,13 +1,13 @@
 #ifndef ROARING64_H
 #define ROARING64_H
 
-#include <roaring.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #include <roaring/memory.h>
 #include <roaring/portability.h>
+#include <roaring/roaring.h>
 #include <roaring/roaring_types.h>
 
 #ifdef __cplusplus

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,12 +59,6 @@ if(ROARING_DISABLE_NEON)
   target_compile_definitions(roaring PUBLIC DISABLENEON=1)
 endif(ROARING_DISABLE_NEON)
 
-
-target_include_directories(roaring
-  PUBLIC
-   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
 target_link_libraries(roaring PUBLIC roaring-headers)
 target_link_libraries(roaring PUBLIC roaring-headers-cpp)
 #
@@ -75,7 +69,7 @@ install(TARGETS roaring
    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-   INCLUDES DESTINATION ${CMAKE_INSTALL_INCDIR}
+   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 install(EXPORT roaring-config
    FILE roaring-config.cmake


### PR DESCRIPTION
We shouldn't be expecting `roaring.h` to be available in the header search path directly.