### PR TITLE
fix build error when microbenchmarking is enabled

### DIFF
--- a/microbenchmarks/synthetic_bench.cpp
+++ b/microbenchmarks/synthetic_bench.cpp
@@ -1,6 +1,7 @@
 #include <benchmark/benchmark.h>
 #include <random>
 #include <set>
+#include <array>
 
 #include "performancecounters/event_counter.h"
 #include "roaring/roaring64.h"


### PR DESCRIPTION
I tried compiling with microbenchmarking enabled : 
```
cmake -B build -D ENABLE_ROARING_MICROBENCHMARKS=ON
cmake --build build
```
However, I got a compile error (Arch Linux, g++ 15.2.1) because of a missing standard header.
This PR just adds the missing header.