### PR TITLE
fix roaring64 iterator state after reading past end

### DIFF
--- a/microbenchmarks/synthetic_bench.cpp
+++ b/microbenchmarks/synthetic_bench.cpp
@@ -1,7 +1,7 @@
+#include <array>
 #include <benchmark/benchmark.h>
 #include <random>
 #include <set>
-#include <array>
 
 #include "performancecounters/event_counter.h"
 #include "roaring/roaring64.h"

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1596,7 +1596,7 @@ roaring_bitmap_t *roaring_bitmap_deserialize_safe(const void *buf,
         for (uint32_t i = 0; i < card; i++) {
             // elems may not be aligned, read with memcpy
             uint32_t elem;
-            memcpy((char*)&elem, (char*)(elems + i), sizeof(elem));
+            memcpy((char *)&elem, (char *)(elems + i), sizeof(elem));
             roaring_bitmap_add_bulk(bitmap, &context, elem);
         }
         return bitmap;
@@ -3016,7 +3016,7 @@ void roaring_bitmap_frozen_serialize(const roaring_bitmap_t *rb, char *buf) {
     uint16_t *key_zone = (uint16_t *)arena_alloc(&buf, 2 * ra->size);
     uint16_t *count_zone = (uint16_t *)arena_alloc(&buf, 2 * ra->size);
     uint8_t *typecode_zone = (uint8_t *)arena_alloc(&buf, ra->size);
-    char *header_zone = (char*)arena_alloc(&buf, 4);
+    char *header_zone = (char *)arena_alloc(&buf, 4);
 
     for (int32_t i = 0; i < ra->size; i++) {
         uint16_t count;

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -2707,6 +2707,8 @@ uint64_t roaring64_iterator_read(roaring64_iterator_t *it, uint64_t *buf,
         it->has_value = art_iterator_next(&it->art_it);
         if (it->has_value) {
             roaring64_iterator_init_at_leaf_first(it);
+        } else {
+            it->saturated_forward = true;
         }
     }
     return consumed;


### PR DESCRIPTION
Set `saturated_forward` flag when iterator reaches end in `roaring64_iterator_read` so iterator knows it's at the end and can move backwards. Add test coverage to validate.

Because the value of `saturated_forward` was never set in this case, the actual value of `saturated_forward` was undefined, and could trigger UB (at least, from reading a value other than 0/1 from a `_Bool`)

This also contains a clang-format added change to `microbenchmarks/synthetic_bench.cpp` and `src/roaring.c`