### PR TITLE
chore: Replace deprecated equalorlarger with move_equalorlarger

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,7 +913,7 @@ int main() {
     const uint32_t manyvalues[] = {2, 3, 4, 7, 8};
     Roaring rogue(5, manyvalues);
     Roaring::const_iterator j = rogue.begin();
-    j.equalorlarger(4);  // *j == 4
+    j.move_equalorlarger(4);  // *j == 4
     return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
While trying out CRoaring as a new user, I noticed the C++ example uses the deprecated `equalorlarger` function.

Updated it to the current API `move_equalorlarger` to ensure the example runs without any warning.

Related issue: https://github.com/RoaringBitmap/CRoaring/issues/653