### PR TITLE
feat: Drop const from return type of c++ frozen view APIs

### DIFF
--- a/cpp/roaring/roaring.hh
+++ b/cpp/roaring/roaring.hh
@@ -713,7 +713,7 @@ class Roaring {
      * For advanced users.
      * This function may throw std::runtime_error.
      */
-    static const Roaring frozenView(const char *buf, size_t length) {
+    static Roaring frozenView(const char *buf, size_t length) {
         const roaring_bitmap_t *s =
             api::roaring_bitmap_frozen_view(buf, length);
         if (s == NULL) {
@@ -728,7 +728,7 @@ class Roaring {
      * For advanced users; see roaring_bitmap_portable_deserialize_frozen.
      * This function may throw std::runtime_error.
      */
-    static const Roaring portableDeserializeFrozen(const char *buf) {
+    static Roaring portableDeserializeFrozen(const char *buf) {
         const roaring_bitmap_t *s =
             api::roaring_bitmap_portable_deserialize_frozen(buf);
         if (s == NULL) {

--- a/cpp/roaring/roaring64map.hh
+++ b/cpp/roaring/roaring64map.hh
@@ -1260,7 +1260,7 @@ class Roaring64Map {
      * For advanced users only. This function is unsafe. You must ensure that
      * the provided buffer is 32-byte aligned.
      */
-    static const Roaring64Map frozenView(const char *buf) {
+    static Roaring64Map frozenView(const char *buf) {
         // We do not check that buf is 32-byte aligned. Caller is responsible.
         // size of bitmap buffer and key
         const size_t metadata_size = sizeof(size_t) + sizeof(uint32_t);
@@ -1300,7 +1300,7 @@ class Roaring64Map {
      * For advanced users only. This function is unsafe in the sense that
      * that it may trigger unaligned memory access. Use with caution.
      */
-    static const Roaring64Map portableDeserializeFrozen(const char *buf) {
+    static Roaring64Map portableDeserializeFrozen(const char *buf) {
         Roaring64Map result;
         // get map size
         uint64_t map_size;


### PR DESCRIPTION
Hi, this is a small follow-up to #804. Sending it as a PR since the diff is short (only 4 lines change), but happy to convert to an issue first if you'd rather discuss the signature change before reviewing code.

The four C++ frozen-view APIs return const T by value:

```
static const Roaring      Roaring::frozenView(const char *, size_t);
static const Roaring      Roaring::portableDeserializeFrozen(const char *);
static const Roaring64Map Roaring64Map::frozenView(const char *);
static const Roaring64Map Roaring64Map::portableDeserializeFrozen(const char *);
```

Because the returned value is a const rvalue, it can't bind to the move overloads (T&&), and overload resolution silently falls 
back to copy assignment / copy constructor. In the wrapper, that path goes through `roaring_bitmap_overwrite` → `ra_overwrite` → per-container `container_clone` (result of this is full deep clone of the bitmap).

So a natural pattern (e.g. a bitmap index holding many frozen views in a container) like:

```cpp
std::vector<Roaring> v;
v.push_back(Roaring::frozenView(buf, len));    // or:  v[i] = Roaring::frozenView(...)
```

ends up duplicating the user-supplied buffer on the heap, which is the opposite of what a "view" is supposed to do. This is the same root cause #804 worked around at the call site inside Roaring64Map::frozenView; dropping const from the signatures themselves addresses it for external callers as well.

Patch (example):
```diff
-static const Roaring frozenView(const char *buf, size_t length);
+static Roaring frozenView(const char *buf, size_t length);
```

After this, auto v = frozenView(...) no longer triggers a deep clone, and vec[i] = frozenView(...) binds to the move overload.

Compatibility

I went through the cases I could think of:

- `Roaring x = frozenView(...)` and `const Roaring x = frozenView(...)` still work.
- `auto x = frozenView(...)` — `x` is deduced as Roaring either way (top-level const is stripped). No change in behaviour.
- `decltype(frozenView(...))` does changes, but I wouldn't expect user code to depend on this?

Verification

All existing tests pass locally. I separately verified the runtime behaviour by checking that ROARING_FLAG_FROZEN survives a vec[i] = frozenView(...) assignment after the patch (it does not without it). I left the regression test out of this PR to keep the change minimal — happy to add one if you'd prefer it bundled here.

If you'd rather not change the signatures, alternative is to keep const and document in the header that callers should bind through a mutable local plus std::move (as #804 did internally) to avoid the deep clone.