### PR TITLE
fix: remove container from roaring64 when removing last item in container

### DIFF
--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -697,6 +697,7 @@ static inline bool containerptr_roaring64_bitmap_remove(roaring64_bitmap_t *r,
         container_free(container2, typecode2);
         bool erased = art_erase(&r->art, high48, (art_val_t *)leaf);
         assert(erased);
+        remove_container(r, *leaf);
         return true;
     }
     return false;

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -1563,6 +1563,10 @@ DEFINE_TEST(test_frozen_serialize) {
     check_frozen_serialization(r);
 
     roaring64_bitmap_add(r, 0);
+    roaring64_bitmap_remove(r, 0);
+    check_frozen_serialization(r);
+
+    roaring64_bitmap_add(r, 0);
     roaring64_bitmap_add(r, 1);
     roaring64_bitmap_add(r, 1ULL << 16);
     roaring64_bitmap_add(r, 1ULL << 32);


### PR DESCRIPTION
Before, this would lead to errors where adding and removing a container would leave a container in the list.