### PR TITLE
Add frozen support to roaring64

### DIFF
--- a/include/roaring/art/art.h
+++ b/include/roaring/art/art.h
@@ -58,8 +58,8 @@ typedef struct art_s {
     // Indexed by node typecode, thus 1 larger than it needs to be for
     // convenience. `first_free` indicates the index where the first free node
     // lives, which may be equal to the capacity.
-    size_t first_free[6];
-    size_t capacities[6];
+    uint64_t first_free[6];
+    uint64_t capacities[6];
 
     art_leaf_t *leaves;
     art_node4_t *node4s;

--- a/include/roaring/art/art.h
+++ b/include/roaring/art/art.h
@@ -208,6 +208,34 @@ void art_iterator_insert(art_iterator_t *iterator, const art_key_chunk_t *key,
  */
 bool art_iterator_erase(art_iterator_t *iterator, art_val_t *erased_val);
 
+/**
+ * Shrinks the internal arrays in the ART to remove any unused elements. Returns
+ * the number of bytes freed.
+ */
+size_t art_shrink_to_fit(art_t *art);
+
+/**
+ * Returns the serialized size in bytes.
+ * Requires `art_shrink_to_fit` to be called first.
+ */
+size_t art_size_in_bytes(const art_t *art);
+
+/**
+ * Serializes the ART and returns the number of bytes written. Returns 0 on
+ * error. Requires `art_shrink_to_fit` to be called first.
+ */
+size_t art_serialize(const art_t *art, char *buf);
+
+/**
+ * Deserializes the ART from a serialized buffer, reading up to `maxbytes`
+ * bytes. Returns 0 on error. Requires `buf` to be 8 byte aligned.
+ *
+ * An ART deserialized in this way should only be used in a readonly context.The
+ * underlying buffer must not be freed before the ART. `art_free` should not be
+ * called on the ART deserialized in this way.
+ */
+size_t art_frozen_view(const char *buf, size_t maxbytes, art_t *art);
+
 #ifdef __cplusplus
 }  // extern "C"
 }  // namespace roaring

--- a/include/roaring/art/art.h
+++ b/include/roaring/art/art.h
@@ -19,8 +19,8 @@
  *    chunks _differ_. This means that if there are two entries with different
  *    high 48 bits, then there is only one inner node containing the common key
  *    prefix, and two leaves.
- *  * Intrusive leaves: the leaf struct is included in user values. This removes
- *    a layer of indirection.
+ *  * Mostly pointer-free: nodes are referred to by index rather than pointer,
+ *    so that the structure can be deserialized with a backing buffer.
  */
 
 // Fixed length of keys in the ART. All keys are assumed to be of this length.
@@ -33,25 +33,42 @@ namespace internal {
 #endif
 
 typedef uint8_t art_key_chunk_t;
-typedef struct art_node_s art_node_t;
+
+// Internal node reference type. Contains the node typecode in the low 8 bits,
+// and the index in the relevant node array in the high 48 bits. Has a value of
+// CROARING_ART_NULL_REF when pointing to a non-existent node.
+typedef uint64_t art_ref_t;
+
+typedef struct art_leaf_s art_leaf_t;
+typedef struct art_node4_s art_node4_t;
+typedef struct art_node16_s art_node16_t;
+typedef struct art_node48_s art_node48_t;
+typedef struct art_node256_s art_node256_t;
 
 /**
- * Wrapper to allow an empty tree.
+ * The ART is empty when root is a null ref.
+ *
+ * Each node type has its own dynamic array of node structs, indexed by
+ * art_ref_t. The arrays are expanded as needed, and shrink only when
+ * `shrink_to_fit` is called.
  */
 typedef struct art_s {
-    art_node_t *root;
+    art_ref_t root;
+
+    // Indexed by node typecode, thus 1 larger than it needs to be for
+    // convenience. `first_free` indicates the index where the first free node
+    // lives, which may be equal to the capacity.
+    size_t first_free[6];
+    size_t capacities[6];
+
+    art_leaf_t *leaves;
+    art_node4_t *node4s;
+    art_node16_t *node16s;
+    art_node48_t *node48s;
+    art_node256_t *node256s;
 } art_t;
 
-/**
- * Values inserted into the tree have to be cast-able to art_val_t. This
- * improves performance by reducing indirection.
- *
- * NOTE: Value pointers must be unique! This is because each value struct
- * contains the key corresponding to the value.
- */
-typedef struct art_val_s {
-    art_key_chunk_t key[ART_KEY_BYTES];
-} art_val_t;
+typedef uint64_t art_val_t;
 
 /**
  * Compares two keys, returns their relative order:
@@ -63,14 +80,21 @@ int art_compare_keys(const art_key_chunk_t key1[],
                      const art_key_chunk_t key2[]);
 
 /**
- * Inserts the given key and value.
+ * Initializes the ART.
  */
-void art_insert(art_t *art, const art_key_chunk_t *key, art_val_t *val);
+void art_init_cleared(art_t *art);
 
 /**
- * Returns the value erased, NULL if not found.
+ * Inserts the given key and value. Returns a pointer to the value inserted,
+ * valid as long as the ART is not modified.
  */
-art_val_t *art_erase(art_t *art, const art_key_chunk_t *key);
+art_val_t *art_insert(art_t *art, const art_key_chunk_t *key, art_val_t val);
+
+/**
+ * Returns true if a value was erased. Sets `*erased_val` to the value erased,
+ * if any.
+ */
+bool art_erase(art_t *art, const art_key_chunk_t *key, art_val_t *erased_val);
 
 /**
  * Returns the value associated with the given key, NULL if not found.
@@ -83,16 +107,10 @@ art_val_t *art_find(const art_t *art, const art_key_chunk_t *key);
 bool art_is_empty(const art_t *art);
 
 /**
- * Frees the nodes of the ART except the values, which the user is expected to
- * free.
+ * Frees the contents of the ART. Should not be called when using
+ * `art_deserialize_frozen_safe`.
  */
 void art_free(art_t *art);
-
-/**
- * Returns the size in bytes of the ART. Includes size of pointers to values,
- * but not the values themselves.
- */
-size_t art_size_in_bytes(const art_t *art);
 
 /**
  * Prints the ART using printf, useful for debugging.
@@ -100,25 +118,28 @@ size_t art_size_in_bytes(const art_t *art);
 void art_printf(const art_t *art);
 
 /**
- * Callback for validating the value stored in a leaf.
+ * Callback for validating the value stored in a leaf. `context` is a
+ * user-provided value passed to the callback without modification.
  *
  * Should return true if the value is valid, false otherwise
  * If false is returned, `*reason` should be set to a static string describing
  * the reason for the failure.
  */
-typedef bool (*art_validate_cb_t)(const art_val_t *val, const char **reason);
+typedef bool (*art_validate_cb_t)(const art_val_t val, const char **reason,
+                                  void *context);
 
 /**
- * Validate the ART tree, ensuring it is internally consistent.
+ * Validate the ART tree, ensuring it is internally consistent. `context` is a
+ * user-provided value passed to the callback without modification.
  */
 bool art_internal_validate(const art_t *art, const char **reason,
-                           art_validate_cb_t validate_cb);
+                           art_validate_cb_t validate_cb, void *context);
 
 /**
  * ART-internal iterator bookkeeping. Users should treat this as an opaque type.
  */
 typedef struct art_iterator_frame_s {
-    art_node_t *node;
+    art_ref_t ref;
     uint8_t index_in_node;
 } art_iterator_frame_t;
 
