### PR TITLE
fix: use BUILD_INTERFACE to prevent header target dependency propagation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,8 +59,9 @@ if(ROARING_DISABLE_NEON)
   target_compile_definitions(roaring PUBLIC DISABLENEON=1)
 endif(ROARING_DISABLE_NEON)
 
-target_link_libraries(roaring PUBLIC roaring-headers)
-target_link_libraries(roaring PUBLIC roaring-headers-cpp)
+target_link_libraries(roaring PUBLIC "$<BUILD_INTERFACE:roaring-headers>")
+target_link_libraries(roaring PUBLIC "$<BUILD_INTERFACE:roaring-headers-cpp>")
+
 #
 #install(TARGETS roaring DESTINATION lib)
 #


### PR DESCRIPTION
Wrap roaring-headers and roaring-headers-cpp targets in generator expressions to prevent these internal targets from being propagated to installed packages, improving CMake package compatibility.

Before submitting this PR, run `tools/run-clangcldocker.sh` on your changes if you can. See the "Contributing" section in the README for details. It is acceptable to skip this formatting.
