### PR TITLE
add read_ranges and read_prev_ranges iterator functions

### DIFF
--- a/cpp/roaring/roaring.hh
+++ b/cpp/roaring/roaring.hh
@@ -1002,6 +1002,24 @@ class RoaringSetBitBiDirectionalIterator final {
         api::roaring_uint32_iterator_move_equalorlarger(&i, val);
     }
 
+    /**
+     * Reads up to ${count} ranges into ${buf}. Returns the number of ranges
+     * read. See roaring_uint32_iterator_read_ranges for full semantics.
+     */
+    size_t read_ranges(api::roaring_uint32_range_closed_t *buf, size_t count) {
+        return api::roaring_uint32_iterator_read_ranges(&i, buf, count);
+    }
+
+    /**
+     * Reads up to ${count} ranges in reverse into ${buf}. Returns the number
+     * of ranges read. See roaring_uint32_iterator_read_prev_ranges for full
+     * semantics.
+     */
+    size_t read_prev_ranges(api::roaring_uint32_range_closed_t *buf,
+                            size_t count) {
+        return api::roaring_uint32_iterator_read_prev_ranges(&i, buf, count);
+    }
+
     type_of_iterator &operator--() {  // prefix --
         api::roaring_uint32_iterator_previous(&i);
         return *this;

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -2627,6 +2627,35 @@ bool container_iterator_skip_backward(const container_t *c, uint8_t typecode,
                                       uint32_t *consumed_count,
                                       uint16_t *value_out);
 
+/**
+ * Finds the end of the consecutive run starting at the current iterator
+ * position within a container. Returns the low16 of the last consecutive
+ * value. If there are more values in the container after the run,
+ * *has_more is set to true, the iterator is positioned at the next value,
+ * and *value is updated to that value. Otherwise *has_more is set to false.
+ *
+ * *value must be the low 16 bits of the current value at the iterator's
+ * position on entry.
+ */
+uint16_t container_iterator_find_run_end(const container_t *c, uint8_t typecode,
+                                         roaring_container_iterator_t *it,
+                                         uint16_t *value, bool *has_more);
+
+/**
+ * Finds the start of the consecutive run ending at the current iterator
+ * position within a container. Returns the low16 of the first consecutive
+ * value. If there are more values in the container before the run,
+ * *has_more is set to true, the iterator is positioned at the previous value,
+ * and *value is updated to that value. Otherwise *has_more is set to false.
+ *
+ * *value must be the low 16 bits of the current value at the iterator's
+ * position on entry.
+ */
+uint16_t container_iterator_find_run_start(const container_t *c,
+                                           uint8_t typecode,
+                                           roaring_container_iterator_t *it,
+                                           uint16_t *value, bool *has_more);
+
 #ifdef __cplusplus
 }
 }

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -1261,6 +1261,60 @@ uint32_t roaring_uint32_iterator_skip(roaring_uint32_iterator_t *it,
 uint32_t roaring_uint32_iterator_skip_backward(roaring_uint32_iterator_t *it,
                                                uint32_t count);
 
+typedef struct roaring_uint32_range_closed_s {
+    uint32_t min;
+    uint32_t max;
+} roaring_uint32_range_closed_t;
+
+/**
+ * Reads next ${count} ranges from iterator into user-supplied ${buf}.
+ * A range is defined as a maximal interval of consecutive values.
+ * For example, the set {1,2,3,5,6} contains two ranges: [1..3] and [5..6].
+ * Each range is represented as a struct {min,max}, both endpoints included.
+ * Consecutive values that span internal container boundaries are merged into
+ * a single range.
+ *
+ * Returns the number of read ranges.
+ * This number can be smaller than ${count}, which means that the iterator is
+ * drained.
+ *
+ * This function satisfies the semantics of iteration and can be used together
+ * with other iterator functions.
+ *  - first range will start with ${it}->current_value
+ *  - after the function returns, the iterator is positioned at the next element
+ *    after the end of the last returned range, or ${it}->has_value is false if
+ *    the bitmap is exhausted.
+ */
+size_t roaring_uint32_iterator_read_ranges(roaring_uint32_iterator_t *it,
+                                           roaring_uint32_range_closed_t *buf,
+                                           size_t count);
+
+/**
+ * Reads previous ${count} ranges from iterator into user-supplied ${buf}.
+ * A range is defined as a maximal interval of consecutive values.
+ * For example, the set {1,2,3,5,6} contains two ranges: [1..3] and [5..6].
+ * Each range is represented as a struct {min,max}, both endpoints included.
+ * Consecutive values that span internal container boundaries are merged into
+ * a single range.
+ *
+ * Returns the number of read ranges.
+ * This number can be smaller than ${count}, which means that the iterator is
+ * drained.
+ *
+ * Ranges are returned in reverse order, e.g. the first range returned is the
+ * highest range (ending at the current value)
+ *
+ * This function satisfies the semantics of reverse iteration and can be used
+ * together with other iterator functions.
+ *  - first range will end with ${it}->current_value
+ *  - after the function returns, the iterator is positioned at the element
+ *    before the beginning of the last returned range, or ${it}->has_value is
+ *    false if the bitmap is exhausted.
+ */
+size_t roaring_uint32_iterator_read_prev_ranges(
+    roaring_uint32_iterator_t *it, roaring_uint32_range_closed_t *buf,
+    size_t count);
+
 #ifdef __cplusplus
 }
 }

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -804,6 +804,58 @@ bool roaring64_iterator_move_equalorlarger(roaring64_iterator_t *it,
 uint64_t roaring64_iterator_read(roaring64_iterator_t *it, uint64_t *buf,
                                  uint64_t count);
 
+typedef struct roaring64_range_closed_s {
+    uint64_t min;
+    uint64_t max;
+} roaring64_range_closed_t;
+
+/**
+ * Reads next ${count} ranges from iterator into user-supplied ${buf}.
+ * A range is defined as a maximal interval of consecutive values.
+ * For example, the set {1,2,3,5,6} contains two ranges: [1..3] and [5..6].
+ * Each range is represented as a struct {min,max}, both endpoints included.
+ * Consecutive values that span internal container boundaries are merged into
+ * a single range.
+ *
+ * Returns the number of read ranges.
+ * This number can be smaller than ${count}, which means that the iterator is
+ * drained.
+ *
+ * This function can be used together with other iterator functions.
+ *  - first range will start with the current iterator value
+ *  - after the function returns, the iterator is positioned at the next element
+ *    after the end of the last returned range, or has_value is false if
+ *    the bitmap is exhausted.
+ */
+size_t roaring64_iterator_read_ranges(roaring64_iterator_t *it,
+                                      roaring64_range_closed_t *buf,
+                                      size_t count);
+
+/**
+ * Reads previous ${count} ranges from iterator into user-supplied ${buf}.
+ * A range is defined as a maximal interval of consecutive values.
+ * For example, the set {1,2,3,5,6} contains two ranges: [1..3] and [5..6].
+ * Each range is represented as a struct {min,max}, both endpoints included.
+ * Consecutive values that span internal container boundaries are merged into
+ * a single range.
+ *
+ * Returns the number of read ranges.
+ * This number can be smaller than ${count}, which means that the iterator is
+ * drained.
+ *
+ * Ranges are returned in reverse order, e.g. the first range returned is the
+ * highest range (ending at the current value).
+ *
+ * This function can be used together with other iterator functions.
+ *  - first range will end with the current iterator value
+ *  - after the function returns, the iterator is positioned at the element
+ *    before the beginning of the last returned range, or has_value is false if
+ *    the bitmap is exhausted.
+ */
+size_t roaring64_iterator_read_prev_ranges(roaring64_iterator_t *it,
+                                           roaring64_range_closed_t *buf,
+                                           size_t count);
+
 #ifdef __cplusplus
 }  // extern "C"
 }  // namespace roaring

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -794,6 +794,171 @@ bool container_iterator_skip_backward(const container_t *c, uint8_t typecode,
     return has_value;
 }
 
