### PR TITLE
Fix accidental deep copy in Roaring64Map::frozenView

### DIFF
--- a/cpp/roaring/roaring64map.hh
+++ b/cpp/roaring/roaring64map.hh
@@ -1287,8 +1287,8 @@ class Roaring64Map {
             buf += sizeof(uint32_t);
 
             // read map value Roaring
-            const Roaring read = Roaring::frozenView(buf, len);
-            result.emplaceOrInsert(key, read);
+            Roaring read = Roaring::frozenView(buf, len);
+            result.emplaceOrInsert(key, std::move(read));
 
             // forward buffer past the last Roaring Bitmap
             buf += len;


### PR DESCRIPTION
There is a unwanted deep copy when using the frozenView of the Roaring64Map since the const-ness causes the copy `Roaring` constructor to be called in `emplaceOrInsert`