### PR TITLE
Obvious optimization for array_container_offset

### DIFF
--- a/microbenchmarks/bench.cpp
+++ b/microbenchmarks/bench.cpp
@@ -514,6 +514,32 @@ auto ContainsWarmHigh =
     BasicBenchPerQuery<contains_warm_high, kWarmBitmaps * kWarmRepeats>;
 BENCHMARK(ContainsWarmHigh);
 
+// Note that input data matters: census1881 produces mostly array containers.
+template <uint64_t offset>
+struct add_offset {
+    static uint64_t run() {
+        uint64_t marker = 0;
+        for (size_t i = 0; i < count; ++i) {
+            roaring_bitmap_t *tmp =
+                roaring_bitmap_add_offset(bitmaps[i], offset);
+            marker += roaring_bitmap_get_cardinality(tmp);
+            roaring_bitmap_free(tmp);
+        }
+        return marker;
+    }
+};
+auto AddOffset1 = BasicBench<add_offset<1>>;
+BENCHMARK(AddOffset1);
+
+// prime number close to the half of the container capacity:
+// inhibits fast code paths and also stresses OR
+auto AddOffset32771 = BasicBench<add_offset<32771>>;
+BENCHMARK(AddOffset32771);
+
+// containers are cpoied verbatim, without tearing
+auto AddOffset65536 = BasicBench<add_offset<65536>>;
+BENCHMARK(AddOffset65536);
+
 int main(int argc, char **argv) {
     const char *dir_name;
     if ((argc == 1) || (argc > 1 && argv[1][0] == '-')) {

--- a/src/containers/array.c
+++ b/src/containers/array.c
@@ -111,17 +111,19 @@ void array_container_offset(const array_container_t *c, container_t **loc,
     if (loc && lo_cap) {
         lo = array_container_create_given_capacity(lo_cap);
         for (int i = 0; i < lo_cap; ++i) {
-            array_container_add(lo, c->array[i] + offset);
+            lo->array[i] = c->array[i] + offset;
         }
+        lo->cardinality = lo_cap;
         *loc = (container_t *)lo;
     }
 
     hi_cap = c->cardinality - lo_cap;
     if (hic && hi_cap) {
         hi = array_container_create_given_capacity(hi_cap);
-        for (int i = lo_cap; i < c->cardinality; ++i) {
-            array_container_add(hi, c->array[i] + offset);
+        for (int i = 0; i < hi_cap; ++i) {
+            hi->array[i] = c->array[lo_cap + i] + offset;
         }
+        hi->cardinality = hi_cap;
         *hic = (container_t *)hi;
     }
 }


### PR DESCRIPTION
`sudo microbenchmarks/bench --benchmark_filter=AddOffset`

Before (Intel, GCC-14):
```
AddOffset1        5221057 ns      5221064 ns          135 GHz=1.56291 cycles=7.83175M instructions=29.5835M
AddOffset32771    6584476 ns      6584493 ns          106 GHz=1.55978 cycles=10.1052M instructions=34.0348M
AddOffset65536     669515 ns       669480 ns         1072 GHz=1.59796 cycles=1.02286M instructions=1.44815M
```

After:
```
AddOffset1         803629 ns       803581 ns          882 GHz=1.59883 cycles=1.22918M instructions=2.23819M
AddOffset32771    2609924 ns      2609937 ns          267 GHz=1.5754 cycles=3.99144M instructions=8.60521M
AddOffset65536     679623 ns       679626 ns         1036 GHz=1.59769 cycles=1.03674M instructions=1.44928M
```

NB: clang-format check failure is not related to the files changed in this PR 