@@ -129,6 +150,8 @@ typedef struct art_iterator_frame_s {
 typedef struct art_iterator_s {
     art_key_chunk_t key[ART_KEY_BYTES];
     art_val_t *value;
+
+    art_t *art;
 
     uint8_t depth;  // Key depth
     uint8_t frame;  // Node depth
@@ -143,19 +166,19 @@ typedef struct art_iterator_s {
  * depending on `first`. The iterator is not valid if there are no entries in
  * the ART.
  */
-art_iterator_t art_init_iterator(const art_t *art, bool first);
+art_iterator_t art_init_iterator(art_t *art, bool first);
 
 /**
  * Returns an initialized iterator positioned at a key equal to or greater than
  * the given key, if it exists.
  */
-art_iterator_t art_lower_bound(const art_t *art, const art_key_chunk_t *key);
+art_iterator_t art_lower_bound(art_t *art, const art_key_chunk_t *key);
 
 /**
  * Returns an initialized iterator positioned at a key greater than the given
  * key, if it exists.
  */
-art_iterator_t art_upper_bound(const art_t *art, const art_key_chunk_t *key);
+art_iterator_t art_upper_bound(art_t *art, const art_key_chunk_t *key);
 
 /**
  * The following iterator movement functions return true if a new entry was
@@ -174,14 +197,16 @@ bool art_iterator_lower_bound(art_iterator_t *iterator,
 /**
  * Insert the value and positions the iterator at the key.
  */
-void art_iterator_insert(art_t *art, art_iterator_t *iterator,
-                         const art_key_chunk_t *key, art_val_t *val);
+void art_iterator_insert(art_iterator_t *iterator, const art_key_chunk_t *key,
+                         art_val_t val);
 
 /**
  * Erase the value pointed at by the iterator. Moves the iterator to the next
- * leaf. Returns the value erased or NULL if nothing was erased.
+ * leaf.
+ * Returns true if a value was erased. Sets `*erased_val` to the value erased,
+ * if any.
  */
-art_val_t *art_iterator_erase(art_t *art, art_iterator_t *iterator);
+bool art_iterator_erase(art_iterator_t *iterator, art_val_t *erased_val);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/roaring/art/art.h
+++ b/include/roaring/art/art.h
@@ -39,11 +39,7 @@ typedef uint8_t art_key_chunk_t;
 // CROARING_ART_NULL_REF when pointing to a non-existent node.
 typedef uint64_t art_ref_t;
 
-typedef struct art_leaf_s art_leaf_t;
-typedef struct art_node4_s art_node4_t;
-typedef struct art_node16_s art_node16_t;
-typedef struct art_node48_s art_node48_t;
-typedef struct art_node256_s art_node256_t;
+typedef void art_node_t;
 
 /**
  * The ART is empty when root is a null ref.
@@ -55,17 +51,12 @@ typedef struct art_node256_s art_node256_t;
 typedef struct art_s {
     art_ref_t root;
 
-    // Indexed by node typecode, thus 1 larger than it needs to be for
+    // Indexed by node typecode, thus 1 larger than they need to be for
     // convenience. `first_free` indicates the index where the first free node
     // lives, which may be equal to the capacity.
     uint64_t first_free[6];
     uint64_t capacities[6];
-
-    art_leaf_t *leaves;
-    art_node4_t *node4s;
-    art_node16_t *node16s;
-    art_node48_t *node48s;
-    art_node256_t *node256s;
+    art_node_t *nodes[6];
 } art_t;
 
 typedef uint64_t art_val_t;

--- a/include/roaring/art/art.h
+++ b/include/roaring/art/art.h
@@ -206,6 +206,11 @@ bool art_iterator_erase(art_iterator_t *iterator, art_val_t *erased_val);
 size_t art_shrink_to_fit(art_t *art);
 
 /**
+ * Returns true if the ART has no unused elements.
+ */
+bool art_is_shrunken(const art_t *art);
+
+/**
  * Returns the serialized size in bytes.
  * Requires `art_shrink_to_fit` to be called first.
  */

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -313,6 +313,12 @@ uint64_t roaring64_bitmap_maximum(const roaring64_bitmap_t *r);
 bool roaring64_bitmap_run_optimize(roaring64_bitmap_t *r);
 
 /**
+ * Shrinks internal arrays to eliminate any unused capacity. Returns the number
+ * of bytes freed.
+ */
+size_t roaring64_bitmap_shrink_to_fit(roaring64_bitmap_t *r);
+
+/**
  *  (For advanced users.)
  * Collect statistics about the bitmap
  */
@@ -563,6 +569,53 @@ size_t roaring64_bitmap_portable_deserialize_size(const char *buf,
  */
 roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_safe(const char *buf,
                                                                size_t maxbytes);
+
+/**
+ * Returns the number of bytes required to serialize this bitmap in a "frozen"
+ * format. This is not compatible with any other serialization formats.
+ *
+ * `roaring64_bitmap_shrink_to_fit()` must be called before this method.
+ */
+size_t roaring64_bitmap_frozen_size_in_bytes(const roaring64_bitmap_t *r);
+
+/**
+ * Serializes the bitmap in a "frozen" format. The given buffer must be at least
+ * `roaring64_bitmap_frozen_size_in_bytes()` in size. Returns the number of
+ * bytes used for serialization.
+ *
+ * `roaring64_bitmap_shrink_to_fit()` must be called before this method.
+ *
+ * The frozen format is optimized for speed of (de)serialization, as well as
+ * allowing the user to create a bitmap based on a memory mapped file, which is
+ * possible because the format mimics the memory layout of the bitmap.
+ *
+ * Because the format mimics the memory layout of the bitmap, the format is not
+ * fixed across releases of Roaring Bitmaps, and may change in future releases.
+ *
+ * This function is endian-sensitive. If you have a big-endian system (e.g., a
+ * mainframe IBM s390x), the data format is going to be big-endian and not
+ * compatible with little-endian systems.
+ */
+size_t roaring64_bitmap_frozen_serialize(const roaring64_bitmap_t *r,
+                                         char *buf);
+
+/**
+ * Creates a readonly bitmap that is a view of the given buffer. The buffer
+ * should be created with `roaring64_bitmap_frozen_serialize()`, and must be
+ * aligned by 64 bytes.
+ *
+ * Returns NULL if deserialization fails.
+ *
+ * The returned bitmap must only be used in a readonly manner. The bitmap must
+ * be freed using `roaring64_bitmap_free()` as normal. The backing buffer must
+ * only be freed after the bitmap.
+ *
+ * This function is endian-sensitive. If you have a big-endian system (e.g., a
+ * mainframe IBM s390x), the data format is going to be big-endian and not
+ * compatible with little-endian systems.
+ */
+roaring64_bitmap_t *roaring64_bitmap_frozen_view(const char *buf,
+                                                 size_t maxbytes);
 
 /**
  * Iterate over the bitmap elements. The function `iterator` is called once for

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -601,7 +601,7 @@ size_t roaring64_bitmap_frozen_serialize(const roaring64_bitmap_t *r,
 
 /**
  * Creates a readonly bitmap that is a view of the given buffer. The buffer
- * should be created with `roaring64_bitmap_frozen_serialize()`, and must be
+ * must be created with `roaring64_bitmap_frozen_serialize()`, and must be
  * aligned by 64 bytes.
  *
  * Returns NULL if deserialization fails.

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -17,7 +17,7 @@ namespace api {
 #endif
 
 typedef struct roaring64_bitmap_s roaring64_bitmap_t;
-typedef struct roaring64_leaf_s roaring64_leaf_t;
+typedef uint64_t roaring64_leaf_t;
 typedef struct roaring64_iterator_s roaring64_iterator_t;
 
 /**

--- a/microbenchmarks/CMakeLists.txt
+++ b/microbenchmarks/CMakeLists.txt
@@ -25,3 +25,7 @@ add_executable(bench bench.cpp)
 target_link_libraries(bench PRIVATE roaring)
 target_link_libraries(bench PRIVATE benchmark::benchmark)
 target_compile_definitions(bench PRIVATE BENCHMARK_DATA_DIR="${BENCHMARK_DATA_DIR}")
+
+add_executable(synthetic_bench synthetic_bench.cpp)
+target_link_libraries(synthetic_bench PRIVATE roaring)
+target_link_libraries(synthetic_bench PRIVATE benchmark::benchmark)

--- a/microbenchmarks/synthetic_bench.cpp
+++ b/microbenchmarks/synthetic_bench.cpp
@@ -1,0 +1,472 @@
+#include <benchmark/benchmark.h>
+#include <random>
+#include <set>
+
+#include "performancecounters/event_counter.h"
+#include "roaring/roaring64.h"
+#include "roaring64map.hh"
+
+namespace roaring {
+
+const auto kCountAndDensityRange = {
+    benchmark::CreateRange(1000, 1000000, /*multi=*/10),
+    benchmark::CreateRange(1, uint64_t{1} << 48,
+                           /*multi=*/256)};
+
+// Bitmasks with 20 bits set, spread out over: 20, 32, 48, 64 bits.
+//
+// These bitmasks make it so that the set size is bounded, and the hit rate is
+// high, while also changing density at different bit orders. With 2^20 random
+// elements inserted, the hit rate is ~63% due to the overlap in elements
+// inserted.
+constexpr std::array<uint64_t, 10> kBitmasks = {
+    // 20 bit spread
+    0x00000000000FFFFF,
+    0x0000000FFFFF0000,
+    0x000FFFFF00000000,
+    0xFFFFF00000000000,
+    // 32 bit spread
+    0x000000005DBFC83E,
+    0x00005DBFC83E0000,
+    0x5DBFC83E00000000,
+    // 48 bit spread
+    0x0000493B189604B6,
+    0x493B189604B60000,
+    // 64 bit spread
+    0x420C684950A2D088,
+};
+
+std::random_device rd;
+std::mt19937 gen(rd());
+
+uint64_t randUint64() {
+    return std::uniform_int_distribution<uint64_t>(
+        std::numeric_limits<uint64_t>::min(),
+        std::numeric_limits<uint64_t>::max())(gen);
+}
+
+static void r64ContainsHit(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        roaring64_bitmap_add(r, val);
+    }
+    size_t i = 0;
+    for (auto _ : state) {
+        uint64_t val = i * step;
+        i = (i + 1) % count;
+        benchmark::DoNotOptimize(roaring64_bitmap_contains(r, val));
+    }
+    roaring64_bitmap_free(r);
+}
+BENCHMARK(r64ContainsHit)->ArgsProduct({kCountAndDensityRange});
+
+static void cppContainsHit(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    Roaring64Map r;
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        r.add(val);
+    }
+    size_t i = 0;
+    for (auto _ : state) {
+        uint64_t val = i * step;
+        i = (i + 1) % count;
+        benchmark::DoNotOptimize(r.contains(val));
+    }
+}
+BENCHMARK(cppContainsHit)->ArgsProduct({kCountAndDensityRange});
+
+static void setContainsHit(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    std::set<uint64_t> set;
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        set.insert(val);
+    }
+    size_t i = 0;
+    for (auto _ : state) {
+        uint64_t val = i * step;
+        i = (i + 1) % count;
+        benchmark::DoNotOptimize(set.find(val) != set.end());
+    }
+}
+BENCHMARK(setContainsHit)->ArgsProduct({kCountAndDensityRange});
+
+static void r64ContainsMiss(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        roaring64_bitmap_add(r, val);
+    }
+    size_t i = 0;
+    for (auto _ : state) {
+        uint64_t val = (i + 1) * step - 1;
+        i = (i + 1) % count;
+        benchmark::DoNotOptimize(roaring64_bitmap_contains(r, val));
+    }
+    roaring64_bitmap_free(r);
+}
+BENCHMARK(r64ContainsMiss)->ArgsProduct({kCountAndDensityRange});
+
+static void cppContainsMiss(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    Roaring64Map r;
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        r.add(val);
+    }
+    size_t i = 0;
+    for (auto _ : state) {
+        uint64_t val = (i + 1) * step - 1;
+        i = (i + 1) % count;
+        benchmark::DoNotOptimize(r.contains(val));
+    }
+}
+BENCHMARK(cppContainsMiss)->ArgsProduct({kCountAndDensityRange});
+
+static void setContainsMiss(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    std::set<uint64_t> set;
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        set.insert(val);
+    }
+    size_t i = 0;
+    for (auto _ : state) {
+        uint64_t val = (i + 1) * step - 1;
+        i = (i + 1) % count;
+        benchmark::DoNotOptimize(set.find(val) != set.end());
+    }
+}
+BENCHMARK(setContainsMiss)->ArgsProduct({kCountAndDensityRange});
+
+static void r64ContainsRandom(benchmark::State& state) {
+    uint64_t bitmask = kBitmasks[state.range(0)];
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+    for (size_t i = 0; i < (1 << 20); ++i) {
+        uint64_t val = randUint64() & bitmask;
+        roaring64_bitmap_add(r, val);
+    }
+    for (auto _ : state) {
+        uint64_t val = randUint64() & bitmask;
+        benchmark::DoNotOptimize(roaring64_bitmap_contains(r, val));
+    }
+    roaring64_bitmap_free(r);
+}
+BENCHMARK(r64ContainsRandom)->DenseRange(0, kBitmasks.size() - 1, 1);
+
+static void cppContainsRandom(benchmark::State& state) {
+    uint64_t bitmask = kBitmasks[state.range(0)];
+    Roaring64Map r;
+    for (size_t i = 0; i < (1 << 20); ++i) {
+        uint64_t val = randUint64() & bitmask;
+        r.add(val);
+    }
+    for (auto _ : state) {
+        uint64_t val = randUint64() & bitmask;
+        benchmark::DoNotOptimize(r.contains(val));
+    }
+}
+BENCHMARK(cppContainsRandom)->DenseRange(0, kBitmasks.size() - 1, 1);
+
+static void setContainsRandom(benchmark::State& state) {
+    uint64_t bitmask = kBitmasks[state.range(0)];
+    std::set<uint64_t> set;
+    for (size_t i = 0; i < (1 << 20); ++i) {
+        uint64_t val = randUint64() & bitmask;
+        set.insert(val);
+    }
+    for (auto _ : state) {
+        uint64_t val = randUint64() & bitmask;
+        benchmark::DoNotOptimize(set.find(val) != set.end());
+    }
+}
+BENCHMARK(setContainsRandom)->DenseRange(0, kBitmasks.size() - 1, 1);
+
+static void r64Insert(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    for (auto _ : state) {
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        for (size_t i = 0; i < count; ++i) {
+            uint64_t val = i * step;
+            roaring64_bitmap_add(r, val);
+        }
+        roaring64_bitmap_free(r);
+    }
+    state.SetItemsProcessed(count);
+}
+BENCHMARK(r64Insert)->ArgsProduct({kCountAndDensityRange});
+
+static void cppInsert(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    for (auto _ : state) {
+        Roaring64Map r;
+        for (size_t i = 0; i < count; ++i) {
+            uint64_t val = i * step;
+            r.add(val);
+        }
+    }
+    state.SetItemsProcessed(count);
+}
+BENCHMARK(cppInsert)->ArgsProduct({kCountAndDensityRange});
+
+static void setInsert(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    for (auto _ : state) {
+        std::set<uint64_t> set;
+        for (size_t i = 0; i < count; ++i) {
+            uint64_t val = i * step;
+            set.insert(val);
+        }
+    }
+    state.SetItemsProcessed(count);
+}
+BENCHMARK(setInsert)->ArgsProduct({kCountAndDensityRange});
+
+static void r64Remove(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    for (auto _ : state) {
+        state.PauseTiming();
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        for (size_t i = 0; i < count; ++i) {
+            uint64_t val = i * step;
+            roaring64_bitmap_add(r, val);
+        }
+        state.ResumeTiming();
+        for (size_t i = 0; i < count; ++i) {
+            uint64_t val = i * step;
+            roaring64_bitmap_remove(r, val);
+        }
+        state.PauseTiming();
+        roaring64_bitmap_free(r);
+    }
+    state.SetItemsProcessed(count);
+}
+BENCHMARK(r64Remove)->ArgsProduct({kCountAndDensityRange});
+
+static void cppRemove(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    for (auto _ : state) {
+        state.PauseTiming();
+        Roaring64Map r;
+        for (size_t i = 0; i < count; ++i) {
+            uint64_t val = i * step;
+            r.add(val);
+        }
+        state.ResumeTiming();
+        for (size_t i = 0; i < count; ++i) {
+            uint64_t val = i * step;
+            r.remove(val);
+        }
+        state.PauseTiming();
+    }
+    state.SetItemsProcessed(count);
+}
+BENCHMARK(cppRemove)->ArgsProduct({kCountAndDensityRange});
+
+static void setRemove(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    for (auto _ : state) {
+        state.PauseTiming();
+        std::set<uint64_t> set;
+        for (size_t i = 0; i < count; ++i) {
+            uint64_t val = i * step;
+            set.insert(val);
+        }
+        state.ResumeTiming();
+        for (size_t i = 0; i < count; ++i) {
+            uint64_t val = i * step;
+            set.erase(val);
+        }
+        state.PauseTiming();
+    }
+    state.SetItemsProcessed(count);
+}
+BENCHMARK(setRemove)->ArgsProduct({kCountAndDensityRange});
+
+static void r64PortableSerialize(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        roaring64_bitmap_add(r, val);
+    }
+    size_t size = roaring64_bitmap_portable_size_in_bytes(r);
+    std::vector<char> buf(size);
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(
+            roaring64_bitmap_portable_serialize(r, buf.data()));
+    }
+    state.SetItemsProcessed(count);
+    state.SetBytesProcessed(size);
+    roaring64_bitmap_free(r);
+}
+BENCHMARK(r64PortableSerialize)->ArgsProduct({kCountAndDensityRange});
+
+static void r64FrozenSerialize(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        roaring64_bitmap_add(r, val);
+    }
+    roaring64_bitmap_shrink_to_fit(r);
+    size_t size = roaring64_bitmap_frozen_size_in_bytes(r);
+    std::vector<char> buf(size);
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(
+            roaring64_bitmap_frozen_serialize(r, buf.data()));
+    }
+    state.SetItemsProcessed(count);
+    state.SetBytesProcessed(size);
+    roaring64_bitmap_free(r);
+}
+BENCHMARK(r64FrozenSerialize)->ArgsProduct({kCountAndDensityRange});
+
+static void cppPortableSerialize(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    Roaring64Map r;
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        r.add(val);
+    }
+    size_t size = r.getSizeInBytes(/*portable=*/true);
+    std::vector<char> buf(size);
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(r.write(buf.data(), /*portable=*/true));
+    }
+    state.SetItemsProcessed(count);
+    state.SetBytesProcessed(size);
+}
+BENCHMARK(cppPortableSerialize)->ArgsProduct({kCountAndDensityRange});
+
+static void cppFrozenSerialize(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    Roaring64Map r;
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        r.add(val);
+    }
+    size_t size = r.getFrozenSizeInBytes();
+    // TODO: there seems to be a bug in writeFrozen that causes writes beyond
+    // getFrozenSizeInBytes()
+    std::vector<char> buf(size * 2);
+    for (auto _ : state) {
+        r.writeFrozen(buf.data());
+        benchmark::DoNotOptimize(buf);
+    }
+    state.SetItemsProcessed(count);
+    state.SetBytesProcessed(size);
+}
+BENCHMARK(cppFrozenSerialize)->ArgsProduct({kCountAndDensityRange});
+
+static void r64PortableDeserialize(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    roaring64_bitmap_t* r1 = roaring64_bitmap_create();
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        roaring64_bitmap_add(r1, val);
+    }
+    size_t size = roaring64_bitmap_portable_size_in_bytes(r1);
+    std::vector<char> buf(size);
+    roaring64_bitmap_portable_serialize(r1, buf.data());
+    roaring64_bitmap_free(r1);
+    for (auto _ : state) {
+        auto r2 = roaring64_bitmap_portable_deserialize_safe(buf.data(), size);
+        benchmark::DoNotOptimize(r2);
+        roaring64_bitmap_free(r2);
+    }
+    state.SetItemsProcessed(count);
+    state.SetBytesProcessed(size);
+}
+BENCHMARK(r64PortableDeserialize)->ArgsProduct({kCountAndDensityRange});
+
+static void r64FrozenDeserialize(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    roaring64_bitmap_t* r1 = roaring64_bitmap_create();
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        roaring64_bitmap_add(r1, val);
+    }
+    roaring64_bitmap_shrink_to_fit(r1);
+    size_t size = roaring64_bitmap_frozen_size_in_bytes(r1);
+    char* buf = (char*)aligned_alloc(64, size);
+    roaring64_bitmap_frozen_serialize(r1, buf);
+    roaring64_bitmap_free(r1);
+    for (auto _ : state) {
+        auto r2 = roaring64_bitmap_frozen_view(buf, size);
+        benchmark::DoNotOptimize(r2);
+        roaring64_bitmap_free(r2);
+    }
+    free(buf);
+    state.SetItemsProcessed(count);
+    state.SetBytesProcessed(size);
+}
+BENCHMARK(r64FrozenDeserialize)->ArgsProduct({kCountAndDensityRange});
+
+static void cppPortableDeserialize(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    Roaring64Map r1;
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        r1.add(val);
+    }
+    size_t size = r1.getSizeInBytes(/*portable=*/true);
+    std::vector<char> buf(size);
+    r1.write(buf.data(), /*portable=*/true);
+    for (auto _ : state) {
+        auto r2 = Roaring64Map::read(buf.data(), /*portable=*/true);
+        benchmark::DoNotOptimize(r2);
+    }
+    state.SetItemsProcessed(count);
+    state.SetBytesProcessed(size);
+}
+BENCHMARK(cppPortableDeserialize)->ArgsProduct({kCountAndDensityRange});
+
+static void cppFrozenDeserialize(benchmark::State& state) {
+    size_t count = state.range(0);
+    uint64_t step = state.range(1);
+    Roaring64Map r1;
+    for (size_t i = 0; i < count; ++i) {
+        uint64_t val = i * step;
+        r1.add(val);
+    }
+    size_t size = r1.getFrozenSizeInBytes();
+    // TODO: there seems to be a bug in writeFrozen that causes writes beyond
+    // getFrozenSizeInBytes()
+    std::vector<char> buf(size * 2);
+    r1.writeFrozen(buf.data());
+    for (auto _ : state) {
+        auto r2 = Roaring64Map::frozenView(buf.data());
+        benchmark::DoNotOptimize(r2);
+    }
+    state.SetItemsProcessed(count);
+    state.SetBytesProcessed(size);
+}
+BENCHMARK(cppFrozenDeserialize)->ArgsProduct({kCountAndDensityRange});
+
+}  // namespace roaring
+
+BENCHMARK_MAIN();

