### PR TITLE
Performance improvement array_container_contains()

### DIFF
--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -338,6 +338,10 @@ inline bool array_container_contains(const array_container_t *arr,
     int32_t low = 0;
     const uint16_t *carr = (const uint16_t *)arr->array;
     int32_t high = arr->cardinality - 1;
+    if (high > pos) {
+        // since elements are unique, x can be located only at index <= x
+        high = pos;
+    }
     //    while (high - low >= 0) {
     while (high >= low + 16) {
         int32_t middleIndex = (low + high) >> 1;
@@ -351,12 +355,19 @@ inline bool array_container_contains(const array_container_t *arr,
         }
     }
 
+    while (high >= low + 3) {
+        if (carr[low + 3] >= pos) {
+            return (carr[low] == pos) || (carr[low + 1] == pos) ||
+                   (carr[low + 2] == pos) || (carr[low + 3] == pos);
+        }
+        low += 4;
+    }
+
     for (int i = low; i <= high; i++) {
         uint16_t v = carr[i];
-        if (v == pos) {
-            return true;
+        if (v >= pos) {
+            return (v == pos);  // compiles into SETE
         }
-        if (v > pos) return false;
     }
     return false;
 }


### PR DESCRIPTION
1) Limit initial binsearch boundary by x value
2) Reorder conditional logic to follow the pattern "first find smallest item >= x", next perform return decision
3) Consume 16 remaining elements in blocks of four

Tested on KabyLake. Overall this gives ~33% improvement in array_container_benchmark:contains_test and ~8% improvement in real_bitmaps_contains_benchmark.

Before:
```
contains_test(B):  37.48 cycles per operation
contains_test(B):  37.48 cycles per operation
contains_test(B):  37.45 cycles per operation
contains_test(B):  37.47 cycles per operation
contains_test(B):  37.47 cycles per operation
Quartile queries on 200 bitmaps took 15299 cycles
Quartile queries on 200 bitmaps took 14222 cycles
Quartile queries on 200 bitmaps took 14945 cycles
Quartile queries on 200 bitmaps took 15525 cycles
Quartile queries on 200 bitmaps took 15311 cycles
```

After:
```
contains_test(B):  24.64 cycles per operation
contains_test(B):  24.55 cycles per operation
contains_test(B):  24.61 cycles per operation
contains_test(B):  24.62 cycles per operation
contains_test(B):  24.56 cycles per operation
Quartile queries on 200 bitmaps took 13898 cycles
Quartile queries on 200 bitmaps took 14159 cycles
Quartile queries on 200 bitmaps took 13608 cycles
Quartile queries on 200 bitmaps took 13995 cycles
Quartile queries on 200 bitmaps took 13706 cycles
```