### PR TITLE
Deserialization/validation unit tests

### DIFF
--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -637,7 +637,7 @@ size_t ra_portable_deserialize_size(const char *buf, const size_t maxbytes) {
         memcpy(&size, buf, sizeof(int32_t));
         buf += sizeof(uint32_t);
     }
-    if (size > (1 << 16)) {
+    if (size > (1 << 16) || size < 0) {
         return 0;
     }
     char *bitmapOfRunContainers = NULL;

--- a/tests/robust_deserialization_unit.c
+++ b/tests/robust_deserialization_unit.c
@@ -94,66 +94,161 @@ int test_deserialize(const char* filename) {
 }
 
 DEFINE_TEST(test_robust_deserialize1) {
-    char filename[1024];
-
-    strcpy(filename, TEST_DATA_DIR);
-    strcat(filename, "crashproneinput1.bin");
-
-    test_deserialize(filename);
+    test_deserialize(TEST_DATA_DIR "crashproneinput1.bin");
 }
 
 DEFINE_TEST(test_robust_deserialize2) {
-    char filename[1024];
-
-    strcpy(filename, TEST_DATA_DIR);
-    strcat(filename, "crashproneinput2.bin");
-
-    test_deserialize(filename);
+    test_deserialize(TEST_DATA_DIR "crashproneinput2.bin");
 }
 
 DEFINE_TEST(test_robust_deserialize3) {
-    char filename[1024];
-
-    strcpy(filename, TEST_DATA_DIR);
-    strcat(filename, "crashproneinput3.bin");
-
-    test_deserialize(filename);
+    test_deserialize(TEST_DATA_DIR "crashproneinput3.bin");
 }
 
 DEFINE_TEST(test_robust_deserialize4) {
-    char filename[1024];
-
-    strcpy(filename, TEST_DATA_DIR);
-    strcat(filename, "crashproneinput4.bin");
-
-    test_deserialize(filename);
+    test_deserialize(TEST_DATA_DIR "crashproneinput4.bin");
 }
 
 DEFINE_TEST(test_robust_deserialize5) {
-    char filename[1024];
-
-    strcpy(filename, TEST_DATA_DIR);
-    strcat(filename, "crashproneinput5.bin");
-
-    test_deserialize(filename);
+    test_deserialize(TEST_DATA_DIR "crashproneinput5.bin");
 }
 
 DEFINE_TEST(test_robust_deserialize6) {
-    char filename[1024];
-
-    strcpy(filename, TEST_DATA_DIR);
-    strcat(filename, "crashproneinput6.bin");
-
-    test_deserialize(filename);
+    test_deserialize(TEST_DATA_DIR "crashproneinput6.bin");
 }
 
 DEFINE_TEST(test_robust_deserialize7) {
-    char filename[1024];
+    test_deserialize(TEST_DATA_DIR "crashproneinput7.bin");
+}
 
-    strcpy(filename, TEST_DATA_DIR);
-    strcat(filename, "crashproneinput7.bin");
+static void invalid_deserialize_test(const void* data, size_t size,
+                                     const char* description) {
+    // Ensure that the data _looks_ like a valid bitmap, but is not.
+    size_t serialized_size =
+        roaring_bitmap_portable_deserialize_size(data, size);
+    if (serialized_size != size) {
+        fail_msg("expected size %zu, got %zu", size, serialized_size);
+    }
+    // If we truncate the data by one byte, we should get a size of 0
+    assert_int_equal(roaring_bitmap_portable_deserialize_size(data, size - 1),
+                     0);
+    roaring_bitmap_t* bitmap =
+        roaring_bitmap_portable_deserialize_safe(data, size);
+    if (bitmap != NULL) {
+        if (roaring_bitmap_internal_validate(bitmap, NULL)) {
+            fail_msg("Validation must fail if a bitmap was returned, %s",
+                     description);
+        }
+        roaring_bitmap_free(bitmap);
+    }
+    // Truncated data will never return a bitmap
+    bitmap = roaring_bitmap_portable_deserialize_safe(data, size - 1);
+    assert_null(bitmap);
+}
 
-    test_deserialize(filename);
+static void valid_deserialize_test(const void* data, size_t size) {
+    // Ensure that the data _looks_ like a valid bitmap, but is not.
+    size_t serialized_size =
+        roaring_bitmap_portable_deserialize_size(data, size);
+    if (serialized_size != size) {
+        fail_msg("expected size %zu, got %zu", size, serialized_size);
+    }
+    // If we truncate the data by one byte, we should get a size of 0
+    assert_int_equal(roaring_bitmap_portable_deserialize_size(data, size - 1),
+                     0);
+    roaring_bitmap_t* bitmap =
+        roaring_bitmap_portable_deserialize_safe(data, size);
+    assert_non_null(bitmap);
+    assert_true(roaring_bitmap_internal_validate(bitmap, NULL));
+    roaring_bitmap_free(bitmap);
+}
+
+DEFINE_TEST(deserialize_duplicate_keys) {
+    // clang-format off
+    const char data[] = {
+        0x3B, 0x30, // Serial Cookie
+        1, 0,       // Container count - 1
+        0,          // Run Flag Bitset (no runs)
+        0, 0,       // Upper 16 bits of the first container
+        0, 0,       // Cardinality - 1 of the first container
+        0, 0,       // Upper 16 bits of the second container - DUPLICATE
+        0, 0,       // Cardinality - 1 of the second container
+        0, 0,       // Only value of first container
+        0, 0,       // Only value of second container
+    };
+    // clang-format on
+    invalid_deserialize_test(data, sizeof(data), "overlapping keys");
+}
+
+DEFINE_TEST(deserialize_unsorted_keys) {
+    // clang-format off
+    const char data[] = {
+        0x3B, 0x30, // Serial Cookie
+        1, 0,       // Container count - 1
+        0,          // Run Flag Bitset (no runs)
+        1, 0,       // Upper 16 bits of the first container
+        0, 0,       // Cardinality - 1 of the first container
+        0, 0,       // Upper 16 bits of the second container (LESS THAN FIRST)
+        0, 0,       // Cardinality - 1 of the second container
+        0, 0,       // Only value of first container
+        0, 0,       // Only value of second container
+    };
+    // clang-format on
+    invalid_deserialize_test(data, sizeof(data), "unsorted keys");
+}
+
+DEFINE_TEST(deserialize_duplicate_array) {
+    // clang-format off
+    const char data[] = {
+        0x3B, 0x30, // Serial Cookie
+        0, 0,       // Container count - 1
+        0,          // Run Flag Bitset (no runs)
+        0, 0,       // Upper 16 bits of the first container
+        1, 0,       // Cardinality - 1 of the first container
+        1, 0,       // first value of first container
+        0, 0,       // second value of first container (LESS THAN FIRST)
+    };
+    // clang-format on
+    invalid_deserialize_test(data, sizeof(data), "duplicate array values");
+}
+
+DEFINE_TEST(deserialize_unsorted_array) {
+    // clang-format off
+    const char data[] = {
+        0x3B, 0x30, // Serial Cookie
+        0, 0,       // Container count - 1
+        0,          // Run Flag Bitset (no runs)
+        0, 0,       // Upper 16 bits of the first container
+        1, 0,       // Cardinality - 1 of the first container
+        0, 0,       // first value of first container
+        0, 0,       // second value of first container (DUPLICATE)
+    };
+    // clang-format on
+    invalid_deserialize_test(data, sizeof(data), "duplicate array values");
+}
+
+DEFINE_TEST(deserialize_bitset_incorrect_cardinality) {
+    // clang-format off
+    const uint8_t data_begin[] = {
+        0x3B, 0x30, // Serial Cookie
+        0, 0,       // Container count - 1
+        0,          // Run Flag Bitset (no runs)
+        0, 0,       // Upper 16 bits of the first container
+        0xFF, 0xFF, // Cardinality - 1 of the first container.
+
+        // First container is a bitset, should be followed by 1 << 16 bits
+    };
+    // clang-format on
+    uint8_t data[sizeof(data_begin) + (1 << 16) / 8];
+
+    memcpy(data, data_begin, sizeof(data_begin));
+    memset(data + sizeof(data_begin), 0xFF, (1 << 16) / 8);
+
+    valid_deserialize_test(data, sizeof(data));
+
+    data[sizeof(data) - 1] = 0xFE;
+    invalid_deserialize_test(data, sizeof(data),
+                             "Incorrect bitset cardinality");
 }
 
 int main() {
@@ -170,6 +265,11 @@ int main() {
         cmocka_unit_test(test_robust_deserialize5),
         cmocka_unit_test(test_robust_deserialize6),
         cmocka_unit_test(test_robust_deserialize7),
+        cmocka_unit_test(deserialize_duplicate_keys),
+        cmocka_unit_test(deserialize_unsorted_keys),
+        cmocka_unit_test(deserialize_duplicate_array),
+        cmocka_unit_test(deserialize_unsorted_array),
+        cmocka_unit_test(deserialize_bitset_incorrect_cardinality),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Add some unit tests for deserialization/validation.

This also does add a small fix to the `ra_portable_deserialize_size` function to not allow negative container counts.

Related to #662 