### PR TITLE
Run CI against illumos and make the tests pass.

### DIFF
--- a/.github/workflows/omnios-ci.yml
+++ b/.github/workflows/omnios-ci.yml
@@ -1,0 +1,55 @@
+name: OmniOS
+
+'on':
+  - push
+  - pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - name: Build and Test on OmniOS
+        uses: vmactions/omnios-vm@v1
+        with:
+          release: r151050
+          usesh: true
+          prepare: |
+            set -e
+            pkg install developer/cmake developer/gcc13 developer/build/gnu-make developer/versioning/git
+          run: |
+            set -e
+            SRCDIR=$(pwd)
+
+            # Build and Test
+            mkdir build
+            cd build
+            cmake -DCMAKE_INSTALL_PREFIX:PATH=destination -DENABLE_ROARING_TESTS=ON ..
+            cmake --build . 
+            ctest . --output-on-failure
+            cmake --install . 
+            cd ../tests/installation/find && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=../../../build/destination .. && cmake --build .
+            cd $SRCDIR
+
+            # Build and Test Shared
+            cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX:PATH=destinationshared -DENABLE_ROARING_TESTS=ON -B buildshared
+            cmake --build buildshared
+            cmake --install buildshared
+            cd tests/installation/find
+            cmake -DCMAKE_INSTALL_PREFIX:PATH=../../../destinationshared -B buildshared
+            cmake --build buildshared
+            ./buildshared/repro
+            cd $SRCDIR
+
+            # Build and Test Debug
+            mkdir builddebug
+            cd builddebug
+            cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=destination -DENABLE_ROARING_TESTS=ON ..
+            cmake --build .
+            ctest . --output-on-failure
+            cmake --install .
+            cd ../tests/installation/find && mkdir builddebug && cd builddebug && cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=../../../build/destination .. && cmake --build .
+            cd $SRCDIR

--- a/include/roaring/bitset/bitset.h
+++ b/include/roaring/bitset/bitset.h
@@ -2,13 +2,14 @@
 #define CROARING_CBITSET_BITSET_H
 
 // For compatibility with MSVC with the use of `restrict`
-#if (__STDC_VERSION__ >= 199901L) || \
+#ifdef __cplusplus
+#define CROARING_CBITSET_RESTRICT
+#elif (__STDC_VERSION__ >= 199901L) || \
     (defined(__GNUC__) && defined(__STDC_VERSION__))
 #define CROARING_CBITSET_RESTRICT restrict
 #else
 #define CROARING_CBITSET_RESTRICT
-#endif  // (__STDC_VERSION__ >= 199901L) || (defined(__GNUC__) &&
-        // defined(__STDC_VERSION__ ))
+#endif
 
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
We only want to use the `restrict` keyword in C, not in C++. Under linux, darwin, etc., we can check for `__STDC_VERSION__` to verify that we're compiling C and not C++. However, illumos defines `__STDC_VERSION__` whether we're compiling C *or* C++. To ensure that we don't use the `restrict` keyword in C++ on illumos, this patch adds a check on `__cplusplus` as well, and skips `restrict` if it's defined.

This patch also adds a test workflow for illumos to avoid future regressions.

Before submitting this PR, run `tools/run-clangcldocker.sh` on your changes if you can. See the "Contributing" section in the README for details. It is acceptable to skip this formatting.
