### PR TITLE
Add buffered backward read iterator for roaring32 and roaring64

### DIFF
--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -2130,6 +2130,45 @@ void register_real_bitmaps(std::vector<Entry> &out, LoadedBitmaps *loaded,
         e.inner_reps = 20;
         out.push_back(std::move(e));
     }
+    {
+        struct S {
+            roaring_bitmap_t *bm;
+            uint64_t card;
+        };
+        Entry e;
+        e.name = "iteration/previous" + suffix;
+        e.description =
+            "Iterates backward over every value in the union (merged bitmap) "
+            "of all bitmaps in the \"" +
+            dataset +
+            "\" dataset using roaring_uint32_iterator_previous() — the "
+            "one-value-at-a-time backward API. Accumulates a sum of visited "
+            "values so the compiler cannot elide the loop. Reported cost "
+            "is per iterated value." +
+            in_dataset;
+        e.setup = [loaded]() -> void * {
+            auto *s = new S;
+            s->bm = loaded->merged;
+            s->card = roaring_bitmap_get_cardinality(loaded->merged);
+            return s;
+        };
+        e.run = [](void *sv) -> int64_t {
+            auto *s = static_cast<S *>(sv);
+            roaring_uint32_iterator_t it;
+            roaring_iterator_init_last(s->bm, &it);
+            uint64_t sum = 0;
+            while (it.has_value) {
+                sum += it.current_value;
+                roaring_uint32_iterator_previous(&it);
+            }
+            return static_cast<int64_t>(sum);
+        };
+        e.teardown = [](void *sv) { delete static_cast<S *>(sv); };
+        e.ops_per_run = static_cast<int64_t>(
+            roaring_bitmap_get_cardinality(loaded->merged));
+        e.inner_reps = 20;
+        out.push_back(std::move(e));
+    }
     const uint32_t bufsizes[] = {1, 4, 16, 128, 1024};
     for (uint32_t bs : bufsizes) {
         struct S {
@@ -2170,6 +2209,57 @@ void register_real_bitmaps(std::vector<Entry> &out, LoadedBitmaps *loaded,
             while (true) {
                 uint32_t got = roaring_uint32_iterator_read(&it, buffer.data(),
                                                             s->bufsize);
+                for (uint32_t i = 0; i < got; ++i) sum += buffer[i];
+                if (got < s->bufsize) break;
+            }
+            return static_cast<int64_t>(sum);
+        };
+        e.teardown = [](void *sv) { delete static_cast<S *>(sv); };
+        e.ops_per_run = static_cast<int64_t>(
+            roaring_bitmap_get_cardinality(loaded->merged));
+        e.inner_reps = 20;
+        out.push_back(std::move(e));
+    }
+
+    for (uint32_t bs : bufsizes) {
+        struct S {
+            roaring_bitmap_t *bm;
+            uint32_t bufsize;
+        };
+        Entry e;
+        char buf[96];
+        snprintf(buf, sizeof(buf), "iteration/read_backward/bufsize=%u/%s", bs,
+                 dataset.c_str());
+        e.name = buf;
+        char dbuf[768];
+        snprintf(dbuf, sizeof(dbuf),
+                 "Iterates backward over every value in the merged bitmap "
+                 "(union of all bitmaps in the \"%s\" dataset) using "
+                 "roaring_uint32_iterator_read_backward() with a %u-element "
+                 "buffer. Each call drains up to %u values, amortising "
+                 "the iterator state machine over multiple values. "
+                 "Comparing the bufsize=1 variant against "
+                 "iteration/previous shows the per-call overhead of "
+                 "previous(); comparing larger bufsizes shows where the "
+                 "amortisation plateaus. Reported cost is per iterated "
+                 "value.%s",
+                 dataset.c_str(), bs, bs, in_dataset.c_str());
+        e.description = dbuf;
+        e.setup = [loaded, bs]() -> void * {
+            auto *s = new S;
+            s->bm = loaded->merged;
+            s->bufsize = bs;
+            return s;
+        };
+        e.run = [](void *sv) -> int64_t {
+            auto *s = static_cast<S *>(sv);
+            std::vector<uint32_t> buffer(s->bufsize);
+            roaring_uint32_iterator_t it;
+            roaring_iterator_init_last(s->bm, &it);
+            uint64_t sum = 0;
+            while (true) {
+                uint32_t got = roaring_uint32_iterator_read_backward(
+                    &it, buffer.data(), s->bufsize);
                 for (uint32_t i = 0; i < got; ++i) sum += buffer[i];
                 if (got < s->bufsize) break;
             }

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -2611,6 +2611,32 @@ bool container_iterator_read_into_uint64(const container_t *c, uint8_t typecode,
                                          uint16_t *value_out);
 
 /**
+ * Reads up to `count` entries backward from the container, writing them into
+ * `buf` as `high16 | entry` in descending order. Returns true and sets
+ * `value_out` if a value is present before the entries read. Sets `consumed`
+ * to the number of values read. `count` should be greater than zero.
+ *
+ * `value_out` must be initialized to the current value yielded by the iterator.
+ */
+bool container_iterator_read_backward_into_uint32(
+    const container_t *c, uint8_t typecode, roaring_container_iterator_t *it,
+    uint32_t high16, uint32_t *buf, uint32_t count, uint32_t *consumed,
+    uint16_t *value_out);
+
+/**
+ * Reads up to `count` entries backward from the container, writing them into
+ * `buf` as `high48 | entry` in descending order. Returns true and sets
+ * `value_out` if a value is present before the entries read. Sets `consumed`
+ * to the number of values read. `count` should be greater than zero.
+ *
+ * `value_out` must be initialized to the current value yielded by the iterator.
+ */
+bool container_iterator_read_backward_into_uint64(
+    const container_t *c, uint8_t typecode, roaring_container_iterator_t *it,
+    uint64_t high48, uint64_t *buf, uint32_t count, uint32_t *consumed,
+    uint16_t *value_out);
+
+/**
  * Skips the next `skip_count` entries in the container iterator. Returns true
  * and sets `value_out` if a value is present after skipping. Returns false if
  * the end of the container is reached during the skip operation. Sets

--- a/include/roaring/roaring.h
+++ b/include/roaring/roaring.h
@@ -1258,6 +1258,23 @@ CROARING_DEPRECATED static inline uint32_t roaring_read_uint32_iterator(
 }
 
 /**
+ * Reads previous ${count} values from iterator into user-supplied ${buf}.
+ * Returns the number of read elements.
+ * This number can be smaller than ${count}, which means that iterator is
+ * drained.
+ *
+ * Values are written in descending order: buf[0] is the highest (current)
+ * value, buf[ret-1] is the lowest value read.
+ *
+ * This function satisfies semantics of reverse iteration and can be used
+ * together with other iterator functions.
+ *  - first value is copied from ${it}->current_value
+ *  - after function returns, iterator is positioned at the previous element
+ */
+uint32_t roaring_uint32_iterator_read_backward(roaring_uint32_iterator_t *it,
+                                               uint32_t *buf, uint32_t count);
+
+/**
  * Skip the next ${count} values from iterator.
  * Returns the number of values actually skipped.
  * The number can be smaller than ${count}, which means that iterator is

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -813,6 +813,23 @@ bool roaring64_iterator_move_equalorlarger(roaring64_iterator_t *it,
 uint64_t roaring64_iterator_read(roaring64_iterator_t *it, uint64_t *buf,
                                  uint64_t count);
 
+/**
+ * Reads previous ${count} values from iterator into user-supplied ${buf}.
+ * Returns the number of read elements.
+ * This number can be smaller than ${count}, which means that iterator is
+ * drained.
+ *
+ * Values are written in descending order: buf[0] is the highest (current)
+ * value, buf[ret-1] is the lowest value read.
+ *
+ * This function satisfies semantics of reverse iteration and can be used
+ * together with other iterator functions.
+ *  - first value is copied from the current iterator value
+ *  - after function returns, iterator is positioned at the previous element
+ */
+uint64_t roaring64_iterator_read_backward(roaring64_iterator_t *it,
+                                          uint64_t *buf, uint64_t count);
+
 typedef struct roaring64_range_closed_s {
     uint64_t min;
     uint64_t max;

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -595,6 +595,180 @@ bool container_iterator_read_into_uint64(const container_t *c, uint8_t typecode,
     }
 }
 
+bool container_iterator_read_backward_into_uint32(
+    const container_t *c, uint8_t typecode, roaring_container_iterator_t *it,
+    uint32_t high16, uint32_t *buf, uint32_t count, uint32_t *consumed,
+    uint16_t *value_out) {
+    *consumed = 0;
+    if (count == 0) {
+        return false;
+    }
+    switch (typecode) {
+        case BITSET_CONTAINER_TYPE: {
+            const bitset_container_t *bc = const_CAST_bitset(c);
+            uint32_t wordindex = it->index / 64;
+            uint64_t word =
+                bc->words[wordindex] & (UINT64_MAX >> (63 - (it->index % 64)));
+            do {
+                // Read set bits.
+                while (word != 0 && *consumed < count) {
+                    uint32_t bit = 63 - roaring_leading_zeroes(word);
+                    *buf = high16 | (wordindex * 64 + bit);
+                    word &= ~(UINT64_C(1) << bit);
+                    buf++;
+                    (*consumed)++;
+                }
+                // Skip unset bits.
+                while (word == 0 && wordindex > 0) {
+                    wordindex--;
+                    word = bc->words[wordindex];
+                }
+            } while (word != 0 && *consumed < count);
+
+            if (word != 0) {
+                it->index =
+                    wordindex * 64 + (63 - roaring_leading_zeroes(word));
+                *value_out = it->index;
+                return true;
+            }
+            return false;
+        }
+        case ARRAY_CONTAINER_TYPE: {
+            const array_container_t *ac = const_CAST_array(c);
+            uint32_t num_values =
+                minimum_uint32((uint32_t)(it->index + 1), count);
+            for (uint32_t i = 0; i < num_values; i++) {
+                buf[i] = high16 | ac->array[it->index - i];
+            }
+            *consumed += num_values;
+            it->index -= num_values;
+            if (it->index >= 0) {
+                *value_out = ac->array[it->index];
+                return true;
+            }
+            return false;
+        }
+        case RUN_CONTAINER_TYPE: {
+            const run_container_t *rc = const_CAST_run(c);
+            do {
+                uint32_t run_start = rc->runs[it->index].value;
+                uint32_t num_values = minimum_uint32(*value_out - run_start + 1,
+                                                     count - *consumed);
+                for (uint32_t i = 0; i < num_values; i++) {
+                    buf[i] = high16 | (*value_out - i);
+                }
+                *value_out -= num_values;
+                buf += num_values;
+                *consumed += num_values;
+
+                // We check for `value == UINT16_MAX` because
+                // `*value_out -= num_values` can underflow when
+                // `value == 0` (run_start == 0). In this case `value`
+                // will underflow to UINT16_MAX.
+                if (*value_out < run_start || *value_out == UINT16_MAX) {
+                    it->index--;
+                    if (it->index >= 0) {
+                        *value_out = rc->runs[it->index].value +
+                                     rc->runs[it->index].length;
+                    } else {
+                        return false;
+                    }
+                }
+            } while (*consumed < count);
+            return true;
+        }
+        default:
+            assert(false);
+            roaring_unreachable;
+            return 0;
+    }
+}
+
+bool container_iterator_read_backward_into_uint64(
+    const container_t *c, uint8_t typecode, roaring_container_iterator_t *it,
+    uint64_t high48, uint64_t *buf, uint32_t count, uint32_t *consumed,
+    uint16_t *value_out) {
+    *consumed = 0;
+    if (count == 0) {
+        return false;
+    }
+    switch (typecode) {
+        case BITSET_CONTAINER_TYPE: {
+            const bitset_container_t *bc = const_CAST_bitset(c);
+            uint32_t wordindex = it->index / 64;
+            uint64_t word =
+                bc->words[wordindex] & (UINT64_MAX >> (63 - (it->index % 64)));
+            do {
+                // Read set bits.
+                while (word != 0 && *consumed < count) {
+                    uint32_t bit = 63 - roaring_leading_zeroes(word);
+                    *buf = high48 | (wordindex * 64 + bit);
+                    word &= ~(UINT64_C(1) << bit);
+                    buf++;
+                    (*consumed)++;
+                }
+                // Skip unset bits.
+                while (word == 0 && wordindex > 0) {
+                    wordindex--;
+                    word = bc->words[wordindex];
+                }
+            } while (word != 0 && *consumed < count);
+
+            if (word != 0) {
+                it->index =
+                    wordindex * 64 + (63 - roaring_leading_zeroes(word));
+                *value_out = it->index;
+                return true;
+            }
+            return false;
+        }
+        case ARRAY_CONTAINER_TYPE: {
+            const array_container_t *ac = const_CAST_array(c);
+            uint32_t num_values =
+                minimum_uint32((uint32_t)(it->index + 1), count);
+            for (uint32_t i = 0; i < num_values; i++) {
+                buf[i] = high48 | ac->array[it->index - i];
+            }
+            *consumed += num_values;
+            it->index -= num_values;
+            if (it->index >= 0) {
+                *value_out = ac->array[it->index];
+                return true;
+            }
+            return false;
+        }
+        case RUN_CONTAINER_TYPE: {
+            const run_container_t *rc = const_CAST_run(c);
+            do {
+                uint32_t run_start = rc->runs[it->index].value;
+                uint32_t num_values = minimum_uint32(*value_out - run_start + 1,
+                                                     count - *consumed);
+                for (uint32_t i = 0; i < num_values; i++) {
+                    buf[i] = high48 | (*value_out - i);
+                }
+                *value_out -= num_values;
+                buf += num_values;
+                *consumed += num_values;
+
+                if (*value_out < run_start || *value_out == UINT16_MAX) {
+                    it->index--;
+                    if (it->index >= 0) {
+                        *value_out = rc->runs[it->index].value +
+                                     rc->runs[it->index].length;
+                    } else {
+                        return false;
+                    }
+                }
+            } while (*consumed < count);
+            return true;
+        }
+        default:
+            assert(false);
+            roaring_unreachable;
+            return 0;
+    }
+}
+
 bool container_iterator_skip(const container_t *c, uint8_t typecode,
                              roaring_container_iterator_t *it,
                              uint32_t skip_count, uint32_t *consumed_count,

--- a/src/roaring.c
+++ b/src/roaring.c
@@ -1872,12 +1872,37 @@ uint32_t roaring_uint32_iterator_read(roaring_uint32_iterator_t *it,
             it->has_value = true;
             it->current_value = it->highbits | low16;
             // If the container still has values, we must have stopped because
-            // we skipped enough values.
+            // we read enough values.
             assert(ret == count);
             return ret;
         }
         it->container_index++;
         it->has_value = loadfirstvalue(it);
+    }
+    return ret;
+}
+
+uint32_t roaring_uint32_iterator_read_backward(roaring_uint32_iterator_t *it,
+                                               uint32_t *buf, uint32_t count) {
+    uint32_t ret = 0;
+    while (it->has_value && ret < count) {
+        uint32_t consumed;
+        uint16_t low16 = (uint16_t)it->current_value;
+        bool has_value = container_iterator_read_backward_into_uint32(
+            it->container, it->typecode, &it->container_it, it->highbits, buf,
+            count - ret, &consumed, &low16);
+        ret += consumed;
+        buf += consumed;
+        if (has_value) {
+            it->has_value = true;
+            it->current_value = it->highbits | low16;
+            // If the container still has values, we must have stopped because
+            // we read enough values.
+            assert(ret == count);
+            return ret;
+        }
+        it->container_index--;
+        it->has_value = loadlastvalue(it);
     }
     return ret;
 }

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -2897,6 +2897,38 @@ uint64_t roaring64_iterator_read(roaring64_iterator_t *it, uint64_t *buf,
     return consumed;
 }
 
+uint64_t roaring64_iterator_read_backward(roaring64_iterator_t *it,
+                                          uint64_t *buf, uint64_t count) {
+    uint64_t consumed = 0;
+    while (it->has_value && consumed < count) {
+        uint32_t container_consumed;
+        leaf_t leaf = *it->art_it.value;
+        uint16_t low16 = (uint16_t)it->value;
+        uint32_t container_count = UINT32_MAX;
+        if (count - consumed < (uint64_t)UINT32_MAX) {
+            container_count = count - consumed;
+        }
+        bool has_value = container_iterator_read_backward_into_uint64(
+            get_container(it->r, leaf), get_typecode(leaf), &it->container_it,
+            it->high48, buf, container_count, &container_consumed, &low16);
+        consumed += container_consumed;
+        buf += container_consumed;
+        if (has_value) {
+            it->has_value = true;
+            it->value = it->high48 | low16;
+            assert(consumed == count);
+            return consumed;
+        }
+        it->has_value = art_iterator_prev(&it->art_it);
+        if (it->has_value) {
+            roaring64_iterator_init_at_leaf_last(it);
+        } else {
+            it->saturated_forward = false;
+        }
+    }
+    return consumed;
+}
+
 size_t roaring64_iterator_read_ranges(roaring64_iterator_t *it,
                                       roaring64_range_closed_t *buf,
                                       size_t count) {

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -34,6 +34,18 @@ void assert_vector_equal(const std::vector<uint64_t>& lhs,
     }
 }
 
+// Checks that lhs equals rhs in reverse order.
+void assert_vector_reversed(const std::vector<uint64_t>& lhs,
+                            const std::vector<uint64_t>& rhs) {
+    assert_int_equal(lhs.size(), rhs.size());
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        if (lhs[i] != rhs[rhs.size() - 1 - i]) {
+            printf("Mismatch at %zu\n", i);
+            assert_int_equal(lhs[i], rhs[rhs.size() - 1 - i]);
+        }
+    }
+}
+
 void assert_r32_valid(const roaring_bitmap_t* b) {
     const char* reason = nullptr;
     if (!roaring_bitmap_internal_validate(b, &reason)) {
@@ -2320,6 +2332,75 @@ DEFINE_TEST(test_iterator_read) {
     roaring64_bitmap_free(r);
 }
 
+// Reads all elements from the iterator backward, `step` values at a time, and
+// compares the elements with `values` in reverse order.
+void readBackwardCompare(const std::vector<uint64_t>& values,
+                         const roaring64_bitmap_t* r, uint64_t step) {
+    roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+    std::vector<uint64_t> buffer(step == UINT64_MAX ? values.size() : step, 0);
+    uint64_t read = 0;
+    while (read < values.size()) {
+        assert_true(roaring64_iterator_has_value(it));
+        uint64_t step_read =
+            roaring64_iterator_read_backward(it, buffer.data(), step);
+        assert_int_equal(step_read, std::min(step, values.size() - read));
+        for (size_t i = 0; i < step_read; ++i) {
+            assert_int_equal(values[values.size() - 1 - read - i], buffer[i]);
+        }
+        read += step_read;
+    }
+    assert_false(roaring64_iterator_has_value(it));
+    roaring64_iterator_free(it);
+}
+
+DEFINE_TEST(test_iterator_read_backward) {
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+    std::vector<uint64_t> values;
+    values.reserve(1000);
+    roaring64_bulk_context_t context{};
+    for (uint64_t i = 0; i < 1000; ++i) {
+        uint64_t v = i * 10000;
+        values.push_back(v);
+        roaring64_bitmap_add_bulk(r, &context, v);
+    }
+
+    {
+        // Check that a zero count results in zero elements read.
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+        uint64_t buf[1];
+        assert_int_equal(roaring64_iterator_read_backward(it, buf, 0), 0);
+        roaring64_iterator_free(it);
+    }
+
+    readBackwardCompare(values, r, 1);
+    readBackwardCompare(values, r, 2);
+    readBackwardCompare(values, r, values.size() - 1);
+    readBackwardCompare(values, r, values.size());
+    readBackwardCompare(values, r, values.size() + 1);
+
+    {
+        // A count of UINT64_MAX.
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+        std::vector<uint64_t> buf(values.size(), 0);
+        assert_int_equal(
+            roaring64_iterator_read_backward(it, buf.data(), UINT64_MAX), 1000);
+        assert_vector_reversed(buf, values);
+        roaring64_iterator_free(it);
+    }
+    {
+        // A count that becomes zero if cast to uint32.
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+        std::vector<uint64_t> buf(values.size(), 0);
+        assert_int_equal(roaring64_iterator_read_backward(it, buf.data(),
+                                                          0xFFFFFFFF00000000),
+                         1000);
+        assert_vector_reversed(buf, values);
+        roaring64_iterator_free(it);
+    }
+
+    roaring64_bitmap_free(r);
+}
+
 DEFINE_TEST(test_iterator_read_ranges) {
     roaring64_bitmap_t* r = roaring64_bitmap_create();
 
@@ -2791,6 +2872,7 @@ int main() {
         cmocka_unit_test(test_iterator_previous),
         cmocka_unit_test(test_iterator_move_equalorlarger),
         cmocka_unit_test(test_iterator_read),
+        cmocka_unit_test(test_iterator_read_backward),
         cmocka_unit_test(test_iterator_read_ranges),
         cmocka_unit_test(test_iterator_read_prev_ranges),
         cmocka_unit_test(test_iterator_read_ranges_mid_range),

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -4059,6 +4059,102 @@ DEFINE_TEST(test_read_uint32_iterator_native) {
     test_read_uint32_iterator(UINT8_MAX);  // special value
 }
 
+/*
+ * Read bitmap backward in steps of given size, compare with reference values.
+ * If step is UINT32_MAX (special value), then read single non-empty container
+ * at a time.
+ */
+void read_backward_compare(roaring_bitmap_t *r, const uint32_t *ref_values,
+                           uint32_t ref_count, uint32_t step) {
+    roaring_uint32_iterator_t *iter = roaring_iterator_create(r);
+    roaring_iterator_init_last(r, iter);
+    uint32_t *buffer =
+        malloc(sizeof(uint32_t) * (step == UINT32_MAX ? 65536 : step));
+    uint32_t remaining = ref_count;
+    while (remaining > 0) {
+        assert_true(iter->has_value == true);
+        assert_true(iter->current_value == ref_values[remaining - 1]);
+
+        uint32_t num_ask = step;
+        if (step == UINT32_MAX) {
+            num_ask = 0;
+            for (uint32_t i = remaining; i > 0; i--) {
+                if ((ref_values[i - 1] >> 16) ==
+                    (ref_values[remaining - 1] >> 16)) {
+                    num_ask++;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        uint32_t num_got =
+            roaring_uint32_iterator_read_backward(iter, buffer, num_ask);
+        assert_true(num_got == minimum_uint32(num_ask, remaining));
+        for (uint32_t i = 0; i < num_got; i++) {
+            assert_true(ref_values[remaining - 1 - i] == buffer[i]);
+        }
+        remaining -= num_got;
+    }
+
+    assert_true(iter->has_value == false);
+    assert_true(iter->current_value == UINT32_MAX);
+
+    assert_true(roaring_uint32_iterator_read_backward(iter, buffer, step) == 0);
+    assert_true(iter->has_value == false);
+    assert_true(iter->current_value == UINT32_MAX);
+
+    free(buffer);
+    roaring_uint32_iterator_free(iter);
+}
+
+void test_read_backward_uint32_iterator(uint8_t type) {
+    uint32_t *ref_values;
+    uint32_t ref_count;
+    test_iterator_generate_data(&ref_values, &ref_count);
+
+    roaring_bitmap_t *r = roaring_bitmap_create();
+    for (uint32_t i = 0; i < ref_count; i++) {
+        roaring_bitmap_add(r, ref_values[i]);
+    }
+    if (type != UINT8_MAX) {
+        convert_all_containers(r, type);
+    }
+
+    roaring_uint32_iterator_t *iter = roaring_iterator_create(r);
+    roaring_iterator_init_last(r, iter);
+    uint32_t buffer[1];
+    uint32_t got = roaring_uint32_iterator_read_backward(iter, buffer, 0);
+    assert_true(got == 0);
+    assert_true(iter->has_value);
+    assert_true(iter->current_value == ref_values[ref_count - 1]);
+    roaring_uint32_iterator_free(iter);
+
+    read_backward_compare(r, ref_values, ref_count, 1);
+    read_backward_compare(r, ref_values, ref_count, 2);
+    read_backward_compare(r, ref_values, ref_count, 7);
+    read_backward_compare(r, ref_values, ref_count, ref_count - 1);
+    read_backward_compare(r, ref_values, ref_count, ref_count);
+    read_backward_compare(r, ref_values, ref_count,
+                          UINT32_MAX);  // special value
+
+    roaring_bitmap_free(r);
+    free(ref_values);
+}
+
+DEFINE_TEST(test_read_backward_uint32_iterator_array) {
+    test_read_backward_uint32_iterator(ARRAY_CONTAINER_TYPE);
+}
+DEFINE_TEST(test_read_backward_uint32_iterator_bitset) {
+    test_read_backward_uint32_iterator(BITSET_CONTAINER_TYPE);
+}
+DEFINE_TEST(test_read_backward_uint32_iterator_run) {
+    test_read_backward_uint32_iterator(RUN_CONTAINER_TYPE);
+}
+DEFINE_TEST(test_read_backward_uint32_iterator_native) {
+    test_read_backward_uint32_iterator(UINT8_MAX);  // special value
+}
+
 void test_previous_iterator(uint8_t type) {
     uint32_t *ref_values;
     uint32_t ref_count;
@@ -5543,6 +5639,10 @@ int main() {
         cmocka_unit_test(test_read_uint32_iterator_bitset),
         cmocka_unit_test(test_read_uint32_iterator_run),
         cmocka_unit_test(test_read_uint32_iterator_native),
+        cmocka_unit_test(test_read_backward_uint32_iterator_array),
+        cmocka_unit_test(test_read_backward_uint32_iterator_bitset),
+        cmocka_unit_test(test_read_backward_uint32_iterator_run),
+        cmocka_unit_test(test_read_backward_uint32_iterator_native),
         cmocka_unit_test(test_previous_iterator_array),
         cmocka_unit_test(test_previous_iterator_bitset),
         cmocka_unit_test(test_previous_iterator_run),


### PR DESCRIPTION
### Summary

Implements `roaring_uint32_iterator_read_backward()` and `roaring64_iterator_read_backward()`
Reverse counterparts to `roaring_uint32_iterator_read()` and `roaring64_iterator_read()`

Fixes: https://github.com/RoaringBitmap/CRoaring/issues/812

---

The structure of the `backward` functions mirrors that of the forward functions, thus these changes are easier to review by comparing the diff between each.

<details>
<summary>Forward/backward iterator diffs</summary>

## Implementation

### container (uint32)

```diff
--- container_iterator_read_into_uint32
+++ container_iterator_read_backward_into_uint32
@@ -1,8 +1,7 @@
-bool container_iterator_read_into_uint32(const container_t *c, uint8_t typecode,
-                                         roaring_container_iterator_t *it,
-                                         uint32_t high16, uint32_t *buf,
-                                         uint32_t count, uint32_t *consumed,
-                                         uint16_t *value_out) {
+bool container_iterator_read_backward_into_uint32(
+    const container_t *c, uint8_t typecode, roaring_container_iterator_t *it,
+    uint32_t high16, uint32_t *buf, uint32_t count, uint32_t *consumed,
+    uint16_t *value_out) {
     *consumed = 0;
     if (count == 0) {
         return false;
@@ -12,26 +11,26 @@
             const bitset_container_t *bc = const_CAST_bitset(c);
             uint32_t wordindex = it->index / 64;
             uint64_t word =
-                bc->words[wordindex] & (UINT64_MAX << (it->index % 64));
+                bc->words[wordindex] & (UINT64_MAX >> (63 - (it->index % 64)));
             do {
                 // Read set bits.
                 while (word != 0 && *consumed < count) {
-                    *buf = high16 |
-                           (wordindex * 64 + roaring_trailing_zeroes(word));
-                    word = word & (word - 1);
+                    uint32_t bit = 63 - roaring_leading_zeroes(word);
+                    *buf = high16 | (wordindex * 64 + bit);
+                    word &= ~(UINT64_C(1) << bit);
                     buf++;
                     (*consumed)++;
                 }
                 // Skip unset bits.
-                while (word == 0 &&
-                       wordindex + 1 < BITSET_CONTAINER_SIZE_IN_WORDS) {
-                    wordindex++;
+                while (word == 0 && wordindex > 0) {
+                    wordindex--;
                     word = bc->words[wordindex];
                 }
             } while (word != 0 && *consumed < count);
 
             if (word != 0) {
-                it->index = wordindex * 64 + roaring_trailing_zeroes(word);
+                it->index =
+                    wordindex * 64 + (63 - roaring_leading_zeroes(word));
                 *value_out = it->index;
                 return true;
             }
@@ -40,13 +39,13 @@
         case ARRAY_CONTAINER_TYPE: {
             const array_container_t *ac = const_CAST_array(c);
             uint32_t num_values =
-                minimum_uint32(ac->cardinality - it->index, count);
+                minimum_uint32((uint32_t)(it->index + 1), count);
             for (uint32_t i = 0; i < num_values; i++) {
-                buf[i] = high16 | ac->array[it->index + i];
+                buf[i] = high16 | ac->array[it->index - i];
             }
             *consumed += num_values;
-            it->index += num_values;
-            if (it->index < ac->cardinality) {
+            it->index -= num_values;
+            if (it->index >= 0) {
                 *value_out = ac->array[it->index];
                 return true;
             }
@@ -55,24 +54,25 @@
         case RUN_CONTAINER_TYPE: {
             const run_container_t *rc = const_CAST_run(c);
             do {
-                uint32_t largest_run_value =
-                    rc->runs[it->index].value + rc->runs[it->index].length;
-                uint32_t num_values = minimum_uint32(
-                    largest_run_value - *value_out + 1, count - *consumed);
+                uint32_t run_start = rc->runs[it->index].value;
+                uint32_t num_values = minimum_uint32(*value_out - run_start + 1,
+                                                     count - *consumed);
                 for (uint32_t i = 0; i < num_values; i++) {
-                    buf[i] = high16 | (*value_out + i);
+                    buf[i] = high16 | (*value_out - i);
                 }
-                *value_out += num_values;
+                *value_out -= num_values;
                 buf += num_values;
                 *consumed += num_values;
 
-                // We check for `value == 0` because `it->value += num_values`
-                // can overflow when `value == UINT16_MAX`, and `count >
-                // length`. In this case `value` will overflow to 0.
-                if (*value_out > largest_run_value || *value_out == 0) {
-                    it->index++;
-                    if (it->index < rc->n_runs) {
-                        *value_out = rc->runs[it->index].value;
+                // We check for `value == UINT16_MAX` because
+                // `*value_out -= num_values` can underflow when
+                // `value == 0` (run_start == 0). In this case `value`
+                // will underflow to UINT16_MAX.
+                if (*value_out < run_start || *value_out == UINT16_MAX) {
+                    it->index--;
+                    if (it->index >= 0) {
+                        *value_out = rc->runs[it->index].value +
+                                     rc->runs[it->index].length;
                     } else {
                         return false;
                     }
```

### container (uint64)

```diff
--- container_iterator_read_into_uint64
+++ container_iterator_read_backward_into_uint64
@@ -1,8 +1,7 @@
-bool container_iterator_read_into_uint64(const container_t *c, uint8_t typecode,
-                                         roaring_container_iterator_t *it,
-                                         uint64_t high48, uint64_t *buf,
-                                         uint32_t count, uint32_t *consumed,
-                                         uint16_t *value_out) {
+bool container_iterator_read_backward_into_uint64(
+    const container_t *c, uint8_t typecode, roaring_container_iterator_t *it,
+    uint64_t high48, uint64_t *buf, uint32_t count, uint32_t *consumed,
+    uint16_t *value_out) {
     *consumed = 0;
     if (count == 0) {
         return false;
@@ -12,26 +11,26 @@
             const bitset_container_t *bc = const_CAST_bitset(c);
             uint32_t wordindex = it->index / 64;
             uint64_t word =
-                bc->words[wordindex] & (UINT64_MAX << (it->index % 64));
+                bc->words[wordindex] & (UINT64_MAX >> (63 - (it->index % 64)));
             do {
                 // Read set bits.
                 while (word != 0 && *consumed < count) {
-                    *buf = high48 |
-                           (wordindex * 64 + roaring_trailing_zeroes(word));
-                    word = word & (word - 1);
+                    uint32_t bit = 63 - roaring_leading_zeroes(word);
+                    *buf = high48 | (wordindex * 64 + bit);
+                    word &= ~(UINT64_C(1) << bit);
                     buf++;
                     (*consumed)++;
                 }
                 // Skip unset bits.
-                while (word == 0 &&
-                       wordindex + 1 < BITSET_CONTAINER_SIZE_IN_WORDS) {
-                    wordindex++;
+                while (word == 0 && wordindex > 0) {
+                    wordindex--;
                     word = bc->words[wordindex];
                 }
             } while (word != 0 && *consumed < count);
 
             if (word != 0) {
-                it->index = wordindex * 64 + roaring_trailing_zeroes(word);
+                it->index =
+                    wordindex * 64 + (63 - roaring_leading_zeroes(word));
                 *value_out = it->index;
                 return true;
             }
@@ -40,13 +39,13 @@
         case ARRAY_CONTAINER_TYPE: {
             const array_container_t *ac = const_CAST_array(c);
             uint32_t num_values =
-                minimum_uint32(ac->cardinality - it->index, count);
+                minimum_uint32((uint32_t)(it->index + 1), count);
             for (uint32_t i = 0; i < num_values; i++) {
-                buf[i] = high48 | ac->array[it->index + i];
+                buf[i] = high48 | ac->array[it->index - i];
             }
             *consumed += num_values;
-            it->index += num_values;
-            if (it->index < ac->cardinality) {
+            it->index -= num_values;
+            if (it->index >= 0) {
                 *value_out = ac->array[it->index];
                 return true;
             }
@@ -55,24 +54,21 @@
         case RUN_CONTAINER_TYPE: {
             const run_container_t *rc = const_CAST_run(c);
             do {
-                uint32_t largest_run_value =
-                    rc->runs[it->index].value + rc->runs[it->index].length;
-                uint32_t num_values = minimum_uint32(
-                    largest_run_value - *value_out + 1, count - *consumed);
+                uint32_t run_start = rc->runs[it->index].value;
+                uint32_t num_values = minimum_uint32(*value_out - run_start + 1,
+                                                     count - *consumed);
                 for (uint32_t i = 0; i < num_values; i++) {
-                    buf[i] = high48 | (*value_out + i);
+                    buf[i] = high48 | (*value_out - i);
                 }
-                *value_out += num_values;
+                *value_out -= num_values;
                 buf += num_values;
                 *consumed += num_values;
 
-                // We check for `value == 0` because `it->value += num_values`
-                // can overflow when `value == UINT16_MAX`, and `count >
-                // length`. In this case `value` will overflow to 0.
-                if (*value_out > largest_run_value || *value_out == 0) {
-                    it->index++;
-                    if (it->index < rc->n_runs) {
-                        *value_out = rc->runs[it->index].value;
+                if (*value_out < run_start || *value_out == UINT16_MAX) {
+                    it->index--;
+                    if (it->index >= 0) {
+                        *value_out = rc->runs[it->index].value +
+                                     rc->runs[it->index].length;
                     } else {
                         return false;
                     }
```

### roaring_uint32_iterator

```diff
--- roaring_uint32_iterator_read
+++ roaring_uint32_iterator_read_backward
@@ -1,10 +1,10 @@
-uint32_t roaring_uint32_iterator_read(roaring_uint32_iterator_t *it,
-                                      uint32_t *buf, uint32_t count) {
+uint32_t roaring_uint32_iterator_read_backward(roaring_uint32_iterator_t *it,
+                                               uint32_t *buf, uint32_t count) {
     uint32_t ret = 0;
     while (it->has_value && ret < count) {
         uint32_t consumed;
         uint16_t low16 = (uint16_t)it->current_value;
-        bool has_value = container_iterator_read_into_uint32(
+        bool has_value = container_iterator_read_backward_into_uint32(
             it->container, it->typecode, &it->container_it, it->highbits, buf,
             count - ret, &consumed, &low16);
         ret += consumed;
@@ -17,8 +17,8 @@
             assert(ret == count);
             return ret;
         }
-        it->container_index++;
-        it->has_value = loadfirstvalue(it);
+        it->container_index--;
+        it->has_value = loadlastvalue(it);
     }
     return ret;
 }
```

### roaring64_iterator

```diff
--- roaring64_iterator_read
+++ roaring64_iterator_read_backward
@@ -1,15 +1,15 @@
-uint64_t roaring64_iterator_read(roaring64_iterator_t *it, uint64_t *buf,
-                                 uint64_t count) {
+uint64_t roaring64_iterator_read_backward(roaring64_iterator_t *it,
+                                          uint64_t *buf, uint64_t count) {
     uint64_t consumed = 0;
     while (it->has_value && consumed < count) {
         uint32_t container_consumed;
-        leaf_t leaf = (leaf_t)*it->art_it.value;
+        leaf_t leaf = *it->art_it.value;
         uint16_t low16 = (uint16_t)it->value;
         uint32_t container_count = UINT32_MAX;
         if (count - consumed < (uint64_t)UINT32_MAX) {
             container_count = count - consumed;
         }
-        bool has_value = container_iterator_read_into_uint64(
+        bool has_value = container_iterator_read_backward_into_uint64(
             get_container(it->r, leaf), get_typecode(leaf), &it->container_it,
             it->high48, buf, container_count, &container_consumed, &low16);
         consumed += container_consumed;
@@ -20,11 +20,11 @@
             assert(consumed == count);
             return consumed;
         }
-        it->has_value = art_iterator_next(&it->art_it);
+        it->has_value = art_iterator_prev(&it->art_it);
         if (it->has_value) {
-            roaring64_iterator_init_at_leaf_first(it);
+            roaring64_iterator_init_at_leaf_last(it);
         } else {
-            it->saturated_forward = true;
+            it->saturated_forward = false;
         }
     }
     return consumed;
```

## Tests (roaring64_unit.cpp)

### readCompare helper

```diff
--- readCompare
+++ readBackwardCompare
@@ -1,14 +1,15 @@
-void readCompare(const std::vector<uint64_t>& values,
-                 const roaring64_bitmap_t* r, uint64_t step) {
-    roaring64_iterator_t* it = roaring64_iterator_create(r);
-    std::vector<uint64_t> buffer(values.size(), 0);
+void readBackwardCompare(const std::vector<uint64_t>& values,
+                         const roaring64_bitmap_t* r, uint64_t step) {
+    roaring64_iterator_t* it = roaring64_iterator_create_last(r);
+    std::vector<uint64_t> buffer(step == UINT64_MAX ? values.size() : step, 0);
     uint64_t read = 0;
     while (read < values.size()) {
         assert_true(roaring64_iterator_has_value(it));
-        uint64_t step_read = roaring64_iterator_read(it, buffer.data(), step);
+        uint64_t step_read =
+            roaring64_iterator_read_backward(it, buffer.data(), step);
         assert_int_equal(step_read, std::min(step, values.size() - read));
         for (size_t i = 0; i < step_read; ++i) {
-            assert_int_equal(values[read + i], buffer[i]);
+            assert_int_equal(values[values.size() - 1 - read - i], buffer[i]);
         }
         read += step_read;
     }
```

### test_iterator_read

```diff
--- test_iterator_read
+++ test_iterator_read_backward
@@ -1,4 +1,4 @@
-DEFINE_TEST(test_iterator_read) {
+DEFINE_TEST(test_iterator_read_backward) {
     roaring64_bitmap_t* r = roaring64_bitmap_create();
     std::vector<uint64_t> values;
     values.reserve(1000);
@@ -11,34 +11,35 @@
 
     {
         // Check that a zero count results in zero elements read.
-        roaring64_iterator_t* it = roaring64_iterator_create(r);
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
         uint64_t buf[1];
-        assert_int_equal(roaring64_iterator_read(it, buf, 0), 0);
+        assert_int_equal(roaring64_iterator_read_backward(it, buf, 0), 0);
         roaring64_iterator_free(it);
     }
 
-    readCompare(values, r, 1);
-    readCompare(values, r, 2);
-    readCompare(values, r, values.size() - 1);
-    readCompare(values, r, values.size());
-    readCompare(values, r, values.size() + 1);
+    readBackwardCompare(values, r, 1);
+    readBackwardCompare(values, r, 2);
+    readBackwardCompare(values, r, values.size() - 1);
+    readBackwardCompare(values, r, values.size());
+    readBackwardCompare(values, r, values.size() + 1);
 
     {
         // A count of UINT64_MAX.
-        roaring64_iterator_t* it = roaring64_iterator_create(r);
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
         std::vector<uint64_t> buf(values.size(), 0);
-        assert_int_equal(roaring64_iterator_read(it, buf.data(), UINT64_MAX),
-                         1000);
-        assert_vector_equal(buf, values);
+        assert_int_equal(
+            roaring64_iterator_read_backward(it, buf.data(), UINT64_MAX), 1000);
+        assert_vector_reversed(buf, values);
         roaring64_iterator_free(it);
     }
     {
         // A count that becomes zero if cast to uint32.
-        roaring64_iterator_t* it = roaring64_iterator_create(r);
+        roaring64_iterator_t* it = roaring64_iterator_create_last(r);
         std::vector<uint64_t> buf(values.size(), 0);
-        assert_int_equal(
-            roaring64_iterator_read(it, buf.data(), 0xFFFFFFFF00000000), 1000);
-        assert_vector_equal(buf, values);
+        assert_int_equal(roaring64_iterator_read_backward(it, buf.data(),
+                                                          0xFFFFFFFF00000000),
+                         1000);
+        assert_vector_reversed(buf, values);
         roaring64_iterator_free(it);
     }
 
```

## Tests (toplevel_unit.c)

### read_compare helper

```diff
--- read_compare
+++ read_backward_compare
@@ -1,17 +1,20 @@
-void read_compare(roaring_bitmap_t *r, const uint32_t *ref_values,
-                  uint32_t ref_count, uint32_t step) {
+void read_backward_compare(roaring_bitmap_t *r, const uint32_t *ref_values,
+                           uint32_t ref_count, uint32_t step) {
     roaring_uint32_iterator_t *iter = roaring_iterator_create(r);
-    uint32_t *buffer = (uint32_t *)malloc(sizeof(uint32_t) *
-                                          (step == UINT32_MAX ? 65536 : step));
-    while (ref_count > 0) {
+    roaring_iterator_init_last(r, iter);
+    uint32_t *buffer =
+        malloc(sizeof(uint32_t) * (step == UINT32_MAX ? 65536 : step));
+    uint32_t remaining = ref_count;
+    while (remaining > 0) {
         assert_true(iter->has_value == true);
-        assert_true(iter->current_value == ref_values[0]);
+        assert_true(iter->current_value == ref_values[remaining - 1]);
 
         uint32_t num_ask = step;
         if (step == UINT32_MAX) {
             num_ask = 0;
-            for (uint32_t i = 0; i < ref_count; i++) {
-                if ((ref_values[i] >> 16) == (ref_values[0] >> 16)) {
+            for (uint32_t i = remaining; i > 0; i--) {
+                if ((ref_values[i - 1] >> 16) ==
+                    (ref_values[remaining - 1] >> 16)) {
                     num_ask++;
                 } else {
                     break;
@@ -19,19 +22,19 @@
             }
         }
 
-        uint32_t num_got = roaring_uint32_iterator_read(iter, buffer, num_ask);
-        assert_true(num_got == minimum_uint32(num_ask, ref_count));
+        uint32_t num_got =
+            roaring_uint32_iterator_read_backward(iter, buffer, num_ask);
+        assert_true(num_got == minimum_uint32(num_ask, remaining));
         for (uint32_t i = 0; i < num_got; i++) {
-            assert_true(ref_values[i] == buffer[i]);
+            assert_true(ref_values[remaining - 1 - i] == buffer[i]);
         }
-        ref_values += num_got;
-        ref_count -= num_got;
+        remaining -= num_got;
     }
 
     assert_true(iter->has_value == false);
     assert_true(iter->current_value == UINT32_MAX);
 
-    assert_true(roaring_uint32_iterator_read(iter, buffer, step) == 0);
+    assert_true(roaring_uint32_iterator_read_backward(iter, buffer, step) == 0);
     assert_true(iter->has_value == false);
     assert_true(iter->current_value == UINT32_MAX);
 
```

### test_read_uint32_iterator

```diff
--- test_read_uint32_iterator
+++ test_read_backward_uint32_iterator
@@ -1,4 +1,4 @@
-void test_read_uint32_iterator(uint8_t type) {
+void test_read_backward_uint32_iterator(uint8_t type) {
     uint32_t *ref_values;
     uint32_t ref_count;
     test_iterator_generate_data(&ref_values, &ref_count);
@@ -12,19 +12,21 @@
     }
 
     roaring_uint32_iterator_t *iter = roaring_iterator_create(r);
+    roaring_iterator_init_last(r, iter);
     uint32_t buffer[1];
-    uint32_t got = roaring_uint32_iterator_read(iter, buffer, 0);
+    uint32_t got = roaring_uint32_iterator_read_backward(iter, buffer, 0);
     assert_true(got == 0);
     assert_true(iter->has_value);
-    assert_true(iter->current_value == 0);
+    assert_true(iter->current_value == ref_values[ref_count - 1]);
     roaring_uint32_iterator_free(iter);
 
-    read_compare(r, ref_values, ref_count, 1);
-    read_compare(r, ref_values, ref_count, 2);
-    read_compare(r, ref_values, ref_count, 7);
-    read_compare(r, ref_values, ref_count, ref_count - 1);
-    read_compare(r, ref_values, ref_count, ref_count);
-    read_compare(r, ref_values, ref_count, UINT32_MAX);  // special value
+    read_backward_compare(r, ref_values, ref_count, 1);
+    read_backward_compare(r, ref_values, ref_count, 2);
+    read_backward_compare(r, ref_values, ref_count, 7);
+    read_backward_compare(r, ref_values, ref_count, ref_count - 1);
+    read_backward_compare(r, ref_values, ref_count, ref_count);
+    read_backward_compare(r, ref_values, ref_count,
+                          UINT32_MAX);  // special value
 
     roaring_bitmap_free(r);
     free(ref_values);
```

## Benchmarks

### iteration/advance vs iteration/previous

```diff
--- iteration/advance
+++ iteration/previous
@@ -4,13 +4,13 @@
             uint64_t card;
         };
         Entry e;
-        e.name = "iteration/advance" + suffix;
+        e.name = "iteration/previous" + suffix;
         e.description =
-            "Iterates over every value in the union (merged bitmap) of "
-            "all bitmaps in the \"" +
+            "Iterates backward over every value in the union (merged bitmap) "
+            "of all bitmaps in the \"" +
             dataset +
-            "\" dataset using roaring_uint32_iterator_advance() — the "
-            "one-value-at-a-time API. Accumulates a sum of visited "
+            "\" dataset using roaring_uint32_iterator_previous() — the "
+            "one-value-at-a-time backward API. Accumulates a sum of visited "
             "values so the compiler cannot elide the loop. Reported cost "
             "is per iterated value." +
             in_dataset;
@@ -23,11 +23,11 @@
         e.run = [](void *sv) -> int64_t {
             auto *s = static_cast<S *>(sv);
             roaring_uint32_iterator_t it;
-            roaring_iterator_init(s->bm, &it);
+            roaring_iterator_init_last(s->bm, &it);
             uint64_t sum = 0;
             while (it.has_value) {
                 sum += it.current_value;
-                roaring_uint32_iterator_advance(&it);
+                roaring_uint32_iterator_previous(&it);
             }
             return static_cast<int64_t>(sum);
         };
```

### iteration/read vs iteration/read_backward (buffered)

```diff
--- iteration/read/
+++ iteration/read_backward/
@@ -5,19 +5,19 @@
         };
         Entry e;
         char buf[96];
-        snprintf(buf, sizeof(buf), "iteration/read/bufsize=%u/%s", bs,
+        snprintf(buf, sizeof(buf), "iteration/read_backward/bufsize=%u/%s", bs,
                  dataset.c_str());
         e.name = buf;
         char dbuf[768];
         snprintf(dbuf, sizeof(dbuf),
-                 "Iterates over every value in the merged bitmap (union "
-                 "of all bitmaps in the \"%s\" dataset) using "
-                 "roaring_uint32_iterator_read() with a %u-element "
+                 "Iterates backward over every value in the merged bitmap "
+                 "(union of all bitmaps in the \"%s\" dataset) using "
+                 "roaring_uint32_iterator_read_backward() with a %u-element "
                  "buffer. Each call drains up to %u values, amortising "
                  "the iterator state machine over multiple values. "
                  "Comparing the bufsize=1 variant against "
-                 "iteration/advance shows the per-call overhead of "
-                 "advance(); comparing larger bufsizes shows where the "
+                 "iteration/previous shows the per-call overhead of "
+                 "previous(); comparing larger bufsizes shows where the "
                  "amortisation plateaus. Reported cost is per iterated "
                  "value.%s",
                  dataset.c_str(), bs, bs, in_dataset.c_str());
@@ -32,11 +32,11 @@
             auto *s = static_cast<S *>(sv);
             std::vector<uint32_t> buffer(s->bufsize);
             roaring_uint32_iterator_t it;
-            roaring_iterator_init(s->bm, &it);
+            roaring_iterator_init_last(s->bm, &it);
             uint64_t sum = 0;
             while (true) {
-                uint32_t got = roaring_uint32_iterator_read(&it, buffer.data(),
-                                                            s->bufsize);
+                uint32_t got = roaring_uint32_iterator_read_backward(
+                    &it, buffer.data(), s->bufsize);
                 for (uint32_t i = 0; i < got; ++i) sum += buffer[i];
                 if (got < s->bufsize) break;
             }
```

</details>

---

### Performance

The backward implementation performs on par with the forward impl. 

<details>
<summary>Benchmarks</summary>

`./build/benchmarks/roaring_benchmark --filter iteration/`

| benchmark                                                   |      ns/op |
|-------------------------------------------------------------|-----------:|
| iteration/advance/census-income                             |       5.95 |
| iteration/previous/census-income                            |       5.29 |
| iteration/read/bufsize=1/census-income                      |      15.84 |
| iteration/read/bufsize=4/census-income                      |       5.70 |
| iteration/read/bufsize=16/census-income                     |       3.38 |
| iteration/read/bufsize=128/census-income                    |       3.11 |
| iteration/read/bufsize=1024/census-income                   |       3.00 |
| iteration/read_backward/bufsize=1/census-income             |      15.95 |
| iteration/read_backward/bufsize=4/census-income             |       5.67 |
| iteration/read_backward/bufsize=16/census-income            |       3.36 |
| iteration/read_backward/bufsize=128/census-income           |       3.10 |
| iteration/read_backward/bufsize=1024/census-income          |       3.02 |
| iteration/advance/census-income_srt                         |       5.91 |
| iteration/previous/census-income_srt                        |       5.31 |
| iteration/read/bufsize=1/census-income_srt                  |      15.81 |
| iteration/read/bufsize=4/census-income_srt                  |       5.69 |
| iteration/read/bufsize=16/census-income_srt                 |       3.38 |
| iteration/read/bufsize=128/census-income_srt                |       3.11 |
| iteration/read/bufsize=1024/census-income_srt               |       3.01 |
| iteration/read_backward/bufsize=1/census-income_srt         |      15.87 |
| iteration/read_backward/bufsize=4/census-income_srt         |       5.77 |
| iteration/read_backward/bufsize=16/census-income_srt        |       3.46 |
| iteration/read_backward/bufsize=128/census-income_srt       |       3.17 |
| iteration/read_backward/bufsize=1024/census-income_srt      |       3.01 |
| iteration/advance/census1881                                |      13.34 |
| iteration/previous/census1881                               |      12.64 |
| iteration/read/bufsize=1/census1881                         |      18.13 |
| iteration/read/bufsize=4/census1881                         |       8.11 |
| iteration/read/bufsize=16/census1881                        |       6.36 |
| iteration/read/bufsize=128/census1881                       |       5.57 |
| iteration/read/bufsize=1024/census1881                      |       5.34 |
| iteration/read_backward/bufsize=1/census1881                |      18.64 |
| iteration/read_backward/bufsize=4/census1881                |       8.65 |
| iteration/read_backward/bufsize=16/census1881               |       7.27 |
| iteration/read_backward/bufsize=128/census1881              |       6.61 |
| iteration/read_backward/bufsize=1024/census1881             |       6.44 |
| iteration/advance/census1881_srt                            |       6.52 |
| iteration/previous/census1881_srt                           |       6.02 |
| iteration/read/bufsize=1/census1881_srt                     |      16.55 |
| iteration/read/bufsize=4/census1881_srt                     |       6.68 |
| iteration/read/bufsize=16/census1881_srt                    |       4.36 |
| iteration/read/bufsize=128/census1881_srt                   |       3.97 |
| iteration/read/bufsize=1024/census1881_srt                  |       3.78 |
| iteration/read_backward/bufsize=1/census1881_srt            |      16.48 |
| iteration/read_backward/bufsize=4/census1881_srt            |       6.65 |
| iteration/read_backward/bufsize=16/census1881_srt           |       4.38 |
| iteration/read_backward/bufsize=128/census1881_srt          |       3.97 |
| iteration/read_backward/bufsize=1024/census1881_srt         |       3.86 |
| iteration/advance/uscensus2000                              |       6.72 |
| iteration/previous/uscensus2000                             |       6.37 |
| iteration/read/bufsize=1/uscensus2000                       |      15.67 |
| iteration/read/bufsize=4/uscensus2000                       |       8.22 |
| iteration/read/bufsize=16/uscensus2000                      |       6.27 |
| iteration/read/bufsize=128/uscensus2000                     |       5.82 |
| iteration/read/bufsize=1024/uscensus2000                    |       6.44 |
| iteration/read_backward/bufsize=1/uscensus2000              |      15.53 |
| iteration/read_backward/bufsize=4/uscensus2000              |       8.11 |
| iteration/read_backward/bufsize=16/uscensus2000             |       6.37 |
| iteration/read_backward/bufsize=128/uscensus2000            |       5.94 |
| iteration/read_backward/bufsize=1024/uscensus2000           |       6.57 |
| iteration/advance/weather_sept_85                           |       6.72 |
| iteration/previous/weather_sept_85                          |       6.03 |
| iteration/read/bufsize=1/weather_sept_85                    |      16.25 |
| iteration/read/bufsize=4/weather_sept_85                    |       5.91 |
| iteration/read/bufsize=16/weather_sept_85                   |       3.61 |
| iteration/read/bufsize=128/weather_sept_85                  |       3.35 |
| iteration/read/bufsize=1024/weather_sept_85                 |       3.22 |
| iteration/read_backward/bufsize=1/weather_sept_85           |      16.19 |
| iteration/read_backward/bufsize=4/weather_sept_85           |       5.96 |
| iteration/read_backward/bufsize=16/weather_sept_85          |       3.70 |
| iteration/read_backward/bufsize=128/weather_sept_85         |       3.43 |
| iteration/read_backward/bufsize=1024/weather_sept_85        |       3.31 |
| iteration/advance/weather_sept_85_srt                       |       6.04 |
| iteration/previous/weather_sept_85_srt                      |       5.39 |
| iteration/read/bufsize=1/weather_sept_85_srt                |      16.02 |
| iteration/read/bufsize=4/weather_sept_85_srt                |       5.76 |
| iteration/read/bufsize=16/weather_sept_85_srt               |       3.44 |
| iteration/read/bufsize=128/weather_sept_85_srt              |       3.20 |
| iteration/read/bufsize=1024/weather_sept_85_srt             |       3.04 |
| iteration/read_backward/bufsize=1/weather_sept_85_srt       |      16.07 |
| iteration/read_backward/bufsize=4/weather_sept_85_srt       |       5.76 |
| iteration/read_backward/bufsize=16/weather_sept_85_srt      |       3.43 |
| iteration/read_backward/bufsize=128/weather_sept_85_srt     |       3.19 |
| iteration/read_backward/bufsize=1024/weather_sept_85_srt    |       3.08 |
| iteration/advance/wikileaks-noquotes                        |       8.31 |
| iteration/previous/wikileaks-noquotes                       |       7.83 |
| iteration/read/bufsize=1/wikileaks-noquotes                 |      17.76 |
| iteration/read/bufsize=4/wikileaks-noquotes                 |       8.62 |
| iteration/read/bufsize=16/wikileaks-noquotes                |       5.99 |
| iteration/read/bufsize=128/wikileaks-noquotes               |       5.32 |
| iteration/read/bufsize=1024/wikileaks-noquotes              |       5.06 |
| iteration/read_backward/bufsize=1/wikileaks-noquotes        |      17.54 |
| iteration/read_backward/bufsize=4/wikileaks-noquotes        |       8.61 |
| iteration/read_backward/bufsize=16/wikileaks-noquotes       |       6.38 |
| iteration/read_backward/bufsize=128/wikileaks-noquotes      |       5.62 |
| iteration/read_backward/bufsize=1024/wikileaks-noquotes     |       5.29 |
| iteration/advance/wikileaks-noquotes_srt                    |       6.55 |
| iteration/previous/wikileaks-noquotes_srt                   |       6.02 |
| iteration/read/bufsize=1/wikileaks-noquotes_srt             |      16.44 |
| iteration/read/bufsize=4/wikileaks-noquotes_srt             |       6.52 |
| iteration/read/bufsize=16/wikileaks-noquotes_srt            |       4.17 |
| iteration/read/bufsize=128/wikileaks-noquotes_srt           |       3.78 |
| iteration/read/bufsize=1024/wikileaks-noquotes_srt          |       3.61 |
| iteration/read_backward/bufsize=1/wikileaks-noquotes_srt    |      16.40 |
| iteration/read_backward/bufsize=4/wikileaks-noquotes_srt    |       6.52 |
| iteration/read_backward/bufsize=16/wikileaks-noquotes_srt   |       4.25 |
| iteration/read_backward/bufsize=128/wikileaks-noquotes_srt  |       3.90 |
| iteration/read_backward/bufsize=1024/wikileaks-noquotes_srt |       3.71 |

</details>