### PR TITLE
safety guarantees about deserialize_safe & internal_validate functions

### DIFF
--- a/fuzz/croaring_fuzzer.c
+++ b/fuzz/croaring_fuzzer.c
@@ -78,7 +78,6 @@ int bitmap64(const char *data, size_t size) {
     }
     return 0;
 }
-<<<<<<< HEAD
 
 int LLVMFuzzerTestOneInput(const char *data, size_t size) {
     if (size == 0) {
@@ -89,17 +88,4 @@ int LLVMFuzzerTestOneInput(const char *data, size_t size) {
     } else {
         return bitmap64(data + 1, size - 1);
     }
-=======
-int LLVMFuzzerTestOneInput(const char *data, size_t size) {
-    int r;
-    r = bitmap32(data, size);
-    if (r) {
-        return r;
-    }
-    r = bitmap64(data, size);
-    if (r) {
-        return r;
-    }
-    return 0;
->>>>>>> 345433598c21c4e35f817a0cc01d023c949961d1
 }

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -649,11 +649,13 @@ roaring_bitmap_t *roaring_bitmap_portable_deserialize(const char *buf);
  * order. This is is guaranteed to happen when serializing an existing bitmap,
  * but not for random inputs.
  *
- * You may use roaring_bitmap_internal_validate to check the validity of the
- * bitmap prior to using it.
+ * If the source is untrusted, you should call
+ * roaring_bitmap_internal_validate to check the validity of the
+ * bitmap prior to using it. Only after calling roaring_bitmap_internal_validate
+ * is the bitmap considered safe for use.
  *
- * We recommend that you use checksums to check that serialized data corresponds
- * to a serialized bitmap.
+ * We also recommend that you use checksums to check that serialized data corresponds
+ * to the serialized bitmap. The CRoaring library does not provide checksumming.
  *
  * This function is endian-sensitive. If you have a big-endian system (e.g., a
  * mainframe IBM s390x), the data format is going to be big-endian and not

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -548,11 +548,13 @@ size_t roaring64_bitmap_portable_deserialize_size(const char *buf,
  * order. This is is guaranteed to happen when serializing an existing bitmap,
  * but not for random inputs.
  *
- * You may use roaring64_bitmap_internal_validate to check the validity of the
- * bitmap prior to using it.
+ * If the source is untrusted, you should call
+ * roaring64_bitmap_internal_validate to check the validity of the
+ * bitmap prior to using it. Only after calling roaring64_bitmap_internal_validate
+ * is the bitmap considered safe for use.
  *
- * We recommend that you use checksums to check that serialized data corresponds
- * to a serialized bitmap.
+ * We also recommend that you use checksums to check that serialized data corresponds
+ * to the serialized bitmap. The CRoaring library does not provide checksumming.
  *
  * This function is endian-sensitive. If you have a big-endian system (e.g., a
  * mainframe IBM s390x), the data format is going to be big-endian and not


### PR DESCRIPTION
We now guarantee that deserialization from untrusted sources is safe.

Note that users should still use checksums to validate content integrity. We will not be providing checksumming as there are excellent librairies for this purpose already.

