### PR TITLE
fix bitset_next_set_bits when called with non-word-aligned starts

### DIFF
--- a/include/roaring/bitset/bitset.h
+++ b/include/roaring/bitset/bitset.h
@@ -236,7 +236,8 @@ inline size_t bitset_next_set_bits(const bitset_t *bitset, size_t *buffer,
         return 0;  // nothing more to iterate over
     }
     uint64_t w = bitset->array[x];
-    w >>= (*startfrom & 63);
+    // unset low bits inside the word less than *startfrom
+    w &= ~((UINT64_C(1) << (*startfrom & 63)) - 1);
     size_t howmany = 0;
     size_t base = x << 6;
     while (howmany < capacity) {

--- a/tests/cbitset_unit.c
+++ b/tests/cbitset_unit.c
@@ -14,7 +14,7 @@ int compute_cardinality(bitset_t *b) {
     return k;
 }
 
-void test_iterate() {
+DEFINE_TEST(test_iterate) {
     bitset_t *b = bitset_create();
     for (int k = 0; k < 1000; ++k) bitset_set(b, 3 * k);
     assert_true(bitset_count(b) == 1000);
@@ -37,7 +37,7 @@ bool increment(size_t value, void *param) {
     return true;
 }
 
-void test_iterate2() {
+DEFINE_TEST(test_iterate2) {
     bitset_t *b = bitset_create();
     for (int k = 0; k < 1000; ++k) bitset_set(b, 3 * k);
     assert_true(compute_cardinality(b) == 1000);
@@ -48,7 +48,7 @@ void test_iterate2() {
     bitset_free(b);
 }
 
-void test_construct() {
+DEFINE_TEST(test_construct) {
     bitset_t *b = bitset_create();
     for (int k = 0; k < 1000; ++k) bitset_set(b, 3 * k);
     assert_true(compute_cardinality(b) == 1000);
@@ -58,7 +58,7 @@ void test_construct() {
     bitset_free(b);
 }
 
-void test_max_min() {
+DEFINE_TEST(test_max_min) {
     bitset_t *b = bitset_create();
     assert_true(bitset_empty(b));
     for (size_t k = 100; k < 1000; ++k) {
@@ -69,7 +69,7 @@ void test_max_min() {
     bitset_free(b);
 }
 
-void test_shift_left() {
+DEFINE_TEST(test_shift_left) {
     for (size_t sh = 0; sh < 256; sh++) {
         bitset_t *b = bitset_create();
         int power = 3;
@@ -90,7 +90,7 @@ void test_shift_left() {
     }
 }
 
-void test_set_to_val() {
+DEFINE_TEST(test_set_to_val) {
     bitset_t *b = bitset_create();
     bitset_set_to_value(b, 1, true);
     bitset_set_to_value(b, 1, false);
@@ -101,7 +101,7 @@ void test_set_to_val() {
     bitset_free(b);
 }
 
-void test_shift_right() {
+DEFINE_TEST(test_shift_right) {
     for (size_t sh = 0; sh < 256; sh++) {
         bitset_t *b = bitset_create();
         int power = 3;
@@ -120,7 +120,7 @@ void test_shift_right() {
     }
 }
 
-void test_union_intersection() {
+DEFINE_TEST(test_union_intersection) {
     bitset_t *b1 = bitset_create();
     bitset_t *b2 = bitset_create();
 
@@ -148,7 +148,7 @@ void test_union_intersection() {
     bitset_free(b2);
 }
 
-void test_counts() {
+DEFINE_TEST(test_counts) {
     bitset_t *b1 = bitset_create();
     bitset_t *b2 = bitset_create();
 
@@ -165,7 +165,7 @@ void test_counts() {
 /* Creates 2 bitsets, one containing even numbers the other odds.
 Checks bitsets_disjoint() returns that they are disjoint, then sets a common
 bit between both sets and checks that they are no longer disjoint. */
-void test_disjoint() {
+DEFINE_TEST(test_disjoint) {
     bitset_t *evens = bitset_create();
     bitset_t *odds = bitset_create();
 
@@ -190,7 +190,7 @@ void test_disjoint() {
 /* Creates 2 bitsets, one containing even numbers the other odds.
 Checks that bitsets_intersect() returns that they do not intersect, then sets
 a common bit and checks that they now intersect. */
-void test_intersects() {
+DEFINE_TEST(test_intersects) {
     bitset_t *evens = bitset_create();
     bitset_t *odds = bitset_create();
 
@@ -215,7 +215,7 @@ void test_intersects() {
 contains the subset bits plus additional bits after the subset arraysize.
 Checks that the bitset_contains_all() returns false when checking if
 the superset contains all the subset bits, and true in the opposite case. */
-void test_contains_all_different_sizes() {
+DEFINE_TEST(test_contains_all_different_sizes) {
     const size_t superset_size = 10;
     const size_t subset_size = 5;
 
@@ -240,7 +240,7 @@ void test_contains_all_different_sizes() {
 even bits set in the same range. Checks that the bitset_contains_all()
 returns true, then sets a single bit at 1001 in the prior subset and checks that
 bitset_contains_all() returns false. */
-void test_contains_all() {
+DEFINE_TEST(test_contains_all) {
     bitset_t *superset = bitset_create();
     bitset_t *subset = bitset_create();
 
@@ -262,18 +262,21 @@ void test_contains_all() {
 }
 
 int main() {
-    test_set_to_val();
-    test_construct();
-    test_union_intersection();
-    test_iterate();
-    test_iterate2();
-    test_max_min();
-    test_counts();
-    test_shift_right();
-    test_shift_left();
-    test_disjoint();
-    test_intersects();
-    test_contains_all();
-    test_contains_all_different_sizes();
-    printf("All asserts passed. Code is probably ok.\n");
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_set_to_val),
+        cmocka_unit_test(test_construct),
+        cmocka_unit_test(test_union_intersection),
+        cmocka_unit_test(test_iterate),
+        cmocka_unit_test(test_iterate2),
+        cmocka_unit_test(test_max_min),
+        cmocka_unit_test(test_counts),
+        cmocka_unit_test(test_shift_right),
+        cmocka_unit_test(test_shift_left),
+        cmocka_unit_test(test_disjoint),
+        cmocka_unit_test(test_intersects),
+        cmocka_unit_test(test_contains_all),
+        cmocka_unit_test(test_contains_all_different_sizes),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/cbitset_unit.c
+++ b/tests/cbitset_unit.c
@@ -28,6 +28,34 @@ DEFINE_TEST(test_iterate) {
     bitset_free(b);
 }
 
+DEFINE_TEST(test_next_bits_iterate) {
+    bitset_t *b = bitset_create();
+    for (int i = 0; i < 100; i++) bitset_set(b, i);
+    for (int i = 1000; i < 1100; i += 2) bitset_set(b, i);
+
+    // Use an odd, small buffer size
+    size_t buffer[3];
+    size_t howmany = 0;
+    size_t i = 0;
+    for (size_t startfrom = 0;
+         (howmany = bitset_next_set_bits(
+              b, buffer, sizeof(buffer) / sizeof(buffer[0]), &startfrom)) > 0;
+         startfrom++) {
+        for (size_t j = 0; j < howmany; j++) {
+            size_t expected;
+            if (i < 100) {
+                expected = i;
+            } else {
+                expected = 1000 + 2 * (i - 100);
+            }
+            assert_int_equal(buffer[j], expected);
+            ++i;
+        }
+    }
+    assert_int_equal(i, 150);
+    bitset_free(b);
+}
+
 bool increment(size_t value, void *param) {
     size_t k;
     memcpy(&k, param, sizeof(size_t));
@@ -268,6 +296,7 @@ int main() {
         cmocka_unit_test(test_union_intersection),
         cmocka_unit_test(test_iterate),
         cmocka_unit_test(test_iterate2),
+        cmocka_unit_test(test_next_bits_iterate),
         cmocka_unit_test(test_max_min),
         cmocka_unit_test(test_counts),
         cmocka_unit_test(test_shift_right),


### PR DESCRIPTION
`bitset_next_set_bits` was returning incorrect values for bits set within the same word as the start position when the start position is not a multiple of 64. The values within the word would be reported as lower than they should be by `*start % 64`: e.g. a with `*start = 65`, and a bit at 69, the first result would be `68` (`69 - (65 % 64)`). This was especially confusing for start positions between 0-64: it would appear that `bitset_next_set_bits` was returning _relative_ positions, then suddenly it would jump to absolute positions starting at values >= 64.

Instead, `bitset_next_set_bits` will now correctly always return absolute bit positions.

Fixes #691 
