### PR TITLE
Fix roaring64_bitmap_remove_many when removing a container

### DIFF
--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -757,6 +757,7 @@ void roaring64_bitmap_remove_bulk(roaring64_bitmap_t *r,
             assert(erased);
             (void)erased;
             remove_container(r, leaf);
+            context->leaf = NULL;
         }
     } else {
         // We're not positioned anywhere yet or the high bits of the key

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -634,17 +634,47 @@ DEFINE_TEST(test_remove_bulk) {
 }
 
 DEFINE_TEST(test_remove_many) {
-    roaring64_bitmap_t* r = roaring64_bitmap_create();
-    std::array<uint64_t, 1000> vals;
-    std::iota(vals.begin(), vals.end(), 0);
+    {
+        // Remove all values until empty, across multiple containers.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        std::array<uint64_t, 1000> vals;
+        std::iota(vals.begin(), vals.end(), 0);
 
-    roaring64_bitmap_add_many(r, vals.size(), vals.data());
-    roaring64_bitmap_remove_many(r, vals.size(), vals.data());
-    assert_r64_valid(r);
-    for (uint64_t i = 0; i < 1000; ++i) {
-        assert_false(roaring64_bitmap_contains(r, vals[i]));
+        roaring64_bitmap_add_many(r, vals.size(), vals.data());
+        roaring64_bitmap_remove_many(r, vals.size(), vals.data());
+        assert_r64_valid(r);
+        for (uint64_t i = 0; i < 1000; ++i) {
+            assert_false(roaring64_bitmap_contains(r, vals[i]));
+        }
+        assert_true(roaring64_bitmap_is_empty(r));
+        roaring64_bitmap_free(r);
     }
-    roaring64_bitmap_free(r);
+    {
+        // Remove values not present.
+        roaring64_bitmap_t* r = roaring64_bitmap_from(123, 124);
+        std::array<uint64_t, 1> vals = {125};
+        roaring64_bitmap_remove_many(r, 1, vals.data());
+        assert_r64_valid(r);
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Remove all values in a container.
+        roaring64_bitmap_t* r = roaring64_bitmap_from(123, 124);
+        std::array<uint64_t, 3> vals = {123, 124, 125};
+        roaring64_bitmap_remove_many(r, 3, vals.data());
+        assert_true(roaring64_bitmap_is_empty(r));
+        assert_r64_valid(r);
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Remove a value multiple times.
+        roaring64_bitmap_t* r = roaring64_bitmap_from(123, 124);
+        std::array<uint64_t, 3> vals = {123, 124, 124};
+        roaring64_bitmap_remove_many(r, 3, vals.data());
+        assert_true(roaring64_bitmap_is_empty(r));
+        assert_r64_valid(r);
+        roaring64_bitmap_free(r);
+    }
 }
 
 DEFINE_TEST(test_remove_range_closed) {


### PR DESCRIPTION
When we remove a container we need to reset the leaf in the context, as it is no longer valid. Added unit tests to validate. Fixes #742.