--- a/microbenchmarks/synthetic_bench.cpp
+++ b/microbenchmarks/synthetic_bench.cpp
@@ -299,6 +299,55 @@ static void setRemove(benchmark::State& state) {
 }
 BENCHMARK(setRemove)->ArgsProduct({kCountAndDensityRange});
 
+static void r64InsertRemoveRandom(benchmark::State& state) {
+    uint64_t bitmask = kBitmasks[state.range(0)];
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+    for (size_t i = 0; i < (1 << 20); ++i) {
+        uint64_t val = randUint64() & bitmask;
+        roaring64_bitmap_add(r, val);
+    }
+    for (auto _ : state) {
+        uint64_t val1 = randUint64() & bitmask;
+        uint64_t val2 = randUint64() & bitmask;
+        roaring64_bitmap_add(r, val1);
+        roaring64_bitmap_remove(r, val2);
+    }
+    roaring64_bitmap_free(r);
+}
+BENCHMARK(r64InsertRemoveRandom)->DenseRange(0, kBitmasks.size() - 1, 1);
+
+static void cppInsertRemoveRandom(benchmark::State& state) {
+    uint64_t bitmask = kBitmasks[state.range(0)];
+    Roaring64Map r;
+    for (size_t i = 0; i < (1 << 20); ++i) {
+        uint64_t val = randUint64() & bitmask;
+        r.add(val);
+    }
+    for (auto _ : state) {
+        uint64_t val1 = randUint64() & bitmask;
+        uint64_t val2 = randUint64() & bitmask;
+        r.add(val1);
+        r.remove(val2);
+    }
+}
+BENCHMARK(cppInsertRemoveRandom)->DenseRange(0, kBitmasks.size() - 1, 1);
+
+static void setInsertRemoveRandom(benchmark::State& state) {
+    uint64_t bitmask = kBitmasks[state.range(0)];
+    std::set<uint64_t> set;
+    for (size_t i = 0; i < (1 << 20); ++i) {
+        uint64_t val = randUint64() & bitmask;
+        set.insert(val);
+    }
+    for (auto _ : state) {
+        uint64_t val1 = randUint64() & bitmask;
+        uint64_t val2 = randUint64() & bitmask;
+        set.insert(val1);
+        set.erase(val2);
+    }
+}
+BENCHMARK(setInsertRemoveRandom)->DenseRange(0, kBitmasks.size() - 1, 1);
+
 static void r64PortableSerialize(benchmark::State& state) {
     size_t count = state.range(0);
     uint64_t step = state.range(1);

--- a/src/art/art.c
+++ b/src/art/art.c
@@ -1299,9 +1299,6 @@ static uint8_t art_common_prefix(const art_key_chunk_t key1[],
 /**
  * Extends the array of nodes of the given typecode. Invalidates pointers into
  * the array obtained by `art_deref`.
- *
- * Must only be called when the node array of the given type is "full"
- * (first_free == capacity).
  */
 static void art_extend(art_t *art, art_typecode_t typecode) {
     uint64_t size = art->first_free[typecode];

--- a/src/art/art.c
+++ b/src/art/art.c
@@ -1794,19 +1794,6 @@ static void art_shrink_at(art_t *art, art_ref_t ref) {
     }
 }
 
-static bool art_is_shrunken(const art_t *art) {
-    return art->first_free[CROARING_ART_LEAF_TYPE] ==
-               art->capacities[CROARING_ART_LEAF_TYPE] &&
-           art->first_free[CROARING_ART_NODE4_TYPE] ==
-               art->capacities[CROARING_ART_NODE4_TYPE] &&
-           art->first_free[CROARING_ART_NODE16_TYPE] ==
-               art->capacities[CROARING_ART_NODE16_TYPE] &&
-           art->first_free[CROARING_ART_NODE48_TYPE] ==
-               art->capacities[CROARING_ART_NODE48_TYPE] &&
-           art->first_free[CROARING_ART_NODE256_TYPE] ==
-               art->capacities[CROARING_ART_NODE256_TYPE];
-}
-
 void art_init_cleared(art_t *art) {
     art->root = CROARING_ART_NULL_REF;
     memset(art->first_free, 0, sizeof(art->first_free));
@@ -1827,6 +1814,16 @@ size_t art_shrink_to_fit(art_t *art) {
         art_shrink_at(art, art->root);
     }
     return art_shrink_node_arrays(art);
+}
+
+bool art_is_shrunken(const art_t *art) {
+    for (art_typecode_t t = CROARING_ART_MIN_TYPE; t <= CROARING_ART_MAX_TYPE;
+         ++t) {
+        if (art->first_free[t] != art->capacities[t]) {
+            return false;
+        }
+    }
+    return true;
 }
 
 art_val_t *art_insert(art_t *art, const art_key_chunk_t *key, art_val_t val) {

--- a/src/art/art.c
+++ b/src/art/art.c
@@ -37,19 +37,15 @@ namespace internal {
 #endif
 
 typedef uint8_t art_typecode_t;
-
-// All node types should count as unoccupied if zeroed with memset.
-
 typedef void art_node_t;
 
 typedef struct art_leaf_s {
-    bool occupied;
     union {
         struct {
             art_key_chunk_t key[ART_KEY_BYTES];
             art_val_t val;
         };
-        size_t next_free;  // Used if !occupied.
+        size_t next_free;
     };
 } art_leaf_t;
 
@@ -65,27 +61,27 @@ typedef struct art_inner_node_s {
 
 // Node4: key[i] corresponds with children[i]. Keys are sorted.
 typedef struct art_node4_s {
-    art_inner_node_t base;
-    uint8_t count;
     union {
         struct {
+            art_inner_node_t base;
+            uint8_t count;
             uint8_t keys[4];
             art_ref_t children[4];
         };
-        size_t next_free;  // Used if count == 0.
+        size_t next_free;
     };
 } art_node4_t;
 
 // Node16: key[i] corresponds with children[i]. Keys are sorted.
 typedef struct art_node16_s {
-    art_inner_node_t base;
-    uint8_t count;
     union {
         struct {
+            art_inner_node_t base;
+            uint8_t count;
             uint8_t keys[16];
             art_ref_t children[16];
         };
-        size_t next_free;  // Used if count == 0.
+        size_t next_free;
     };
 } art_node16_t;
 
@@ -93,10 +89,10 @@ typedef struct art_node16_s {
 // CROARING_ART_NODE48_EMPTY_VAL. Keys are naturally sorted due to direct
 // indexing.
 typedef struct art_node48_s {
-    art_inner_node_t base;
-    uint8_t count;
     union {
         struct {
+            art_inner_node_t base;
+            uint8_t count;
             // Bitset where the ith bit is set if children[i] is available
             // Because there are at most 48 children, only the bottom 48 bits
             // are used.
@@ -104,20 +100,20 @@ typedef struct art_node48_s {
             uint8_t keys[256];
             art_ref_t children[48];
         };
-        size_t next_free;  // Used if count == 0.
+        size_t next_free;
     };
 } art_node48_t;
 
 // Node256: children[i] is directly indexed by key chunk. A child is present if
 // children[i] != NULL.
 typedef struct art_node256_s {
-    art_inner_node_t base;
-    uint16_t count;
     union {
         struct {
+            art_inner_node_t base;
+            uint16_t count;
             art_ref_t children[256];
         };
-        size_t next_free;  // Used if count == 0.
+        size_t next_free;
     };
 } art_node256_t;
 
@@ -235,14 +231,12 @@ static art_ref_t art_leaf_create(art_t *art, const art_key_chunk_t key[],
                                  art_val_t val) {
     uint64_t index = art_allocate_index(art, CROARING_ART_LEAF_TYPE);
     art_leaf_t *leaf = art->leaves + index;
-    leaf->occupied = true;
     memcpy(leaf->key, key, ART_KEY_BYTES);
     leaf->val = val;
     return art_to_ref(index, CROARING_ART_LEAF_TYPE);
 }
 
 static inline void art_leaf_clear(art_leaf_t *leaf, art_ref_t next_free) {
-    leaf->occupied = false;
     leaf->next_free = next_free;
 }
 

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -179,8 +179,6 @@ static inline leaf_t copy_leaf_container(const roaring64_bitmap_t *r1,
     return add_container(r2, container, typecode);
 }
 
-static inline void free_leaf(leaf_t *leaf) { roaring_free(leaf); }
-
 static inline int compare_high48(art_key_chunk_t key1[],
                                  art_key_chunk_t key2[]) {
     return art_compare_keys(key1, key2);

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -113,8 +113,7 @@ static inline leaf_t replace_container(roaring64_bitmap_t *r, leaf_t *leaf,
 }
 
 /**
- * Extends the array of container pointers. Must only be called when the array
- * is "full" (first_free == capacity).
+ * Extends the array of container pointers.
  */
 static void extend_containers(roaring64_bitmap_t *r) {
     size_t size = r->first_free;

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -964,7 +964,7 @@ static void move_to_shrink(roaring64_bitmap_t *r, leaf_t *leaf) {
 }
 
 static inline bool is_shrunken(const roaring64_bitmap_t *r) {
-    return r->first_free == r->capacity;
+    return art_is_shrunken(&r->art) && r->first_free == r->capacity;
 }
 
 size_t roaring64_bitmap_shrink_to_fit(roaring64_bitmap_t *r) {

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -969,9 +969,6 @@ static inline bool is_shrunken(const roaring64_bitmap_t *r) {
 
 size_t roaring64_bitmap_shrink_to_fit(roaring64_bitmap_t *r) {
     size_t freed = art_shrink_to_fit(&r->art);
-    if (is_shrunken(r)) {
-        return freed;
-    }
     art_iterator_t it = art_init_iterator(&r->art, true);
     while (it.value != NULL) {
         leaf_t *leaf = (leaf_t *)it.value;
@@ -979,6 +976,9 @@ size_t roaring64_bitmap_shrink_to_fit(roaring64_bitmap_t *r) {
                                          get_typecode(*leaf));
         move_to_shrink(r, leaf);
         art_iterator_next(&it);
+    }
+    if (is_shrunken(r)) {
+        return freed;
     }
     size_t new_capacity = r->first_free;
     if (new_capacity < r->capacity) {

--- a/tests/art_unit.cpp
+++ b/tests/art_unit.cpp
@@ -676,6 +676,7 @@ DEFINE_TEST(test_art_frozen_view) {
             assert_art_valid(&art1);
         }
 
+        art_shrink_to_fit(&art1);
         size_t serialized_size = art_size_in_bytes(&art1);
         char* buf = (char*)roaring_aligned_malloc(8, serialized_size);
         assert_int_equal(art_serialize(&art1, buf), serialized_size);
@@ -709,6 +710,7 @@ DEFINE_TEST(test_art_frozen_view) {
             assert_art_valid(&art1);
         }
 
+        art_shrink_to_fit(&art1);
         size_t serialized_size = art_size_in_bytes(&art1);
         char* buf = (char*)roaring_aligned_malloc(8, serialized_size);
         assert_int_equal(art_serialize(&art1, buf), serialized_size);

--- a/tests/art_unit.cpp
+++ b/tests/art_unit.cpp
@@ -18,7 +18,7 @@ namespace {
 
 void print_key(const art_key_chunk_t* key) {
     for (size_t i = 0; i < ART_KEY_BYTES; ++i) {
-        printf("%x", *(key + i));
+        printf("%02x", *(key + i));
     }
 }
 
@@ -37,7 +37,7 @@ void assert_key_eq(const art_key_chunk_t* key1, const art_key_chunk_t* key2) {
 
 void assert_art_valid(art_t* art) {
     const char* reason = nullptr;
-    if (!art_internal_validate(art, &reason, nullptr)) {
+    if (!art_internal_validate(art, &reason, nullptr, nullptr)) {
         fail_msg("ART is invalid: '%s'\n", reason);
     }
 }
@@ -80,26 +80,20 @@ class Key {
     std::array<uint8_t, 6> key_;
 };
 
-struct Value : art_val_t {
-    Value() {}
-    Value(uint64_t val_) : val(val_) {}
-    bool operator==(const Value& other) const { return val == other.val; }
-
-    uint64_t val = 0;
-};
-
 class ShadowedART {
    public:
+    ShadowedART() { art_init_cleared(&art_); }
     ~ShadowedART() { art_free(&art_); }
 
-    void insert(Key key, Value value) {
+    void insert(Key key, art_val_t value) {
         shadow_[key] = value;
-        art_insert(&art_, key.data(), &shadow_[key]);
+        art_insert(&art_, key.data(), shadow_[key]);
     }
 
     void erase(Key key) {
-        art_erase(&art_, key.data());
-        shadow_.erase(key);
+        bool erased = art_erase(&art_, key.data(), nullptr);
+        bool shadow_erased = shadow_.erase(key) == 1;
+        assert_true(erased == shadow_erased);
     }
 
     void assertLowerBoundValid(Key key) {
@@ -118,17 +112,17 @@ class ShadowedART {
         for (const auto& entry : shadow_) {
             auto& key = entry.first;
             auto& value = entry.second;
-            Value* found_val = (Value*)art_find(&art_, key.data());
+            art_val_t* found_val = art_find(&art_, key.data());
             if (found_val == nullptr) {
                 printf("Key %s is not null in shadow but null in ART\n",
                        key.string().c_str());
                 assert_true(found_val != nullptr);
                 break;
             }
-            if (found_val->val != value.val) {
+            if (*found_val != value) {
                 printf("Key %s: ART value %" PRIu64 " != shadow value %" PRIu64
                        "\n",
-                       key.string().c_str(), found_val->val, value.val);
+                       key.string().c_str(), *found_val, value);
                 assert_true(*found_val == value);
                 break;
             }
@@ -136,7 +130,7 @@ class ShadowedART {
     }
 
    private:
-    void assertIteratorValid(std::map<Key, Value>::iterator& shadow_it,
+    void assertIteratorValid(std::map<Key, art_val_t>::iterator& shadow_it,
                              art_iterator_t* art_it) {
         if (shadow_it != shadow_.end() && art_it->value == nullptr) {
             printf("Iterator for key %s is null\n",
@@ -155,40 +149,45 @@ class ShadowedART {
             assert_true(shadow_it->first == Key(art_it->key));
         }
     }
-    std::map<Key, Value> shadow_;
-    art_t art_{NULL};
+    std::map<Key, art_val_t> shadow_;
+    art_t art_;
 };
 
 DEFINE_TEST(test_art_simple) {
     std::vector<const char*> keys = {
         "000001", "000002", "000003", "000004", "001005",
     };
-    std::vector<Value> values = {{1}, {2}, {3}, {4}, {5}};
+    std::vector<art_val_t> values = {1, 2, 3, 4, 5};
 
-    art_t art{NULL};
+    art_t art;
+    art_init_cleared(&art);
     for (size_t i = 0; i < keys.size(); ++i) {
-        art_insert(&art, (art_key_chunk_t*)keys[i], &values[i]);
+        art_insert(&art, (art_key_chunk_t*)keys[i], values[i]);
     }
-    Value* found_val = (Value*)art_find(&art, (uint8_t*)keys[0]);
-    assert_true(*found_val == values[0]);
-    Value* erased_val = (Value*)art_erase(&art, (uint8_t*)keys[0]);
-    assert_true(*erased_val == values[0]);
+    art_val_t found_val = *art_find(&art, (uint8_t*)keys[0]);
+    assert_true(found_val == values[0]);
+    art_val_t erased_val;
+    assert_true(art_erase(&art, (uint8_t*)keys[0], &erased_val));
+    assert_true(erased_val == values[0]);
     art_free(&art);
 }
 
 DEFINE_TEST(test_art_erase_all) {
     std::vector<const char*> keys = {"000001", "000002"};
-    std::vector<Value> values = {{1}, {2}};
+    std::vector<art_val_t> values = {1, 2};
 
-    art_t art{NULL};
-    art_insert(&art, (uint8_t*)keys[0], &values[0]);
-    art_insert(&art, (uint8_t*)keys[1], &values[1]);
+    art_t art;
+    art_init_cleared(&art);
+    art_insert(&art, (uint8_t*)keys[0], values[0]);
+    art_insert(&art, (uint8_t*)keys[1], values[1]);
     assert_art_valid(&art);
 
-    Value* erased_val1 = (Value*)art_erase(&art, (uint8_t*)keys[0]);
-    Value* erased_val2 = (Value*)art_erase(&art, (uint8_t*)keys[1]);
-    assert_true(*erased_val1 == values[0]);
-    assert_true(*erased_val2 == values[1]);
+    art_val_t erased_val1;
+    art_val_t erased_val2;
+    assert_true(art_erase(&art, (uint8_t*)keys[0], &erased_val1));
+    assert_true(art_erase(&art, (uint8_t*)keys[1], &erased_val2));
+    assert_true(erased_val1 == values[0]);
+    assert_true(erased_val2 == values[1]);
 
     assert_art_valid(&art);
     art_free(&art);
@@ -198,14 +197,14 @@ DEFINE_TEST(test_art_is_empty) {
     std::vector<const char*> keys = {
         "000001", "000002", "000003", "000004", "001005",
     };
-    std::vector<Value> values = {{1}, {2}, {3}, {4}, {5}};
+    std::vector<art_val_t> values = {1, 2, 3, 4, 5};
 
-    art_t art{NULL};
+    art_t art;
+    art_init_cleared(&art);
     assert_art_valid(&art);
     assert_true(art_is_empty(&art));
     const char* key = "000001";
-    Value val{1};
-    art_insert(&art, (art_key_chunk_t*)key, &val);
+    art_insert(&art, (art_key_chunk_t*)key, 1);
     assert_art_valid(&art);
     assert_false(art_is_empty(&art));
     art_free(&art);
@@ -215,19 +214,20 @@ DEFINE_TEST(test_art_iterator_next) {
     {
         // ART with multiple node sizes.
         std::vector<std::array<uint8_t, 6>> keys;
-        std::vector<Value> values;
+        std::vector<art_val_t> values;
         std::vector<size_t> sizes = {4, 16, 48, 256};
         for (size_t i = 0; i < sizes.size(); i++) {
-            uint8_t size = static_cast<uint8_t>(sizes[i]);
+            size_t size = sizes[i];
             for (size_t j = 0; j < size; j++) {
                 keys.push_back({0, 0, 0, static_cast<uint8_t>(i),
                                 static_cast<uint8_t>(j)});
-                values.push_back({static_cast<uint64_t>(i) * j});
+                values.push_back(i * j);
             }
         }
-        art_t art{NULL};
+        art_t art;
+        art_init_cleared(&art);
         for (size_t i = 0; i < keys.size(); ++i) {
-            art_insert(&art, (art_key_chunk_t*)keys[i].data(), &values[i]);
+            art_insert(&art, (art_key_chunk_t*)keys[i].data(), values[i]);
             assert_art_valid(&art);
         }
 
@@ -235,7 +235,7 @@ DEFINE_TEST(test_art_iterator_next) {
         size_t i = 0;
         do {
             assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i].data());
-            assert_true(iterator.value == &values[i]);
+            assert_true(*iterator.value == values[i]);
             ++i;
         } while (art_iterator_next(&iterator));
         art_free(&art);
@@ -247,10 +247,11 @@ DEFINE_TEST(test_art_iterator_next) {
             {0, 0, 0, 1, 0, 0}, {0, 0, 1, 0, 0, 0}, {0, 1, 0, 0, 0, 0},
             {1, 0, 0, 0, 0, 0},
         };
-        std::vector<Value> values = {{0, 1, 2, 3, 4, 5, 6}};
-        art_t art{NULL};
+        std::vector<art_val_t> values = {0, 1, 2, 3, 4, 5, 6};
+        art_t art;
+        art_init_cleared(&art);
         for (size_t i = 0; i < keys.size(); ++i) {
-            art_insert(&art, (art_key_chunk_t*)keys[i].data(), &values[i]);
+            art_insert(&art, (art_key_chunk_t*)keys[i].data(), values[i]);
             assert_art_valid(&art);
         }
 
@@ -258,7 +259,7 @@ DEFINE_TEST(test_art_iterator_next) {
         size_t i = 0;
         do {
             assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i].data());
-            assert_true(iterator.value == &values[i]);
+            assert_true(*iterator.value == values[i]);
             ++i;
         } while (art_iterator_next(&iterator));
         art_free(&art);
@@ -269,19 +270,20 @@ DEFINE_TEST(test_art_iterator_prev) {
     {
         // ART with multiple node sizes.
         std::vector<std::array<uint8_t, 6>> keys;
-        std::vector<Value> values;
+        std::vector<art_val_t> values;
         std::vector<size_t> sizes = {4, 16, 48, 256};
         for (size_t i = 0; i < sizes.size(); i++) {
             uint8_t size = static_cast<uint8_t>(sizes[i]);
             for (size_t j = 0; j < size; j++) {
                 keys.push_back({0, 0, 0, static_cast<uint8_t>(i),
                                 static_cast<uint8_t>(j)});
-                values.push_back({static_cast<uint64_t>(i) * j});
+                values.push_back(static_cast<uint64_t>(i) * j);
             }
         }
-        art_t art{NULL};
+        art_t art;
+        art_init_cleared(&art);
         for (size_t i = 0; i < keys.size(); ++i) {
-            art_insert(&art, (art_key_chunk_t*)keys[i].data(), &values[i]);
+            art_insert(&art, (art_key_chunk_t*)keys[i].data(), values[i]);
             assert_art_valid(&art);
         }
 
@@ -300,10 +302,11 @@ DEFINE_TEST(test_art_iterator_prev) {
             {0, 0, 0, 1, 0, 0}, {0, 0, 1, 0, 0, 0}, {0, 1, 0, 0, 0, 0},
             {1, 0, 0, 0, 0, 0},
         };
-        std::vector<Value> values = {{0, 1, 2, 3, 4, 5, 6}};
-        art_t art{NULL};
+        std::vector<art_val_t> values = {0, 1, 2, 3, 4, 5, 6};
+        art_t art;
+        art_init_cleared(&art);
         for (size_t i = 0; i < keys.size(); ++i) {
-            art_insert(&art, (art_key_chunk_t*)keys[i].data(), &values[i]);
+            art_insert(&art, (art_key_chunk_t*)keys[i].data(), values[i]);
             assert_art_valid(&art);
         }
 
@@ -311,7 +314,7 @@ DEFINE_TEST(test_art_iterator_prev) {
         size_t i = keys.size() - 1;
         do {
             assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i].data());
-            assert_true(iterator.value == &values[i]);
+            assert_true(*iterator.value == values[i]);
             --i;
         } while (art_iterator_prev(&iterator));
         art_free(&art);
@@ -320,7 +323,8 @@ DEFINE_TEST(test_art_iterator_prev) {
 
 DEFINE_TEST(test_art_iterator_lower_bound) {
     {
-        art_t art{NULL};
+        art_t art;
+        art_init_cleared(&art);
         art_iterator_t iterator = art_init_iterator(&art, true);
         assert_null(iterator.value);
         assert_false(
@@ -333,10 +337,11 @@ DEFINE_TEST(test_art_iterator_lower_bound) {
         std::vector<const char*> keys = {
             "000001", "000002", "000003", "000004", "001005",
         };
-        std::vector<Value> values = {{1}, {2}, {3}, {4}, {5}};
-        art_t art{NULL};
+        std::vector<art_val_t> values = {1, 2, 3, 4, 5};
+        art_t art;
+        art_init_cleared(&art);
         for (size_t i = 0; i < keys.size(); ++i) {
-            art_insert(&art, (art_key_chunk_t*)keys[i], &values[i]);
+            art_insert(&art, (art_key_chunk_t*)keys[i], values[i]);
             assert_art_valid(&art);
         }
 
@@ -353,10 +358,11 @@ DEFINE_TEST(test_art_iterator_lower_bound) {
         // Lower bound search within a node's children.
         std::vector<const char*> keys = {"000001", "000003", "000004",
                                          "001005"};
-        std::vector<Value> values = {{1}, {3}, {4}, {5}};
-        art_t art{NULL};
+        std::vector<art_val_t> values = {1, 3, 4, 5};
+        art_t art;
+        art_init_cleared(&art);
         for (size_t i = 0; i < keys.size(); ++i) {
-            art_insert(&art, (art_key_chunk_t*)keys[i], &values[i]);
+            art_insert(&art, (art_key_chunk_t*)keys[i], values[i]);
             assert_art_valid(&art);
         }
         art_iterator_t iterator = art_init_iterator(&art, true);
@@ -378,10 +384,11 @@ DEFINE_TEST(test_art_iterator_lower_bound) {
         // Lower bound search with leaf where prefix is equal but full key is
         // smaller.
         std::vector<const char*> keys = {"000100", "000200", "000300"};
-        std::vector<Value> values = {{1}, {2}, {3}};
-        art_t art{NULL};
+        std::vector<art_val_t> values = {1, 2, 3};
+        art_t art;
+        art_init_cleared(&art);
         for (size_t i = 0; i < keys.size(); ++i) {
-            art_insert(&art, (art_key_chunk_t*)keys[i], &values[i]);
+            art_insert(&art, (art_key_chunk_t*)keys[i], values[i]);
             assert_art_valid(&art);
         }
         art_iterator_t iterator = art_init_iterator(&art, true);
@@ -427,9 +434,10 @@ DEFINE_TEST(test_art_iterator_lower_bound) {
     {
         // Lower bound search with only a single leaf.
         const char* key1 = "000001";
-        Value value{1};
-        art_t art{NULL};
-        art_insert(&art, (art_key_chunk_t*)key1, &value);
+        art_val_t value{1};
+        art_t art;
+        art_init_cleared(&art);
+        art_insert(&art, (art_key_chunk_t*)key1, value);
 
         art_iterator_t iterator = art_init_iterator(&art, true);
 
@@ -454,10 +462,11 @@ DEFINE_TEST(test_art_lower_bound) {
     std::vector<const char*> keys = {
         "000001", "000002", "000003", "000004", "001005",
     };
-    std::vector<Value> values = {{1}, {2}, {3}, {4}, {5}};
-    art_t art{NULL};
+    std::vector<art_val_t> values = {1, 2, 3, 4, 5};
+    art_t art;
+    art_init_cleared(&art);
     for (size_t i = 0; i < keys.size(); ++i) {
-        art_insert(&art, (art_key_chunk_t*)keys[i], &values[i]);
+        art_insert(&art, (art_key_chunk_t*)keys[i], values[i]);
         assert_art_valid(&art);
     }
 
@@ -468,7 +477,7 @@ DEFINE_TEST(test_art_lower_bound) {
         do {
             assert_true(iterator.value != NULL);
             assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i]);
-            assert_true(iterator.value == &values[i]);
+            assert_true(*iterator.value == values[i]);
             ++i;
         } while (art_iterator_next(&iterator));
     }
@@ -477,7 +486,7 @@ DEFINE_TEST(test_art_lower_bound) {
         art_iterator_t iterator = art_lower_bound(&art, (art_key_chunk_t*)key);
         assert_true(iterator.value != NULL);
         assert_key_eq(iterator.key, (art_key_chunk_t*)keys[4]);
-        assert_true(iterator.value == &values[4]);
+        assert_true(*iterator.value == values[4]);
         assert_false(art_iterator_next(&iterator));
     }
     {
@@ -492,10 +501,11 @@ DEFINE_TEST(test_art_upper_bound) {
     std::vector<const char*> keys = {
         "000001", "000002", "000003", "000004", "001005",
     };
-    std::vector<Value> values = {{1}, {2}, {3}, {4}, {5}};
-    art_t art{NULL};
+    std::vector<art_val_t> values = {1, 2, 3, 4, 5};
+    art_t art;
+    art_init_cleared(&art);
     for (size_t i = 0; i < keys.size(); ++i) {
-        art_insert(&art, (art_key_chunk_t*)keys[i], &values[i]);
+        art_insert(&art, (art_key_chunk_t*)keys[i], values[i]);
         assert_art_valid(&art);
     }
 
@@ -506,7 +516,7 @@ DEFINE_TEST(test_art_upper_bound) {
         do {
             assert_true(iterator.value != NULL);
             assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i]);
-            assert_true(iterator.value == &values[i]);
+            assert_true(*iterator.value == values[i]);
             ++i;
         } while (art_iterator_next(&iterator));
     }
@@ -515,7 +525,7 @@ DEFINE_TEST(test_art_upper_bound) {
         art_iterator_t iterator = art_upper_bound(&art, (art_key_chunk_t*)key);
         assert_true(iterator.value != NULL);
         assert_key_eq(iterator.key, (art_key_chunk_t*)keys[4]);
-        assert_true(iterator.value == &values[4]);
+        assert_true(*iterator.value == values[4]);
         assert_false(art_iterator_next(&iterator));
     }
     {
@@ -528,27 +538,30 @@ DEFINE_TEST(test_art_upper_bound) {
 
 DEFINE_TEST(test_art_iterator_erase) {
     std::vector<std::array<uint8_t, 6>> keys;
-    std::vector<Value> values;
+    std::vector<art_val_t> values;
     std::vector<size_t> sizes = {1, 4, 16, 48, 256};
     for (size_t i = 0; i < sizes.size(); i++) {
         uint8_t size = static_cast<uint8_t>(sizes[i]);
         for (size_t j = 0; j < size; j++) {
             keys.push_back(
                 {0, 0, 0, static_cast<uint8_t>(i), static_cast<uint8_t>(j)});
-            values.push_back({static_cast<uint64_t>(i) * j});
+            values.push_back(static_cast<uint64_t>(i) * j);
         }
     }
-    art_t art{NULL};
+    art_t art;
+    art_init_cleared(&art);
     for (size_t i = 0; i < keys.size(); ++i) {
-        art_insert(&art, (art_key_chunk_t*)keys[i].data(), &values[i]);
+        art_insert(&art, (art_key_chunk_t*)keys[i].data(), values[i]);
         assert_art_valid(&art);
     }
     art_iterator_t iterator = art_init_iterator(&art, true);
     size_t i = 0;
     do {
         assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i].data());
-        assert_true(iterator.value == &values[i]);
-        assert_true(art_iterator_erase(&art, &iterator) == &values[i]);
+        assert_true(*iterator.value == values[i]);
+        art_val_t erased_val;
+        assert_true(art_iterator_erase(&iterator, &erased_val));
+        assert_true(erased_val == values[i]);
         assert_art_valid(&art);
         assert_false(art_find(&art, (art_key_chunk_t*)keys[i].data()));
         ++i;
@@ -561,16 +574,16 @@ DEFINE_TEST(test_art_iterator_insert) {
     std::vector<const char*> keys = {
         "000001", "000002", "000003", "000004", "001005",
     };
-    std::vector<Value> values = {{1}, {2}, {3}, {4}, {5}};
-    art_t art{NULL};
-    art_insert(&art, (art_key_chunk_t*)keys[0], &values[0]);
+    std::vector<art_val_t> values = {1, 2, 3, 4, 5};
+    art_t art;
+    art_init_cleared(&art);
+    art_insert(&art, (art_key_chunk_t*)keys[0], values[0]);
     art_iterator_t iterator = art_init_iterator(&art, true);
     for (size_t i = 1; i < keys.size(); ++i) {
-        art_iterator_insert(&art, &iterator, (art_key_chunk_t*)keys[i],
-                            &values[i]);
+        art_iterator_insert(&iterator, (art_key_chunk_t*)keys[i], values[i]);
         assert_art_valid(&art);
         assert_key_eq(iterator.key, (art_key_chunk_t*)keys[i]);
-        assert_true(iterator.value == &values[i]);
+        assert_true(*iterator.value == values[i]);
     }
     art_free(&art);
 }
@@ -591,21 +604,23 @@ DEFINE_TEST(test_art_shadowed) {
 }
 
 DEFINE_TEST(test_art_shrink_grow_node48) {
-    art_t art{nullptr};
-    std::vector<Value> values(48);
+    art_t art;
+    art_init_cleared(&art);
+    std::vector<art_val_t> values(48);
     // Make a full node48.
     for (int i = 0; i < 48; i++) {
         auto key = Key(i);
-        values[i].val = i;
-        art_insert(&art, key.data(), &values[i]);
+        values[i] = i;
+        art_insert(&art, key.data(), values[i]);
         assert_art_valid(&art);
     }
     // Remove the first several containers
     for (int i = 0; i < 8; i++) {
         auto key = Key(i);
-        Value* removed_val = (Value*)(art_erase(&art, key.data()));
+        art_val_t erased_val;
+        assert_true(art_erase(&art, key.data(), &erased_val));
         assert_art_valid(&art);
-        assert_int_equal(removed_val->val, i);
+        assert_int_equal(erased_val, i);
     }
     {
         art_iterator_t iterator = art_init_iterator(&art, true);
@@ -613,7 +628,7 @@ DEFINE_TEST(test_art_shrink_grow_node48) {
         do {
             auto key = Key(i);
             assert_key_eq(iterator.key, key.data());
-            assert_true(iterator.value == &values[i]);
+            assert_true(*iterator.value == values[i]);
             ++i;
         } while (art_iterator_next(&iterator));
         assert_int_equal(i, 48);
@@ -622,8 +637,8 @@ DEFINE_TEST(test_art_shrink_grow_node48) {
     // Fill the containers back up
     for (int i = 0; i < 8; i++) {
         auto key = Key(i);
-        values[i].val = i;
-        art_insert(&art, key.data(), &values[i]);
+        values[i] = i;
+        art_insert(&art, key.data(), values[i]);
     }
     {
         art_iterator_t iterator = art_init_iterator(&art, true);
@@ -631,7 +646,7 @@ DEFINE_TEST(test_art_shrink_grow_node48) {
         do {
             auto key = Key(i);
             assert_key_eq(iterator.key, key.data());
-            assert_true(iterator.value == &values[i]);
+            assert_true(*iterator.value == values[i]);
             ++i;
         } while (art_iterator_next(&iterator));
         assert_int_equal(i, 48);


### PR DESCRIPTION
This PR makes the following changes:
* Change the internals of both ART and roaring64 to be based on indices into arrays rather than pointers.
* Use `uint64_t` as the value of the ART rather than a pointer, which allows the ART to self-contain its serialization code.
* Add support for frozen (de)serialization. This is done by serializing the arrays of objects and indices into them, which means that during deserialization the calls to `memcpy` are limited and the bitmap can mostly act as a view into a buffer.
* Add some benchmarks using synthetic data for roaring64 / roaring 64 C++ / `std::set`. These benchmarks focus more on the higher-order bits than the current microbenchmarks, and thus are a better test case for 64-bit bitmaps.

This is a large change so there is lots of room for mistakes, please let me know what can be improved.