### PR TITLE
art_node_printf: Use unsigned counter values

### DIFF
--- a/src/art/art.c
+++ b/src/art/art.c
@@ -1591,7 +1591,7 @@ void art_node_printf(const art_t *art, art_ref_t ref, uint8_t depth) {
         } break;
         case CROARING_ART_NODE48_TYPE: {
             art_node48_t *node48 = (art_node48_t *)inner_node;
-            for (int i = 0; i < 256; ++i) {
+            for (uint16_t i = 0; i < 256; ++i) {
                 if (node48->keys[i] != CROARING_ART_NODE48_EMPTY_VAL) {
                     printf("%*s", depth, "");
                     printf("key: %02x ", i);
@@ -1603,7 +1603,7 @@ void art_node_printf(const art_t *art, art_ref_t ref, uint8_t depth) {
         } break;
         case CROARING_ART_NODE256_TYPE: {
             art_node256_t *node256 = (art_node256_t *)inner_node;
-            for (int i = 0; i < 256; ++i) {
+            for (uint16_t i = 0; i < 256; ++i) {
                 if (node256->children[i] != CROARING_ART_NULL_REF) {
                     printf("%*s", depth, "");
                     printf("key: %02x ", i);


### PR DESCRIPTION
The C printf() %x conversion specifier requires an unsigned value; change the loop iterator type to unsigned.