+uint16_t container_iterator_find_run_end(const container_t *c, uint8_t typecode,
+                                         roaring_container_iterator_t *it,
+                                         uint16_t *value, bool *has_more) {
+    switch (typecode) {
+        case RUN_CONTAINER_TYPE: {
+            const run_container_t *rc = const_CAST_run(c);
+            uint16_t run_end =
+                rc->runs[it->index].value + rc->runs[it->index].length;
+            it->index++;
+            if (it->index < rc->n_runs) {
+                *has_more = true;
+                *value = rc->runs[it->index].value;
+            } else {
+                *has_more = false;
+            }
+            return run_end;
+        }
+        case ARRAY_CONTAINER_TYPE: {
+            const array_container_t *ac = const_CAST_array(c);
+            uint16_t v = *value;
+            while (it->index + 1 < ac->cardinality &&
+                   ac->array[it->index + 1] == (uint16_t)(v + 1)) {
+                it->index++;
+                v++;
+            }
+            it->index++;
+            if (it->index < ac->cardinality) {
+                *has_more = true;
+                *value = ac->array[it->index];
+            } else {
+                *has_more = false;
+            }
+            return v;
+        }
+        case BITSET_CONTAINER_TYPE: {
+            const bitset_container_t *bc = const_CAST_bitset(c);
+            uint32_t pos = (uint32_t)*value + 1;
+            uint16_t run_end;
+            if (pos >= (1 << 16)) {
+                *has_more = false;
+                return UINT16_MAX;
+            }
+            uint32_t wordindex = pos / 64;
+            uint64_t word = ~bc->words[wordindex] & (UINT64_MAX << (pos % 64));
+            while (word == 0 &&
+                   wordindex + 1 < BITSET_CONTAINER_SIZE_IN_WORDS) {
+                wordindex++;
+                word = ~bc->words[wordindex];
+            }
+            if (word != 0) {
+                run_end = (uint16_t)(wordindex * 64 +
+                                     roaring_trailing_zeroes(word) - 1);
+            } else {
+                run_end = UINT16_MAX;
+            }
+            uint32_t next_pos = (uint32_t)run_end + 1;
+            if (next_pos >= (1 << 16)) {
+                *has_more = false;
+            } else {
+                wordindex = next_pos / 64;
+                word = bc->words[wordindex] & (UINT64_MAX << (next_pos % 64));
+                while (word == 0 &&
+                       wordindex + 1 < BITSET_CONTAINER_SIZE_IN_WORDS) {
+                    wordindex++;
+                    word = bc->words[wordindex];
+                }
+                if (word != 0) {
+                    *has_more = true;
+                    it->index = wordindex * 64 + roaring_trailing_zeroes(word);
+                    *value = (uint16_t)it->index;
+                } else {
+                    *has_more = false;
+                }
+            }
+            return run_end;
+        }
+        default:
+            assert(false);
+            roaring_unreachable;
+            return 0;
+    }
+}
+
+uint16_t container_iterator_find_run_start(const container_t *c,
+                                           uint8_t typecode,
+                                           roaring_container_iterator_t *it,
+                                           uint16_t *value, bool *has_more) {
+    switch (typecode) {
+        case RUN_CONTAINER_TYPE: {
+            const run_container_t *rc = const_CAST_run(c);
+            uint16_t run_start = rc->runs[it->index].value;
+            it->index--;
+            if (it->index >= 0) {
+                *has_more = true;
+                *value = rc->runs[it->index].value + rc->runs[it->index].length;
+            } else {
+                *has_more = false;
+            }
+            return run_start;
+        }
+        case ARRAY_CONTAINER_TYPE: {
+            const array_container_t *ac = const_CAST_array(c);
+            uint16_t v = *value;
+            while (it->index > 0 &&
+                   ac->array[it->index - 1] == (uint16_t)(v - 1)) {
+                it->index--;
+                v--;
+            }
+            it->index--;
+            if (it->index >= 0) {
+                *has_more = true;
+                *value = ac->array[it->index];
+            } else {
+                *has_more = false;
+            }
+            return v;
+        }
+        case BITSET_CONTAINER_TYPE: {
+            const bitset_container_t *bc = const_CAST_bitset(c);
+            if (*value == 0) {
+                *has_more = false;
+                return 0;
+            }
+            uint32_t pos = (uint32_t)*value - 1;
+            int32_t wordindex = (int32_t)(pos / 64);
+            uint64_t word =
+                ~bc->words[wordindex] & (UINT64_MAX >> (63 - (pos % 64)));
+            while (word == 0 && --wordindex >= 0) {
+                word = ~bc->words[wordindex];
+            }
+            uint16_t run_start;
+            if (word != 0) {
+                run_start = (uint16_t)(wordindex * 64 +
+                                       (63 - roaring_leading_zeroes(word)) + 1);
+            } else {
+                run_start = 0;
+            }
+            if (run_start == 0) {
+                *has_more = false;
+            } else {
+                int32_t prev_pos = (int32_t)run_start - 1;
+                wordindex = prev_pos / 64;
+                word = bc->words[wordindex] &
+                       (UINT64_MAX >> (63 - (prev_pos % 64)));
+                while (word == 0 && --wordindex >= 0) {
+                    word = bc->words[wordindex];
+                }
+                if (word != 0) {
+                    *has_more = true;
+                    it->index =
+                        wordindex * 64 + (63 - roaring_leading_zeroes(word));
+                    *value = (uint16_t)it->index;
+                } else {
+                    *has_more = false;
+                }
+            }
+            return run_start;
+        }
+        default:
+            assert(false);
+            roaring_unreachable;
+            return 0;
+    }
+}
+
 #ifdef __cplusplus
 }
 }

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1932,6 +1932,72 @@ uint32_t roaring_uint32_iterator_skip_backward(roaring_uint32_iterator_t *it,
     return ret;
 }
 
