### PR TITLE
defining the macro _GNU_SOURCE appears to create troubles in some cases.

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -17,9 +17,9 @@
 #define CROARING_INCLUDE_PORTABILITY_H_
 
 // Users who need _GNU_SOURCE should define it?
-//#ifndef _GNU_SOURCE
-//#define _GNU_SOURCE 1
-//#endif  // _GNU_SOURCE
+// #ifndef _GNU_SOURCE
+// #define _GNU_SOURCE 1
+// #endif  // _GNU_SOURCE
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS 1
 #endif  // __STDC_FORMAT_MACROS

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -16,9 +16,10 @@
 #ifndef CROARING_INCLUDE_PORTABILITY_H_
 #define CROARING_INCLUDE_PORTABILITY_H_
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE 1
-#endif  // _GNU_SOURCE
+// Users who need _GNU_SOURCE should define it?
+//#ifndef _GNU_SOURCE
+//#define _GNU_SOURCE 1
+//#endif  // _GNU_SOURCE
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS 1
 #endif  // __STDC_FORMAT_MACROS


### PR DESCRIPTION
It would be better if we did not need this macro.
