### PR TITLE
Enable strict compiler warnings with -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ option(ROARING_LINK_STATIC "Link executables (tests, benchmarks) statically" OFF
 option(ROARING_BUILD_LTO "Build library with Link Time Optimization" OFF)
 option(ROARING_BUILD_C_AS_CPP "Build library C files using C++ compilation" OFF)
 option(ROARING_BUILD_C_TESTS_AS_CPP "Build test C files using C++ compilation" OFF)
+option(ROARING_WERROR "Treat warnings as errors (developer only)" OFF)
 option(ROARING_SANITIZE "Sanitize addresses" OFF)
 option(ROARING_SANITIZE_THREADS "Sanitize threads" OFF)
 option(ROARING_SANITIZE_UNDEFINED "Sanitize undefined behaviors" OFF)
@@ -146,21 +147,16 @@ if(ENABLE_ROARING_TESTS AND BASH AND NOT EMSCRIPTEN)
 
   add_executable(amalgamate_demo $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/amalgamation_demo.c>)
   target_link_libraries(amalgamate_demo croaring-singleheader-include-source)
-  # The amalgamation compiles everything in a single translation unit, which
-  # gives GCC deeper interprocedural visibility and triggers false-positive
-  # null-dereference warnings through allocation-failure paths. Suppress
-  # this warning for amalgamation targets only; the library itself is still
-  # checked with -Wnull-dereference in separate compilation units.
-  if(NOT MSVC)
-    target_compile_options(amalgamate_demo PRIVATE -Wno-null-dereference)
+  if(AMALG_EXTRA_WARNING_FLAGS)
+    target_compile_options(amalgamate_demo PRIVATE ${AMALG_EXTRA_WARNING_FLAGS})
   endif()
   add_test(amalgamate_demo amalgamate_demo)
 
   add_library(croaring-singleheader-source-lib $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/roaring.c>)
   set_target_properties(croaring-singleheader-source-lib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS YES)
   target_include_directories(croaring-singleheader-source-lib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
-  if(NOT MSVC)
-    target_compile_options(croaring-singleheader-source-lib PRIVATE -Wno-null-dereference)
+  if(AMALG_EXTRA_WARNING_FLAGS)
+    target_compile_options(croaring-singleheader-source-lib PRIVATE ${AMALG_EXTRA_WARNING_FLAGS})
   endif()
 
   add_executable(amalgamate_demo_cpp $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/amalgamation_demo.cpp>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,11 +146,22 @@ if(ENABLE_ROARING_TESTS AND BASH AND NOT EMSCRIPTEN)
 
   add_executable(amalgamate_demo $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/amalgamation_demo.c>)
   target_link_libraries(amalgamate_demo croaring-singleheader-include-source)
+  # The amalgamation compiles everything in a single translation unit, which
+  # gives GCC deeper interprocedural visibility and triggers false-positive
+  # null-dereference warnings through allocation-failure paths. Suppress
+  # this warning for amalgamation targets only; the library itself is still
+  # checked with -Wnull-dereference in separate compilation units.
+  if(NOT MSVC)
+    target_compile_options(amalgamate_demo PRIVATE -Wno-null-dereference)
+  endif()
   add_test(amalgamate_demo amalgamate_demo)
 
   add_library(croaring-singleheader-source-lib $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/roaring.c>)
   set_target_properties(croaring-singleheader-source-lib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS YES)
   target_include_directories(croaring-singleheader-source-lib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+  if(NOT MSVC)
+    target_compile_options(croaring-singleheader-source-lib PRIVATE -Wno-null-dereference)
+  endif()
 
   add_executable(amalgamate_demo_cpp $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/amalgamation_demo.cpp>)
   target_link_libraries(amalgamate_demo_cpp croaring-singleheader-include-source croaring-singleheader-source-lib)

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -90,7 +90,7 @@ container_t *shared_container_extract_copy(shared_container_t *container,
                                            uint8_t *typecode);
 
 /* access to container underneath */
-static inline const container_t *container_unwrap_shared(
+inline const container_t *container_unwrap_shared(
     const container_t *candidate_shared_container, uint8_t *type) {
     if (*type == SHARED_CONTAINER_TYPE) {
         *type = const_CAST_shared(candidate_shared_container)->typecode;
@@ -102,8 +102,8 @@ static inline const container_t *container_unwrap_shared(
 }
 
 /* access to container underneath */
-static inline container_t *container_mutable_unwrap_shared(container_t *c,
-                                                           uint8_t *type) {
+inline container_t *container_mutable_unwrap_shared(container_t *c,
+                                                    uint8_t *type) {
     if (*type == SHARED_CONTAINER_TYPE) {  // the passed in container is shared
         *type = CAST_shared(c)->typecode;
         assert(*type != SHARED_CONTAINER_TYPE);

--- a/include/roaring/misc/configreport.h
+++ b/include/roaring/misc/configreport.h
@@ -186,14 +186,14 @@ static inline void tellmeall() {
                (long unsigned int)sizeof(size_t),
                (long unsigned int)sizeof(int));
     }
-#if defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__
+#if defined(__LITTLE_ENDIAN__)
 // This is what we expect!
 // printf("you have little endian machine");
 #endif
-#if defined(__BIG_ENDIAN__) && __BIG_ENDIAN__
+#if defined(__BIG_ENDIAN__)
     printf("you have a big endian machine");
 #endif
-#if defined(__CHAR_BIT__) && __CHAR_BIT__
+#if defined(__CHAR_BIT__)
     if (__CHAR_BIT__ != 8) printf("on your machine, chars don't have 8bits???");
 #endif
     if (computecacheline() != 64)
@@ -217,14 +217,14 @@ static inline void tellmeall() {
                (long unsigned int)sizeof(size_t),
                (long unsigned int)sizeof(int));
     }
-#if defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__
+#if defined(__LITTLE_ENDIAN__)
 // This is what we expect!
 // printf("you have little endian machine");
 #endif
-#if defined(__BIG_ENDIAN__) && __BIG_ENDIAN__
+#if defined(__BIG_ENDIAN__)
     printf("you have a big endian machine");
 #endif
-#if defined(__CHAR_BIT__) && __CHAR_BIT__
+#if defined(__CHAR_BIT__)
     if (__CHAR_BIT__ != 8) printf("on your machine, chars don't have 8bits???");
 #endif
 }

--- a/include/roaring/misc/configreport.h
+++ b/include/roaring/misc/configreport.h
@@ -186,14 +186,14 @@ static inline void tellmeall() {
                (long unsigned int)sizeof(size_t),
                (long unsigned int)sizeof(int));
     }
-#if __LITTLE_ENDIAN__
+#if defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__
 // This is what we expect!
 // printf("you have little endian machine");
 #endif
-#if __BIG_ENDIAN__
+#if defined(__BIG_ENDIAN__) && __BIG_ENDIAN__
     printf("you have a big endian machine");
 #endif
-#if __CHAR_BIT__
+#if defined(__CHAR_BIT__) && __CHAR_BIT__
     if (__CHAR_BIT__ != 8) printf("on your machine, chars don't have 8bits???");
 #endif
     if (computecacheline() != 64)
@@ -217,14 +217,14 @@ static inline void tellmeall() {
                (long unsigned int)sizeof(size_t),
                (long unsigned int)sizeof(int));
     }
-#if __LITTLE_ENDIAN__
+#if defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__
 // This is what we expect!
 // printf("you have little endian machine");
 #endif
-#if __BIG_ENDIAN__
+#if defined(__BIG_ENDIAN__) && __BIG_ENDIAN__
     printf("you have a big endian machine");
 #endif
-#if __CHAR_BIT__
+#if defined(__CHAR_BIT__) && __CHAR_BIT__
     if (__CHAR_BIT__ != 8) printf("on your machine, chars don't have 8bits???");
 #endif
 }

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -471,7 +471,7 @@ static inline int roaring_hamming(uint64_t x) {
    // We lack __has_include to check:
 #define CROARING_ATOMIC_IMPL CROARING_ATOMIC_IMPL_CPP
 #endif  //__has_include
-#elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
 #define CROARING_ATOMIC_IMPL CROARING_ATOMIC_IMPL_C
 #elif CROARING_REGULAR_VISUAL_STUDIO
    // https://www.technetworkhub.com/c11-atomics-in-visual-studio-2022-version-17/
@@ -584,7 +584,7 @@ static inline uint32_t croaring_refcount_get(const croaring_refcount_t *val) {
 
 // We want to initialize structs to zero portably (C and C++), without
 // warnings. We can do mystruct s = CROARING_ZERO_INITIALIZER;
-#if defined(__cplusplus) && __cplusplus
+#if defined(__cplusplus)
 #define CROARING_ZERO_INITIALIZER \
     {}
 #else

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -584,7 +584,7 @@ static inline uint32_t croaring_refcount_get(const croaring_refcount_t *val) {
 
 // We want to initialize structs to zero portably (C and C++), without
 // warnings. We can do mystruct s = CROARING_ZERO_INITIALIZER;
-#if __cplusplus
+#if defined(__cplusplus) && __cplusplus
 #define CROARING_ZERO_INITIALIZER \
     {}
 #else

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,9 @@ target_link_libraries(roaring PUBLIC "$<BUILD_INTERFACE:roaring-headers>")
 target_link_libraries(roaring PUBLIC "$<BUILD_INTERFACE:roaring-headers-cpp>")
 
 target_include_directories(roaring PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+if(NOT MSVC)
+  target_compile_options(roaring PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wmissing-prototypes>)
+endif()
 
 #
 #install(TARGETS roaring DESTINATION lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,8 +63,8 @@ target_link_libraries(roaring PUBLIC "$<BUILD_INTERFACE:roaring-headers>")
 target_link_libraries(roaring PUBLIC "$<BUILD_INTERFACE:roaring-headers-cpp>")
 
 target_include_directories(roaring PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-if(NOT MSVC)
-  target_compile_options(roaring PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wmissing-prototypes>)
+if(C_EXTRA_WARNING_FLAGS)
+  target_compile_options(roaring PRIVATE $<$<COMPILE_LANGUAGE:C>:${C_EXTRA_WARNING_FLAGS}>)
 endif()
 
 #

--- a/src/art/art.c
+++ b/src/art/art.c
@@ -1543,7 +1543,7 @@ static void art_node_print_type(art_ref_t ref) {
     }
 }
 
-void art_node_printf(const art_t *art, art_ref_t ref, uint8_t depth) {
+static void art_node_printf(const art_t *art, art_ref_t ref, uint8_t depth) {
     if (art_is_leaf(ref)) {
         printf("{ type: Leaf, key: ");
         art_leaf_t *leaf = (art_leaf_t *)art_deref(art, ref);

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -176,6 +176,9 @@ void bitset_container_offset(const bitset_container_t *c, container_t **loc,
 
     if (loc != NULL) {
         bc = bitset_container_create();
+        if (bc == NULL) {
+            return;
+        }
         if (i == 0) {
             memcpy(bc->words + b, c->words, 8 * end);
         } else {
@@ -197,8 +200,7 @@ void bitset_container_offset(const bitset_container_t *c, container_t **loc,
     }
 
     if (hic == NULL) {
-        // Both hic and loc can't be NULL, so bc is never NULL here
-        if (bc->cardinality == 0) {
+        if (bc != NULL && bc->cardinality == 0) {
             bitset_container_free(bc);
         }
         return;
@@ -206,6 +208,9 @@ void bitset_container_offset(const bitset_container_t *c, container_t **loc,
 
     if (bc == NULL || bc->cardinality != 0) {
         bc = bitset_container_create();
+        if (bc == NULL) {
+            return;
+        }
     }
 
     if (i == 0) {

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -52,8 +52,7 @@ extern bool container_iterator_prev(const container_t *c, uint8_t typecode,
                                     uint16_t *value);
 extern bool container_contains(
     const container_t *c, uint16_t val,
-    uint8_t typecode  // !!! should be second argument?
-);
+    uint8_t typecode);
 
 void container_free(container_t *c, uint8_t type) {
     switch (type) {
@@ -163,7 +162,7 @@ extern inline container_t *container_add(container_t *c, uint16_t val,
                                          uint8_t *new_typecode);
 
 extern inline bool container_contains(const container_t *c, uint16_t val,
-                                      uint8_t typecode);  // !!! 2nd arg?
+                                      uint8_t typecode);
 
 extern inline container_t *container_and(const container_t *c1, uint8_t type1,
                                          const container_t *c2, uint8_t type2,

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -52,7 +52,8 @@ extern bool container_iterator_prev(const container_t *c, uint8_t typecode,
                                     uint16_t *value);
 extern bool container_contains(
     const container_t *c, uint16_t val,
-    uint8_t typecode);
+    uint8_t typecode  // !!! should be second argument?
+);
 
 void container_free(container_t *c, uint8_t type) {
     switch (type) {
@@ -162,7 +163,7 @@ extern inline container_t *container_add(container_t *c, uint16_t val,
                                          uint8_t *new_typecode);
 
 extern inline bool container_contains(const container_t *c, uint16_t val,
-                                      uint8_t typecode);
+                                      uint8_t typecode);  // !!! 2nd arg?
 
 extern inline container_t *container_and(const container_t *c1, uint8_t type1,
                                          const container_t *c2, uint8_t type2,

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -155,22 +155,26 @@ void run_container_offset(const run_container_t *c, container_t **loc,
 
     if (loc && lo_cap) {
         lo = run_container_create_given_capacity(lo_cap);
-        memcpy(lo->runs, c->runs, lo_cap * sizeof(rle16_t));
-        lo->n_runs = lo_cap;
-        for (unsigned int i = 0; i < lo_cap; ++i) {
-            lo->runs[i].value += offset;
+        if (lo != NULL) {
+            memcpy(lo->runs, c->runs, lo_cap * sizeof(rle16_t));
+            lo->n_runs = lo_cap;
+            for (unsigned int i = 0; i < lo_cap; ++i) {
+                lo->runs[i].value += offset;
+            }
+            *loc = (container_t *)lo;
         }
-        *loc = (container_t *)lo;
     }
 
     if (hic && hi_cap) {
         hi = run_container_create_given_capacity(hi_cap);
-        memcpy(hi->runs, c->runs + pivot, hi_cap * sizeof(rle16_t));
-        hi->n_runs = hi_cap;
-        for (unsigned int i = 0; i < hi_cap; ++i) {
-            hi->runs[i].value += offset;
+        if (hi != NULL) {
+            memcpy(hi->runs, c->runs + pivot, hi_cap * sizeof(rle16_t));
+            hi->n_runs = hi_cap;
+            for (unsigned int i = 0; i < hi_cap; ++i) {
+                hi->runs[i].value += offset;
+            }
+            *hic = (container_t *)hi;
         }
-        *hic = (container_t *)hi;
     }
 
     // Fix the split.
@@ -990,8 +994,9 @@ static inline int _avx2_run_container_cardinality(const run_container_t *run) {
 }
 
 CROARING_ALLOW_UNALIGNED
-int _avx2_run_container_to_uint32_array(void *vout, const run_container_t *cont,
-                                        uint32_t base) {
+static int _avx2_run_container_to_uint32_array(void *vout,
+                                                const run_container_t *cont,
+                                                uint32_t base) {
     int outpos = 0;
     uint32_t *out = (uint32_t *)vout;
 
@@ -1063,9 +1068,9 @@ int run_container_cardinality(const run_container_t *run) {
     }
 }
 
-int _scalar_run_container_to_uint32_array(void *vout,
-                                          const run_container_t *cont,
-                                          uint32_t base) {
+static int _scalar_run_container_to_uint32_array(void *vout,
+                                                  const run_container_t *cont,
+                                                  uint32_t base) {
     int outpos = 0;
     uint32_t *out = (uint32_t *)vout;
     for (int i = 0; i < cont->n_runs; ++i) {

--- a/src/isadetection.c
+++ b/src/isadetection.c
@@ -54,7 +54,7 @@ POSSIBILITY OF SUCH DAMAGE.
 // on these systems. It seems that ClangCL is not affected.
 // https://github.com/RoaringBitmap/CRoaring/pull/603
 #ifndef __clang__
-#if _MSC_VER == 1938
+#if defined(_MSC_VER) && _MSC_VER == 1938
 #define ROARING_DISABLE_AVX 1
 #endif  // _MSC_VER == 1938
 #endif  // __clang__

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -789,7 +789,7 @@ void roaring64_bitmap_remove_bulk(roaring64_bitmap_t *r,
         }
         if (!container_nonzero_cardinality(container2, typecode2)) {
             container_free(container2, typecode2);
-            leaf_t leaf;
+            leaf_t leaf = 0;
             bool erased = art_erase(art, high48, (art_val_t *)&leaf);
             assert(erased);
             (void)erased;
@@ -1801,6 +1801,9 @@ static void roaring64_flip_leaf(const roaring64_bitmap_t *r1,
             container_not_range(get_container(r1, *leaf1), get_typecode(*leaf1),
                                 min, max, &typecode2);
     }
+    if (container2 == NULL) {
+        return;
+    }
     if (container_nonzero_cardinality(container2, typecode2)) {
         leaf_t leaf2 = add_container(r2, container2, typecode2);
         art_insert(&r2->art, high48, (art_val_t)leaf2);
@@ -2408,7 +2411,7 @@ static inline size_t container_get_frozen_size(const container_t *c,
     }
 }
 
-uint64_t align_size(uint64_t size, uint64_t alignment) {
+static uint64_t align_size(uint64_t size, uint64_t alignment) {
     return (size + alignment - 1) & ~(alignment - 1);
 }
 

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -1476,7 +1476,7 @@ DEFINE_TEST(test_cpp_frozen_64) {
     roaring_aligned_free(buf);
 }
 
-#if defined(ROARING_UNSAFE_FROZEN_TESTS) && ROARING_UNSAFE_FROZEN_TESTS
+#if defined(ROARING_UNSAFE_FROZEN_TESTS)
 // This test is unsafe, as it may trigger unaligned memory access
 // It is only enabled if ROARING_UNSAFE_FROZEN_TESTS is defined.
 DEFINE_TEST(test_cpp_frozen_portable) {
@@ -1553,7 +1553,7 @@ DEFINE_TEST(test_cpp_frozen_portable) {
 }
 #endif  // ROARING_UNSAFE_FROZEN_TESTS
 
-#if defined(ROARING_UNSAFE_FROZEN_TESTS) && ROARING_UNSAFE_FROZEN_TESTS
+#if defined(ROARING_UNSAFE_FROZEN_TESTS)
 // This test is unsafe, as it may trigger unaligned memory access
 // It is only enabled if ROARING_UNSAFE_FROZEN_TESTS is defined.
 DEFINE_TEST(test_cpp_frozen_64_portable) {
@@ -2215,7 +2215,7 @@ int main() {
         cmocka_unit_test(test_cpp_bidirectional_iterator_64),
         cmocka_unit_test(test_cpp_frozen),
         cmocka_unit_test(test_cpp_frozen_64),
-#if defined(ROARING_UNSAFE_FROZEN_TESTS) && ROARING_UNSAFE_FROZEN_TESTS
+#if defined(ROARING_UNSAFE_FROZEN_TESTS)
         cmocka_unit_test(test_cpp_frozen_portable),
         cmocka_unit_test(test_cpp_frozen_64_portable),
 #endif  // ROARING_UNSAFE_FROZEN_TESTS

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -1476,7 +1476,7 @@ DEFINE_TEST(test_cpp_frozen_64) {
     roaring_aligned_free(buf);
 }
 
-#if ROARING_UNSAFE_FROZEN_TESTS
+#if defined(ROARING_UNSAFE_FROZEN_TESTS) && ROARING_UNSAFE_FROZEN_TESTS
 // This test is unsafe, as it may trigger unaligned memory access
 // It is only enabled if ROARING_UNSAFE_FROZEN_TESTS is defined.
 DEFINE_TEST(test_cpp_frozen_portable) {
@@ -1553,7 +1553,7 @@ DEFINE_TEST(test_cpp_frozen_portable) {
 }
 #endif  // ROARING_UNSAFE_FROZEN_TESTS
 
-#if ROARING_UNSAFE_FROZEN_TESTS
+#if defined(ROARING_UNSAFE_FROZEN_TESTS) && ROARING_UNSAFE_FROZEN_TESTS
 // This test is unsafe, as it may trigger unaligned memory access
 // It is only enabled if ROARING_UNSAFE_FROZEN_TESTS is defined.
 DEFINE_TEST(test_cpp_frozen_64_portable) {
@@ -2215,7 +2215,7 @@ int main() {
         cmocka_unit_test(test_cpp_bidirectional_iterator_64),
         cmocka_unit_test(test_cpp_frozen),
         cmocka_unit_test(test_cpp_frozen_64),
-#if ROARING_UNSAFE_FROZEN_TESTS
+#if defined(ROARING_UNSAFE_FROZEN_TESTS) && ROARING_UNSAFE_FROZEN_TESTS
         cmocka_unit_test(test_cpp_frozen_portable),
         cmocka_unit_test(test_cpp_frozen_64_portable),
 #endif  // ROARING_UNSAFE_FROZEN_TESTS

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -4745,7 +4745,7 @@ DEFINE_TEST(test_frozen_serialization_max_containers) {
     frozen_serialization_compare(r);
 }
 
-#if defined(ROARING_UNSAFE_FROZEN_TESTS) && ROARING_UNSAFE_FROZEN_TESTS
+#if defined(ROARING_UNSAFE_FROZEN_TESTS)
 // This test is unsafe, as it may trigger unaligned memory access
 // It is only enabled if ROARING_UNSAFE_FROZEN_TESTS is defined.
 DEFINE_TEST(test_portable_deserialize_frozen) {
@@ -5177,7 +5177,7 @@ int main() {
 #if !CROARING_IS_BIG_ENDIAN
         cmocka_unit_test(test_frozen_serialization),
         cmocka_unit_test(test_frozen_serialization_max_containers),
-#if defined(ROARING_UNSAFE_FROZEN_TESTS) && ROARING_UNSAFE_FROZEN_TESTS
+#if defined(ROARING_UNSAFE_FROZEN_TESTS)
         cmocka_unit_test(test_portable_deserialize_frozen),
 #endif  // ROARING_UNSAFE_FROZEN_TESTS
         cmocka_unit_test(issue_15jan2024),

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -4745,7 +4745,7 @@ DEFINE_TEST(test_frozen_serialization_max_containers) {
     frozen_serialization_compare(r);
 }
 
-#if ROARING_UNSAFE_FROZEN_TESTS
+#if defined(ROARING_UNSAFE_FROZEN_TESTS) && ROARING_UNSAFE_FROZEN_TESTS
 // This test is unsafe, as it may trigger unaligned memory access
 // It is only enabled if ROARING_UNSAFE_FROZEN_TESTS is defined.
 DEFINE_TEST(test_portable_deserialize_frozen) {
@@ -5177,7 +5177,7 @@ int main() {
 #if !CROARING_IS_BIG_ENDIAN
         cmocka_unit_test(test_frozen_serialization),
         cmocka_unit_test(test_frozen_serialization_max_containers),
-#if ROARING_UNSAFE_FROZEN_TESTS
+#if defined(ROARING_UNSAFE_FROZEN_TESTS) && ROARING_UNSAFE_FROZEN_TESTS
         cmocka_unit_test(test_portable_deserialize_frozen),
 #endif  // ROARING_UNSAFE_FROZEN_TESTS
         cmocka_unit_test(issue_15jan2024),

--- a/tools/cmake/FindOptions.cmake
+++ b/tools/cmake/FindOptions.cmake
@@ -24,7 +24,7 @@ endif()
 endif()
 
 if(NOT MSVC)
-set(WARNING_FLAGS "-Wall")
+set(WARNING_FLAGS "-Wall -Werror -Wnull-dereference -Wundef")
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 set(WARNING_FLAGS "${WARNING_FLAGS} -Wmissing-braces -Wextra -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/tools/cmake/FindOptions.cmake
+++ b/tools/cmake/FindOptions.cmake
@@ -24,11 +24,19 @@ endif()
 endif()
 
 if(NOT MSVC)
-set(WARNING_FLAGS "-Wall -Werror -Wnull-dereference -Wundef")
+set(WARNING_FLAGS "-Wall")
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 set(WARNING_FLAGS "${WARNING_FLAGS} -Wmissing-braces -Wextra -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 set(WARNING_FLAGS "${WARNING_FLAGS} -Wextra -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wcast-align")
+endif()
+if(ROARING_WERROR)
+  set(WARNING_FLAGS "${WARNING_FLAGS} -Werror -Wundef -Wnull-dereference")
+  set(C_EXTRA_WARNING_FLAGS "-Wmissing-prototypes")
+  # The amalgamation compiles everything in a single translation unit, which
+  # gives GCC deeper interprocedural visibility and triggers false-positive
+  # null-dereference warnings through allocation-failure paths.
+  set(AMALG_EXTRA_WARNING_FLAGS -Wno-null-dereference)
 endif()
 endif()
 


### PR DESCRIPTION
## Summary

- Adds a `ROARING_WERROR` CMake option (OFF by default) that enables `-Werror -Wundef -Wnull-dereference -Wmissing-prototypes` for developer builds
- Default build flags are unchanged (`-Wall` only), so downstream users are unaffected
- Fixes all warnings triggered by the stricter flags

## Changes

**Build system:**
- `CMakeLists.txt`: Added `ROARING_WERROR` option (OFF by default)
- `FindOptions.cmake`: `-Werror`, `-Wundef`, `-Wnull-dereference`, `-Wmissing-prototypes`, and amalgamation warning suppressions are all gated behind `ROARING_WERROR`
- `FindOptions.cmake`: Centralized warning flag variables (`C_EXTRA_WARNING_FLAGS`, `AMALG_EXTRA_WARNING_FLAGS`) instead of scattering flags across individual CMake files

**Warning fixes:**
- Made `container_unwrap_shared`/`container_mutable_unwrap_shared` non-static inline to fix static-in-non-static-inline warning
- Added `static` to file-local functions (`art_node_printf`, `align_size`, `_avx2/_scalar_run_container_to_uint32_array`)
- Added NULL checks after allocation calls in `bitset_container_offset`, `run_container_offset`, and `roaring64_flip_leaf`
- Initialized `leaf` variable to fix maybe-uninitialized warning
- Guarded preprocessor macros with `defined()` for `-Wundef`: `__cplusplus`, `__STDC_VERSION__`, `_MSC_VER`, `__LITTLE_ENDIAN__`, `__BIG_ENDIAN__`, `__CHAR_BIT__`, `ROARING_UNSAFE_FROZEN_TESTS`

## Test plan

- [x] Full clean build with `-DROARING_WERROR=ON` passes (library + tests + benchmarks + amalgamation)
- [x] Full clean build with default flags (no `ROARING_WERROR`) passes
- [x] All 66 unit tests pass on both build configurations
- [ ] CI passes on Linux (GCC), macOS (Clang), and Windows (MSVC)


🤖 Generated with [Claude Code](https://claude.com/claude-code)