### PR TITLE
including roaring64.h in roaring.h

### DIFF
--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -1184,7 +1184,6 @@ using namespace ::roaring::api;
 #endif
 #endif
 
-
 // roaring64 will include roaring.h, but we would
 // prefer to avoid having our users include roaring64.h
 // in addition to roaring.h.

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -1183,3 +1183,9 @@ CROARING_DEPRECATED static inline uint32_t roaring_read_uint32_iterator(
 using namespace ::roaring::api;
 #endif
 #endif
+
+
+// roaring64 will include roaring.h, but we would
+// prefer to avoid having our users include roaring64.h
+// in addition to roaring.h.
+#include <roaring/roaring64.h>


### PR DESCRIPTION
For more convenience.

(The additional build time is trivial, these headers compile very fast.)