+size_t roaring_uint32_iterator_read_ranges(roaring_uint32_iterator_t *it,
+                                           roaring_uint32_range_closed_t *buf,
+                                           size_t count) {
+    size_t ret = 0;
+    while (it->has_value && ret < count) {
+        buf[ret].min = it->current_value;
+        for (;;) {
+            uint16_t low16 = (uint16_t)it->current_value;
+            bool container_has_more;
+            uint16_t run_end_low16 = container_iterator_find_run_end(
+                it->container, it->typecode, &it->container_it, &low16,
+                &container_has_more);
+            buf[ret].max = it->highbits | run_end_low16;
+
+            if (container_has_more) {
+                it->current_value = it->highbits | low16;
+                break;
+            }
+            // Move to next container
+            it->container_index++;
+            it->has_value = loadfirstvalue(it);
+            // Continue merging only if the run reached the container
+            // boundary and the next container starts exactly at max+1.
+            if (run_end_low16 != UINT16_MAX || !it->has_value ||
+                it->current_value != buf[ret].max + 1) {
+                break;
+            }
+        }
+        ret++;
+    }
+    return ret;
+}
+
+size_t roaring_uint32_iterator_read_prev_ranges(
+    roaring_uint32_iterator_t *it, roaring_uint32_range_closed_t *buf,
+    size_t count) {
+    size_t ret = 0;
+    while (it->has_value && ret < count) {
+        buf[ret].max = it->current_value;
+        for (;;) {
+            uint16_t low16 = (uint16_t)it->current_value;
+            bool container_has_more;
+            uint16_t run_start_low16 = container_iterator_find_run_start(
+                it->container, it->typecode, &it->container_it, &low16,
+                &container_has_more);
+            buf[ret].min = it->highbits | run_start_low16;
+
+            if (container_has_more) {
+                it->current_value = it->highbits | low16;
+                break;
+            }
+            // Move to previous container
+            it->container_index--;
+            it->has_value = loadlastvalue(it);
+            // Continue merging only if the run reached the container
+            // boundary and the previous container ends exactly at min-1.
+            if (run_start_low16 != 0 || !it->has_value ||
+                it->current_value != buf[ret].min - 1) {
+                break;
+            }
+        }
+        ret++;
+    }
+    return ret;
+}
+
 void roaring_uint32_iterator_free(roaring_uint32_iterator_t *it) {
     roaring_free(it);
 }

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -2897,6 +2897,82 @@ uint64_t roaring64_iterator_read(roaring64_iterator_t *it, uint64_t *buf,
     return consumed;
 }
 
+size_t roaring64_iterator_read_ranges(roaring64_iterator_t *it,
+                                      roaring64_range_closed_t *buf,
+                                      size_t count) {
+    size_t ret = 0;
+    while (it->has_value && ret < count) {
+        buf[ret].min = it->value;
+        for (;;) {
+            uint16_t low16 = (uint16_t)it->value;
+            leaf_t leaf = (leaf_t)*it->art_it.value;
+            bool container_has_more;
+            uint16_t run_end_low16 = container_iterator_find_run_end(
+                get_container(it->r, leaf), get_typecode(leaf),
+                &it->container_it, &low16, &container_has_more);
+            buf[ret].max = it->high48 | run_end_low16;
+
+            if (container_has_more) {
+                it->value = it->high48 | low16;
+                break;
+            }
+            // Move to next leaf
+            it->has_value = art_iterator_next(&it->art_it);
+            if (it->has_value) {
+                roaring64_iterator_init_at_leaf_first(it);
+            } else {
+                it->saturated_forward = true;
+                break;
+            }
+            // Continue merging only if the run reached the container
+            // boundary and the next leaf starts exactly at max+1.
+            if (run_end_low16 != UINT16_MAX || it->value != buf[ret].max + 1) {
+                break;
+            }
+        }
+        ret++;
+    }
+    return ret;
+}
+
+size_t roaring64_iterator_read_prev_ranges(roaring64_iterator_t *it,
+                                           roaring64_range_closed_t *buf,
+                                           size_t count) {
+    size_t ret = 0;
+    while (it->has_value && ret < count) {
+        buf[ret].max = it->value;
+        for (;;) {
+            uint16_t low16 = (uint16_t)it->value;
+            leaf_t leaf = (leaf_t)*it->art_it.value;
+            bool container_has_more;
+            uint16_t run_start_low16 = container_iterator_find_run_start(
+                get_container(it->r, leaf), get_typecode(leaf),
+                &it->container_it, &low16, &container_has_more);
+            buf[ret].min = it->high48 | run_start_low16;
+
+            if (container_has_more) {
+                it->value = it->high48 | low16;
+                break;
+            }
+            // Move to previous leaf
+            it->has_value = art_iterator_prev(&it->art_it);
+            if (it->has_value) {
+                roaring64_iterator_init_at_leaf_last(it);
+            } else {
+                it->saturated_forward = false;
+                break;
+            }
+            // Continue merging only if the run reached the container
+            // boundary and the previous leaf ends exactly at min-1.
+            if (run_start_low16 != 0 || it->value != buf[ret].min - 1) {
+                break;
+            }
+        }
+        ret++;
+    }
+    return ret;
+}
+
 #ifdef __cplusplus
 }  // extern "C"
 }  // namespace roaring

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -2320,6 +2320,362 @@ DEFINE_TEST(test_iterator_read) {
     roaring64_bitmap_free(r);
 }
 
