### PR TITLE
Change BUILD_TESTING in the build example to ENABLE_ROARING_TESTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ CPMAddPackage(
   NAME roaring
   GITHUB_REPOSITORY "RoaringBitmap/CRoaring"
   GIT_TAG v2.0.4
-  OPTIONS "BUILD_TESTING OFF"
+  OPTIONS "ENABLE_ROARING_TESTS OFF"
 )
 
 target_link_libraries(hello roaring::roaring)


### PR DESCRIPTION
${BUILD_TESTING} is no longer used since 7b3da104055cb3a711d806e55d3a68a42cb65ad9, see [1], it's quite misleading to have it in the README, which should be ENABLE_ROARING_TESTS that done the work.

[1] https://github.com/RoaringBitmap/CRoaring/commit/7b3da104055cb3a711d806e55d3a68a42cb65ad9#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a

