### PR TITLE
Fixed build on e2k (Elbrus-2000) arch

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -150,7 +150,12 @@ extern "C" {  // portability definitions are in global scope, not a namespace
 #include <arm_neon.h>
 #endif
 
-#if !CROARING_REGULAR_VISUAL_STUDIO
+#if defined(__e2k__)
+// we have an e2k (Elbrus-2000) processor
+#define CROARING_IS_E2K 1
+#endif
+
+#if !CROARING_REGULAR_VISUAL_STUDIO && !defined(CROARING_IS_E2K)
 /* Non-Microsoft C/C++-compatible compiler, assumes that it supports inline
  * assembly */
 #define CROARING_INLINE_ASM 1


### PR DESCRIPTION
Fixed build on the e2k (Elbrus-2000) architecture with the Clang and MCST-LCC compilers.
