### PR TITLE
remove an unneded allocation in roaring_bitmap_portable_serialize

### DIFF
--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -557,17 +557,14 @@ size_t ra_portable_serialize(const roaring_array_t *ra, char *buf) {
         memcpy(buf, &cookie, sizeof(cookie));
         buf += sizeof(cookie);
         uint32_t s = (ra->size + 7) / 8;
-        uint8_t *bitmapOfRunContainers = (uint8_t *)roaring_calloc(s, 1);
-        assert(bitmapOfRunContainers != NULL);  // todo: handle
+        memset(buf, 0, s);
         for (int32_t i = 0; i < ra->size; ++i) {
             if (get_container_type(ra->containers[i], ra->typecodes[i]) ==
                 RUN_CONTAINER_TYPE) {
-                bitmapOfRunContainers[i / 8] |= (1 << (i % 8));
+                buf[i / 8] |= 1 << (i % 8);
             }
         }
-        memcpy(buf, bitmapOfRunContainers, s);
         buf += s;
-        roaring_free(bitmapOfRunContainers);
         if (ra->size < NO_OFFSET_THRESHOLD) {
             startOffset = 4 + 4 * ra->size + s;
         } else {


### PR DESCRIPTION
Actually, in ra_portable_serialize.

There's no need to allocate an array for the run container bitset, then copying into the destination buffer. Instead, write directly into the destination buffer.