+DEFINE_TEST(test_iterator_read_ranges) {
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+
+    // Empty bitmap
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create(r);
+        roaring64_range_closed_t buf[1];
+        assert_int_equal(roaring64_iterator_read_ranges(it, buf, 1), 0);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    // Build test data: a few ranges with gaps, spanning high48 boundaries
+    // Range 1: [0..2]
+    roaring64_bitmap_add(r, 0);
+    roaring64_bitmap_add(r, 1);
+    roaring64_bitmap_add(r, 2);
+    // Range 2: [10..10] (single value)
+    roaring64_bitmap_add(r, 10);
+    // Range 3 spanning container boundary: [0xFFFE..0x10001]
+    roaring64_bitmap_add(r, 0xFFFE);
+    roaring64_bitmap_add(r, 0xFFFF);
+    roaring64_bitmap_add(r, 0x10000);
+    roaring64_bitmap_add(r, 0x10001);
+    // Range 4 in high48 space: a run at a large offset
+    uint64_t high_base = UINT64_C(1) << 40;
+    roaring64_bitmap_add(r, high_base);
+    roaring64_bitmap_add(r, high_base + 1);
+    roaring64_bitmap_add(r, high_base + 2);
+
+    // Forward: read all at once
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create(r);
+        roaring64_range_closed_t buf[10];
+        size_t got = roaring64_iterator_read_ranges(it, buf, 10);
+        assert_int_equal(got, 4);
+        assert_int_equal(buf[0].min, 0);
+        assert_int_equal(buf[0].max, 2);
+        assert_int_equal(buf[1].min, 10);
+        assert_int_equal(buf[1].max, 10);
+        assert_int_equal(buf[2].min, 0xFFFE);
+        assert_int_equal(buf[2].max, 0x10001);
+        assert_int_equal(buf[3].min, high_base);
+        assert_int_equal(buf[3].max, high_base + 2);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    // Forward: read one at a time
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create(r);
+        roaring64_range_closed_t buf[1];
+        size_t got;
+
+        got = roaring64_iterator_read_ranges(it, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, 0);
+        assert_int_equal(buf[0].max, 2);
+
+        got = roaring64_iterator_read_ranges(it, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, 10);
+        assert_int_equal(buf[0].max, 10);
+
+        got = roaring64_iterator_read_ranges(it, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, 0xFFFE);
+        assert_int_equal(buf[0].max, 0x10001);
+
+        got = roaring64_iterator_read_ranges(it, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, high_base);
+        assert_int_equal(buf[0].max, high_base + 2);
+
+        got = roaring64_iterator_read_ranges(it, buf, 1);
+        assert_int_equal(got, 0);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    roaring64_bitmap_free(r);
+}
+
+DEFINE_TEST(test_iterator_read_prev_ranges) {
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+
+    // Empty bitmap
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+        roaring64_range_closed_t buf[1];
+        assert_int_equal(roaring64_iterator_read_prev_ranges(it, buf, 1), 0);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    // Same data as forward test
+    roaring64_bitmap_add(r, 0);
+    roaring64_bitmap_add(r, 1);
+    roaring64_bitmap_add(r, 2);
+    roaring64_bitmap_add(r, 10);
+    roaring64_bitmap_add(r, 0xFFFE);
+    roaring64_bitmap_add(r, 0xFFFF);
+    roaring64_bitmap_add(r, 0x10000);
+    roaring64_bitmap_add(r, 0x10001);
+    uint64_t high_base = UINT64_C(1) << 40;
+    roaring64_bitmap_add(r, high_base);
+    roaring64_bitmap_add(r, high_base + 1);
+    roaring64_bitmap_add(r, high_base + 2);
+
+    // Backward: read all at once
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+        roaring64_range_closed_t buf[10];
+        size_t got = roaring64_iterator_read_prev_ranges(it, buf, 10);
+        assert_int_equal(got, 4);
+        // Ranges in reverse order
+        assert_int_equal(buf[0].min, high_base);
+        assert_int_equal(buf[0].max, high_base + 2);
+        assert_int_equal(buf[1].min, 0xFFFE);
+        assert_int_equal(buf[1].max, 0x10001);
+        assert_int_equal(buf[2].min, 10);
+        assert_int_equal(buf[2].max, 10);
+        assert_int_equal(buf[3].min, 0);
+        assert_int_equal(buf[3].max, 2);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    // Backward: read one at a time
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+        roaring64_range_closed_t buf[1];
+        size_t got;
+
+        got = roaring64_iterator_read_prev_ranges(it, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, high_base);
+        assert_int_equal(buf[0].max, high_base + 2);
+
+        got = roaring64_iterator_read_prev_ranges(it, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, 0xFFFE);
+        assert_int_equal(buf[0].max, 0x10001);
+
+        got = roaring64_iterator_read_prev_ranges(it, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, 10);
+        assert_int_equal(buf[0].max, 10);
+
+        got = roaring64_iterator_read_prev_ranges(it, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, 0);
+        assert_int_equal(buf[0].max, 2);
+
+        got = roaring64_iterator_read_prev_ranges(it, buf, 1);
+        assert_int_equal(got, 0);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    roaring64_bitmap_free(r);
+}
+
+DEFINE_TEST(test_iterator_read_ranges_mid_range) {
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+    roaring64_bitmap_add_range_closed(r, 0, 10);
+    roaring64_bitmap_add_range_closed(r, 20, 25);
+
+    roaring64_range_closed_t buf[4];
+
+    // Forward: start mid-range at 5, first range should be [5..10]
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create(r);
+        roaring64_iterator_move_equalorlarger(it, 5);
+        assert_int_equal(roaring64_iterator_value(it), 5);
+
+        size_t got = roaring64_iterator_read_ranges(it, buf, 4);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, 5);
+        assert_int_equal(buf[0].max, 10);
+        assert_int_equal(buf[1].min, 20);
+        assert_int_equal(buf[1].max, 25);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    // Backward: start mid-range at 22, first range should be [20..22]
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+        roaring64_iterator_move_equalorlarger(it, 22);
+        assert_int_equal(roaring64_iterator_value(it), 22);
+
+        size_t got = roaring64_iterator_read_prev_ranges(it, buf, 4);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, 20);
+        assert_int_equal(buf[0].max, 22);
+        assert_int_equal(buf[1].min, 0);
+        assert_int_equal(buf[1].max, 10);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    roaring64_bitmap_free(r);
+}
+
+DEFINE_TEST(test_iterator_read_ranges_uint64_max) {
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+
+    // Values near UINT64_MAX
+    roaring64_bitmap_add_range_closed(r, UINT64_MAX - 2, UINT64_MAX);
+    // Also a low value to verify separation
+    roaring64_bitmap_add(r, 42);
+
+    // Forward: read all
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create(r);
+        roaring64_range_closed_t buf[4];
+        size_t got = roaring64_iterator_read_ranges(it, buf, 4);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, 42);
+        assert_int_equal(buf[0].max, 42);
+        assert_int_equal(buf[1].min, UINT64_MAX - 2);
+        assert_int_equal(buf[1].max, UINT64_MAX);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    // Backward: read all
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+        roaring64_range_closed_t buf[4];
+        size_t got = roaring64_iterator_read_prev_ranges(it, buf, 4);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, UINT64_MAX - 2);
+        assert_int_equal(buf[0].max, UINT64_MAX);
+        assert_int_equal(buf[1].min, 42);
+        assert_int_equal(buf[1].max, 42);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    roaring64_bitmap_free(r);
+}
+
+DEFINE_TEST(test_iterator_read_ranges_multi_leaf) {
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+
+    // In roaring64, each leaf covers 2^16 consecutive values (the low 16 bits).
+    // Add a single range spanning the tail of leaf N, all of leaf N+1, and the
+    // head of leaf N+2 -- this must come back as one merged range.
+    uint64_t leaf_size = UINT64_C(0x10000);
+    uint64_t base = UINT64_C(0x000100000000);
+    uint64_t range_start = base + leaf_size / 2;  // mid leaf N
+    uint64_t range_end =
+        base + 2 * leaf_size + leaf_size / 2 - 1;  // mid leaf N+2
+    roaring64_bitmap_add_range_closed(r, range_start, range_end);
+
+    // Also add a disjoint range to verify separation
+    roaring64_bitmap_add(r, 5);
+    roaring64_bitmap_add(r, 6);
+
+    // Forward: two ranges total, the multi-leaf span is one range
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create(r);
+        roaring64_range_closed_t buf[4];
+        size_t got = roaring64_iterator_read_ranges(it, buf, 4);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, 5);
+        assert_int_equal(buf[0].max, 6);
+        assert_int_equal(buf[1].min, range_start);
+        assert_int_equal(buf[1].max, range_end);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    // Backward
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+        roaring64_range_closed_t buf[4];
+        size_t got = roaring64_iterator_read_prev_ranges(it, buf, 4);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, range_start);
+        assert_int_equal(buf[0].max, range_end);
+        assert_int_equal(buf[1].min, 5);
+        assert_int_equal(buf[1].max, 6);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    roaring64_bitmap_free(r);
+}
+
+DEFINE_TEST(test_iterator_read_ranges_interleaved) {
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+
+    // Ranges: [10..12], [20..20], [30..32], [40..40]
+    roaring64_bitmap_add_range_closed(r, 10, 12);
+    roaring64_bitmap_add(r, 20);
+    roaring64_bitmap_add_range_closed(r, 30, 32);
+    roaring64_bitmap_add(r, 40);
+
+    // read_ranges then advance then read_ranges
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create(r);
+        roaring64_range_closed_t buf[4];
+        size_t got = roaring64_iterator_read_ranges(it, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, 10);
+        assert_int_equal(buf[0].max, 12);
+        assert_true(roaring64_iterator_has_value(it));
+        assert_int_equal(roaring64_iterator_value(it), 20);
+
+        roaring64_iterator_advance(it);
+        assert_true(roaring64_iterator_has_value(it));
+        assert_int_equal(roaring64_iterator_value(it), 30);
+
+        got = roaring64_iterator_read_ranges(it, buf, 4);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, 30);
+        assert_int_equal(buf[0].max, 32);
+        assert_int_equal(buf[1].min, 40);
+        assert_int_equal(buf[1].max, 40);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    // read_prev_ranges then previous then read_prev_ranges
+    {
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+        roaring64_range_closed_t buf[4];
+        size_t got = roaring64_iterator_read_prev_ranges(it, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, 40);
+        assert_int_equal(buf[0].max, 40);
+        assert_true(roaring64_iterator_has_value(it));
+        assert_int_equal(roaring64_iterator_value(it), 32);
+
+        roaring64_iterator_previous(it);
+        assert_true(roaring64_iterator_has_value(it));
+        assert_int_equal(roaring64_iterator_value(it), 31);
+
+        got = roaring64_iterator_read_prev_ranges(it, buf, 4);
+        assert_int_equal(got, 3);
+        assert_int_equal(buf[0].min, 30);
+        assert_int_equal(buf[0].max, 31);
+        assert_int_equal(buf[1].min, 20);
+        assert_int_equal(buf[1].max, 20);
+        assert_int_equal(buf[2].min, 10);
+        assert_int_equal(buf[2].max, 12);
+        assert_false(roaring64_iterator_has_value(it));
+        roaring64_iterator_free(it);
+    }
+
+    roaring64_bitmap_free(r);
+}
+
 DEFINE_TEST(test_stats) {
     // create a new empty bitmap
     roaring64_bitmap_t* r1 = roaring64_bitmap_create();
@@ -2435,6 +2791,12 @@ int main() {
         cmocka_unit_test(test_iterator_previous),
         cmocka_unit_test(test_iterator_move_equalorlarger),
         cmocka_unit_test(test_iterator_read),
+        cmocka_unit_test(test_iterator_read_ranges),
+        cmocka_unit_test(test_iterator_read_prev_ranges),
+        cmocka_unit_test(test_iterator_read_ranges_mid_range),
+        cmocka_unit_test(test_iterator_read_ranges_uint64_max),
+        cmocka_unit_test(test_iterator_read_ranges_multi_leaf),
+        cmocka_unit_test(test_iterator_read_ranges_interleaved),
         cmocka_unit_test(test_stats),
         cmocka_unit_test(test_iterator_read_past_end_can_go_previous),
     };

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -4347,6 +4347,393 @@ DEFINE_TEST(test_uint32_iterator_skip_backward_native) {
     test_uint32_iterator_skip_backward(UINT8_MAX);
 }
 
+/*
+ * Convert a sorted array of values into an array of closed ranges.
+ * Consecutive values are merged. Caller must free the returned array.
+ */
+static roaring_uint32_range_closed_t *ranges_from_values(
+    const uint32_t *values, size_t count, uint32_t *num_ranges_out) {
+    roaring_uint32_range_closed_t *ranges =
+        (roaring_uint32_range_closed_t *)malloc(
+            sizeof(roaring_uint32_range_closed_t) * (count + 1));
+    uint32_t num_ranges = 0;
+    for (uint32_t i = 0; i < count; i++) {
+        if (i == 0 || values[i] != values[i - 1] + 1) {
+            ranges[num_ranges].min = values[i];
+            ranges[num_ranges].max = values[i];
+            num_ranges++;
+        } else {
+            ranges[num_ranges - 1].max = values[i];
+        }
+    }
+    *num_ranges_out = num_ranges;
+    return ranges;
+}
+
+/*
+ * Read all ranges forward in batches of ${step}, comparing against ${expected}.
+ */
+static void ranges_read_compare(roaring_bitmap_t *r,
+                                const roaring_uint32_range_closed_t *expected,
+                                uint32_t num_ranges, uint32_t step) {
+    roaring_uint32_iterator_t *iter = roaring_iterator_create(r);
+    roaring_uint32_range_closed_t *buffer =
+        (roaring_uint32_range_closed_t *)malloc(
+            sizeof(roaring_uint32_range_closed_t) * step);
+    uint32_t ranges_read = 0;
+    while (ranges_read < num_ranges) {
+        assert_true(iter->has_value);
+        assert_int_equal(iter->current_value, expected[ranges_read].min);
+
+        size_t got = roaring_uint32_iterator_read_ranges(iter, buffer, step);
+        size_t expect = minimum_uint32(step, num_ranges - ranges_read);
+        assert_int_equal(got, expect);
+        for (size_t i = 0; i < got; i++) {
+            assert_int_equal(buffer[i].min, expected[ranges_read + i].min);
+            assert_int_equal(buffer[i].max, expected[ranges_read + i].max);
+        }
+        ranges_read += got;
+    }
+    assert_false(iter->has_value);
+    size_t got = roaring_uint32_iterator_read_ranges(iter, buffer, step);
+    assert_int_equal(got, 0);
+    assert_false(iter->has_value);
+
+    free(buffer);
+    roaring_uint32_iterator_free(iter);
+}
+
+/*
+ * Read all ranges backward in batches of ${step}, comparing against
+ * ${expected} (which is in forward order).
+ */
+static void ranges_read_prev_compare(
+    roaring_bitmap_t *r, const roaring_uint32_range_closed_t *expected,
+    uint32_t num_ranges, uint32_t step) {
+    roaring_uint32_iterator_t iter;
+    roaring_iterator_init_last(r, &iter);
+    roaring_uint32_range_closed_t *buffer =
+        (roaring_uint32_range_closed_t *)malloc(
+            sizeof(roaring_uint32_range_closed_t) * step);
+    uint32_t ranges_read = 0;
+    while (ranges_read < num_ranges) {
+        assert_true(iter.has_value);
+        uint32_t range_idx = num_ranges - 1 - ranges_read;
+        assert_int_equal(iter.current_value, expected[range_idx].max);
+
+        size_t got =
+            roaring_uint32_iterator_read_prev_ranges(&iter, buffer, step);
+        size_t expect = minimum_uint32(step, num_ranges - ranges_read);
+        assert_int_equal(got, expect);
+        for (size_t i = 0; i < got; i++) {
+            uint32_t idx = num_ranges - 1 - ranges_read - (uint32_t)i;
+            assert_int_equal(buffer[i].min, expected[idx].min);
+            assert_int_equal(buffer[i].max, expected[idx].max);
+        }
+        ranges_read += (uint32_t)got;
+    }
+    assert_false(iter.has_value);
+    size_t got = roaring_uint32_iterator_read_prev_ranges(&iter, buffer, step);
+    assert_int_equal(got, 0);
+    assert_false(iter.has_value);
+
+    free(buffer);
+}
+
+static void test_read_ranges_iterator(uint8_t type) {
+    uint32_t *ref_values;
+    uint32_t ref_count;
+    test_iterator_generate_data(&ref_values, &ref_count);
+
+    roaring_bitmap_t *r = roaring_bitmap_create();
+    for (uint32_t i = 0; i < ref_count; i++) {
+        roaring_bitmap_add(r, ref_values[i]);
+    }
+    if (type != UINT8_MAX) {
+        convert_all_containers(r, type);
+    }
+
+    // Zero count should be a no-op
+    roaring_uint32_iterator_t *iter = roaring_iterator_create(r);
+    roaring_uint32_range_closed_t buf[1];
+    size_t got = roaring_uint32_iterator_read_ranges(iter, buf, 0);
+    assert_int_equal(got, 0);
+    assert_true(iter->has_value);
+    assert_int_equal(iter->current_value, 0);
+    roaring_uint32_iterator_free(iter);
+
+    uint32_t num_ranges;
+    roaring_uint32_range_closed_t *expected =
+        ranges_from_values(ref_values, ref_count, &num_ranges);
+
+    ranges_read_compare(r, expected, num_ranges, 1);
+    ranges_read_compare(r, expected, num_ranges, 2);
+    ranges_read_compare(r, expected, num_ranges, 7);
+    ranges_read_compare(r, expected, num_ranges, 100000);
+
+    free(expected);
+    roaring_bitmap_free(r);
+    free(ref_values);
+}
+
+DEFINE_TEST(test_read_ranges_iterator_array) {
+    test_read_ranges_iterator(ARRAY_CONTAINER_TYPE);
+}
+DEFINE_TEST(test_read_ranges_iterator_bitset) {
+    test_read_ranges_iterator(BITSET_CONTAINER_TYPE);
+}
+DEFINE_TEST(test_read_ranges_iterator_run) {
+    test_read_ranges_iterator(RUN_CONTAINER_TYPE);
+}
+DEFINE_TEST(test_read_ranges_iterator_native) {
+    test_read_ranges_iterator(UINT8_MAX);
+}
+
+static void test_read_prev_ranges_iterator(uint8_t type) {
+    uint32_t *ref_values;
+    uint32_t ref_count;
+    test_iterator_generate_data(&ref_values, &ref_count);
+
+    roaring_bitmap_t *r = roaring_bitmap_create();
+    for (uint32_t i = 0; i < ref_count; i++) {
+        roaring_bitmap_add(r, ref_values[i]);
+    }
+    if (type != UINT8_MAX) {
+        convert_all_containers(r, type);
+    }
+
+    // Zero count should be a no-op
+    roaring_uint32_iterator_t iter;
+    roaring_iterator_init_last(r, &iter);
+    roaring_uint32_range_closed_t buf[1];
+    size_t got = roaring_uint32_iterator_read_prev_ranges(&iter, buf, 0);
+    assert_int_equal(got, 0);
+    assert_true(iter.has_value);
+    assert_int_equal(iter.current_value, UINT32_MAX);
+
+    uint32_t num_ranges;
+    roaring_uint32_range_closed_t *expected =
+        ranges_from_values(ref_values, ref_count, &num_ranges);
+
+    ranges_read_prev_compare(r, expected, num_ranges, 1);
+    ranges_read_prev_compare(r, expected, num_ranges, 2);
+    ranges_read_prev_compare(r, expected, num_ranges, 7);
+    ranges_read_prev_compare(r, expected, num_ranges, 100000);
+
+    free(expected);
+    roaring_bitmap_free(r);
+    free(ref_values);
+}
+
+DEFINE_TEST(test_read_prev_ranges_iterator_array) {
+    test_read_prev_ranges_iterator(ARRAY_CONTAINER_TYPE);
+}
+DEFINE_TEST(test_read_prev_ranges_iterator_bitset) {
+    test_read_prev_ranges_iterator(BITSET_CONTAINER_TYPE);
+}
+DEFINE_TEST(test_read_prev_ranges_iterator_run) {
+    test_read_prev_ranges_iterator(RUN_CONTAINER_TYPE);
+}
+DEFINE_TEST(test_read_prev_ranges_iterator_native) {
+    test_read_prev_ranges_iterator(UINT8_MAX);
+}
+
+DEFINE_TEST(test_read_ranges_empty_bitmap) {
+    roaring_bitmap_t *r = roaring_bitmap_create();
+    roaring_uint32_range_closed_t buf[1];
+
+    // Forward
+    roaring_uint32_iterator_t *iter = roaring_iterator_create(r);
+    size_t got = roaring_uint32_iterator_read_ranges(iter, buf, 1);
+    assert_int_equal(got, 0);
+    assert_false(iter->has_value);
+    roaring_uint32_iterator_free(iter);
+
+    // Backward
+    roaring_uint32_iterator_t riter;
+    roaring_iterator_init_last(r, &riter);
+    got = roaring_uint32_iterator_read_prev_ranges(&riter, buf, 1);
+    assert_int_equal(got, 0);
+    assert_false(riter.has_value);
+
+    roaring_bitmap_free(r);
+}
+
+DEFINE_TEST(test_read_ranges_cross_container) {
+    roaring_bitmap_t *r = roaring_bitmap_create();
+
+    // Values spanning two containers: high16=0 ending, high16=1 starting
+    // This creates a single range [0xFFFE..0x10001]
+    roaring_bitmap_add(r, 0xFFFE);
+    roaring_bitmap_add(r, 0xFFFF);
+    roaring_bitmap_add(r, 0x10000);
+    roaring_bitmap_add(r, 0x10001);
+
+    roaring_bitmap_add(r, 0x20000);
+
+    roaring_uint32_range_closed_t buf[4];
+
+    roaring_uint32_iterator_t *iter = roaring_iterator_create(r);
+    size_t got = roaring_uint32_iterator_read_ranges(iter, buf, 4);
+    assert_int_equal(got, 2);
+    assert_int_equal(buf[0].min, 0xFFFE);
+    assert_int_equal(buf[0].max, 0x10001);
+    assert_int_equal(buf[1].min, 0x20000);
+    assert_int_equal(buf[1].max, 0x20000);
+    assert_false(iter->has_value);
+    roaring_uint32_iterator_free(iter);
+
+    roaring_uint32_iterator_t riter;
+    roaring_iterator_init_last(r, &riter);
+    got = roaring_uint32_iterator_read_prev_ranges(&riter, buf, 4);
+    assert_int_equal(got, 2);
+    assert_int_equal(buf[0].min, 0x20000);
+    assert_int_equal(buf[0].max, 0x20000);
+    assert_int_equal(buf[1].min, 0xFFFE);
+    assert_int_equal(buf[1].max, 0x10001);
+    assert_false(riter.has_value);
+
+    roaring_bitmap_free(r);
+}
+
+DEFINE_TEST(test_read_ranges_mid_range) {
+    roaring_bitmap_t *r = roaring_bitmap_create();
+    roaring_bitmap_add_range_closed(r, 0, 10);
+    roaring_bitmap_add_range_closed(r, 20, 25);
+
+    roaring_uint32_range_closed_t buf[4];
+
+    // Forward: start mid-range at 5, first range should be [5..10]
+    {
+        roaring_uint32_iterator_t *iter = roaring_iterator_create(r);
+        roaring_uint32_iterator_move_equalorlarger(iter, 5);
+        assert_int_equal(iter->current_value, 5);
+
+        size_t got = roaring_uint32_iterator_read_ranges(iter, buf, 4);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, 5);
+        assert_int_equal(buf[0].max, 10);
+        assert_int_equal(buf[1].min, 20);
+        assert_int_equal(buf[1].max, 25);
+        assert_false(iter->has_value);
+        roaring_uint32_iterator_free(iter);
+    }
+
+    // Backward: start mid-range at 22, first range should be [20..22]
+    {
+        roaring_uint32_iterator_t iter;
+        roaring_iterator_init_last(r, &iter);
+        roaring_uint32_iterator_move_equalorlarger(&iter, 22);
+        assert_int_equal(iter.current_value, 22);
+
+        size_t got = roaring_uint32_iterator_read_prev_ranges(&iter, buf, 4);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, 20);
+        assert_int_equal(buf[0].max, 22);
+        assert_int_equal(buf[1].min, 0);
+        assert_int_equal(buf[1].max, 10);
+        assert_false(iter.has_value);
+    }
+
+    roaring_bitmap_free(r);
+}
+
+DEFINE_TEST(test_read_ranges_interleaved) {
+    roaring_bitmap_t *r = roaring_bitmap_create();
+
+    // Ranges: [10..12], [20..20], [30..32], [40..40], [50..55]
+    roaring_bitmap_add_range_closed(r, 10, 12);
+    roaring_bitmap_add(r, 20);
+    roaring_bitmap_add_range_closed(r, 30, 32);
+    roaring_bitmap_add(r, 40);
+    roaring_bitmap_add_range_closed(r, 50, 55);
+
+    roaring_uint32_range_closed_t buf[4];
+
+    // read_ranges then advance then read_ranges
+    {
+        roaring_uint32_iterator_t *iter = roaring_iterator_create(r);
+        size_t got = roaring_uint32_iterator_read_ranges(iter, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, 10);
+        assert_int_equal(buf[0].max, 12);
+        // Iterator should be at 20
+        assert_true(iter->has_value);
+        assert_int_equal(iter->current_value, 20);
+
+        // advance past 20
+        roaring_uint32_iterator_advance(iter);
+        assert_true(iter->has_value);
+        assert_int_equal(iter->current_value, 30);
+
+        // read_ranges again
+        got = roaring_uint32_iterator_read_ranges(iter, buf, 2);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, 30);
+        assert_int_equal(buf[0].max, 32);
+        assert_int_equal(buf[1].min, 40);
+        assert_int_equal(buf[1].max, 40);
+
+        assert_true(iter->has_value);
+        assert_int_equal(iter->current_value, 50);
+        roaring_uint32_iterator_free(iter);
+    }
+
+    // read_ranges then move_equalorlarger then read_ranges
+    {
+        roaring_uint32_iterator_t *iter = roaring_iterator_create(r);
+        size_t got = roaring_uint32_iterator_read_ranges(iter, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, 10);
+        assert_int_equal(buf[0].max, 12);
+
+        // Jump ahead to 40
+        roaring_uint32_iterator_move_equalorlarger(iter, 40);
+        assert_true(iter->has_value);
+        assert_int_equal(iter->current_value, 40);
+
+        got = roaring_uint32_iterator_read_ranges(iter, buf, 4);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, 40);
+        assert_int_equal(buf[0].max, 40);
+        assert_int_equal(buf[1].min, 50);
+        assert_int_equal(buf[1].max, 55);
+        assert_false(iter->has_value);
+        roaring_uint32_iterator_free(iter);
+    }
+
+    // read_prev_ranges then previous then read_prev_ranges
+    {
+        roaring_uint32_iterator_t iter;
+        roaring_iterator_init_last(r, &iter);
+        size_t got = roaring_uint32_iterator_read_prev_ranges(&iter, buf, 1);
+        assert_int_equal(got, 1);
+        assert_int_equal(buf[0].min, 50);
+        assert_int_equal(buf[0].max, 55);
+        // Iterator should be at 40
+        assert_true(iter.has_value);
+        assert_int_equal(iter.current_value, 40);
+
+        // previous past 40
+        roaring_uint32_iterator_previous(&iter);
+        assert_true(iter.has_value);
+        assert_int_equal(iter.current_value, 32);
+
+        // read_prev_ranges again
+        got = roaring_uint32_iterator_read_prev_ranges(&iter, buf, 2);
+        assert_int_equal(got, 2);
+        assert_int_equal(buf[0].min, 30);
+        assert_int_equal(buf[0].max, 32);
+        assert_int_equal(buf[1].min, 20);
+        assert_int_equal(buf[1].max, 20);
+
+        assert_true(iter.has_value);
+        assert_int_equal(iter.current_value, 12);
+    }
+
+    roaring_bitmap_free(r);
+}
+
 DEFINE_TEST(test_add_range) {
     // autoconversion: BITSET -> BITSET -> RUN
     {
@@ -5170,6 +5557,18 @@ int main() {
         cmocka_unit_test(test_uint32_iterator_skip_backward_bitset),
         cmocka_unit_test(test_uint32_iterator_skip_backward_run),
         cmocka_unit_test(test_uint32_iterator_skip_backward_native),
+        cmocka_unit_test(test_read_ranges_iterator_array),
+        cmocka_unit_test(test_read_ranges_iterator_bitset),
+        cmocka_unit_test(test_read_ranges_iterator_run),
+        cmocka_unit_test(test_read_ranges_iterator_native),
+        cmocka_unit_test(test_read_prev_ranges_iterator_array),
+        cmocka_unit_test(test_read_prev_ranges_iterator_bitset),
+        cmocka_unit_test(test_read_prev_ranges_iterator_run),
+        cmocka_unit_test(test_read_prev_ranges_iterator_native),
+        cmocka_unit_test(test_read_ranges_empty_bitmap),
+        cmocka_unit_test(test_read_ranges_cross_container),
+        cmocka_unit_test(test_read_ranges_mid_range),
+        cmocka_unit_test(test_read_ranges_interleaved),
         cmocka_unit_test(test_add_range),
         cmocka_unit_test(test_remove_range),
         cmocka_unit_test(test_remove_many),


### PR DESCRIPTION
This adds `roaring_uint32_iterator_read_ranges` / `roaring_uint32_iterator_read_prev_ranges` to the 32-bit bitmap API, `roaring64_iterator_read_ranges` / `roaring64_iterator_read_prev_ranges` to the 64-bit bitmap API, and `read_ranges` / `read_prev_ranges` to the C++ `RoaringSetBitBiDirectionalIterator`. Each function reads up to N maximal consecutive ranges from the iterator in a single call, merging across internal container boundaries.

Closes #776 