### PR TITLE
Support version constraints when finding CRoaring with CMake

### DIFF
--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+@PACKAGE_INIT@
+
+cmake_minimum_required(VERSION @CMAKE_MINIMUM_REQUIRED_VERSION@)
+
+include("${CMAKE_CURRENT_LIST_DIR}/roaring-targets.cmake" REQUIRED)
+include("${CMAKE_CURRENT_LIST_DIR}/roaring-config-version.cmake" REQUIRED)
+
+set(${CMAKE_FIND_PACKAGE_NAME}_CONFIG "${CMAKE_CURRENT_LIST_FILE}")
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(${CMAKE_FIND_PACKAGE_NAME} CONFIG_MODE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,10 @@ install(TARGETS roaring
 
 include(CMakePackageConfigHelpers)
 
+# Set up both the build and install trees as suitable for find_package calls.
+# Configuring the build tree as well as the install tree makes it much easier
+# to test other libraries against custom builds of CRoaring by pointing
+# CMAKE_PREFIX_PATH or equivalent directly at the build directory of CRoaring.
 foreach(tree_type BUILD INSTALL)
   if(tree_type STREQUAL "BUILD")
     set(install_location ".")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,11 +71,38 @@ install(TARGETS roaring
    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-install(EXPORT roaring-config
-   FILE roaring-config.cmake
-   NAMESPACE roaring::
-   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/roaring
- )
+
+include(CMakePackageConfigHelpers)
+
+foreach(tree_type BUILD INSTALL)
+  if(tree_type STREQUAL "BUILD")
+    set(install_location ".")
+  else()
+    set(install_location "${CMAKE_INSTALL_LIBDIR}/cmake/roaring")
+  endif()
+
+  set(build_location "${PROJECT_BINARY_DIR}/${install_location}")
+  write_basic_package_version_file(
+    "${build_location}/roaring-config-version.cmake"
+    VERSION ${ROARING_LIB_VERSION}
+    COMPATIBILITY SameMajorVersion)
+  configure_package_config_file("${CMAKE_SOURCE_DIR}/cmake/config.cmake.in"
+                                "${build_location}/roaring-config.cmake"
+                                INSTALL_DESTINATION "${install_location}")
+
+  if(tree_type STREQUAL "BUILD")
+    export(EXPORT roaring-config
+           FILE "${build_location}/roaring-targets.cmake"
+           NAMESPACE roaring::)
+
+  else()
+    install(DIRECTORY "${build_location}/" DESTINATION "${install_location}")
+    install(EXPORT roaring-config
+            DESTINATION "${install_location}"
+            FILE "roaring-targets.cmake"
+            NAMESPACE roaring::)
+  endif()
+endforeach()
 
 if(NOT MSVC)
 ## We output the library at the root of the current directory where cmake is invoked


### PR DESCRIPTION
The current approach of writing the exported targets directly to the config file produces a functional set of targets in the base case of a simple `find_package` call, but any version constraint provided to `find_package(roaring <version>)` will cause any installation to be considered invalid because no version file is published. To support that use case, this PR writes a version file as part of the CMake configure. To make the version values accessible in downstream packages (i.e. in a CMakeLists.txt file that contains `find_package(roaring...)`) this PR also adds a basic config.cmake.in file that is configured using standard CMake helpers and includes both the targets file and the version file. To simplify testing of this particular change as well as any future changes to CRoaring, the config, version, and targets files are all written to both the build and install trees so that dependents of CRoaring can test against uncommitted/unpushed changes locally by pointing directly at the build tree without requiring a CMake install step.