### PR TITLE
fix: avoid out of bounds index in PyRoaringBitMap124 test

### DIFF
--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -221,8 +221,12 @@ DEFINE_TEST(is_really_empty) {
 // https://github.com/Ezibenroc/PyRoaringBitMap/issues/124
 DEFINE_TEST(PyRoaringBitMap124) {
     // adversarial test case
-    const char *data = "\x020\x00\x00\x01\x00\x00\x00\x00\x00\t\x00\x10\x00\x00\x002\x003\x004\x005\x006\x007\x008\x00:\x00;\x00<\x00";
-    size_t length = 36;
+    const char data[] = {
+        0x3a, 0x30, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x00,
+        0x10, 0x00, 0x00, 0x00, 0x32, 0x00, 0x33, 0x00, 0x34, 0x00, 0x35, 0x00,
+        0x36, 0x00, 0x37, 0x00, 0x38, 0x00, 0x3a, 0x00, 0x3b, 0x00, 0x3c, 0x00,
+    };
+    size_t length = sizeof(data);
     roaring_bitmap_t *deserialized_bitmap =
         roaring_bitmap_portable_deserialize_safe(data, length);
     assert_true(deserialized_bitmap == NULL);


### PR DESCRIPTION
There are only 28 bytes of data, but a size of 36 was being passed. Instead, make this impossible: convert to a stack array, and use sizeof rather than a magic number to pass the length of data.

It isn't clear where the test data came from: the linked issue includes a base64 input of `OjAAAAEAAAAAAAkAEAAAADIAMwA0ADUANgA3ADgAOgA7ADwA`, which _does_ expand to 36 bytes, so additionally, this replaces the test data with the decoded value of the data from the linked issue instead.

This was (correctly) failing in ASAN when we immediately read past the end of the string literal.

This is a bug, but a bug that only exists in the tests, no actual CRoaring code is affected.