### PR TITLE
feat: add mask and maskClosed methods to Roaring

### DIFF
--- a/cpp/roaring/roaring.hh
+++ b/cpp/roaring/roaring.hh
@@ -282,6 +282,28 @@ class Roaring {
         return api::roaring_bitmap_remove_range_closed(&roaring, min, max);
     }
 
+        /**
+     * Keep only values in the half-open interval [min, max).
+     * Equivalent to two consecutive removeRange calls.
+     */
+    void mask(uint64_t min, uint64_t max) noexcept {
+        removeRange(0, min);
+        if (!isEmpty()) {
+            removeRange(max, (uint64_t)maximum() + 1);
+        }
+    }
+
+    /**
+     * Keep only values in the closed interval [min, max].
+     * Equivalent to two consecutive removeRangeClosed calls.
+     */
+    void maskClosed(uint32_t min, uint32_t max) noexcept {
+        if (min > 0) removeRangeClosed(0, min - 1);
+        if (!isEmpty() && max < maximum()) {
+            removeRangeClosed(max + 1, maximum());
+        }
+    }
+
     /**
      * Clears the bitmap.
      */

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -843,6 +843,62 @@ DEFINE_TEST(test_cpp_remove_range) {
     }
 }
 
+DEFINE_TEST(test_cpp_mask) {
+    {
+        // mask: keep only values in [min, max), values outside are removed
+        Roaring r1 = Roaring::bitmapOf(5, 1, 3, 5, 7, 9);
+        r1.mask(3, 8);
+        Roaring r2 = Roaring::bitmapOf(3, 3, 5, 7);
+        assert_true(r1 == r2);
+    }
+    {
+        // mask: min == max, result should be empty
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 3);
+        r1.mask(2, 2);
+        assert_true(r1.isEmpty());
+    }
+    {
+        // mask: range covers all elements, nothing removed
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 3);
+        r1.mask(0, 10);
+        Roaring r2 = Roaring::bitmapOf(3, 1, 2, 3);
+        assert_true(r1 == r2);
+    }
+    {
+        // mask: empty bitmap, no effect
+        Roaring r1;
+        r1.mask(2, 5);
+        assert_true(r1.isEmpty());
+    }
+    {
+        // maskClosed: keep only values in [min, max], max is included
+        Roaring r1 = Roaring::bitmapOf(5, 1, 3, 5, 7, 9);
+        r1.maskClosed(3, 7);
+        Roaring r2 = Roaring::bitmapOf(3, 3, 5, 7);
+        assert_true(r1 == r2);
+    }
+    {
+        // maskClosed: min == max, only that element remains if present
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 3);
+        r1.maskClosed(2, 2);
+        Roaring r2 = Roaring::bitmapOf(1, 2);
+        assert_true(r1 == r2);
+    }
+    {
+        // maskClosed: range covers all elements, nothing removed
+        Roaring r1 = Roaring::bitmapOf(3, 1, 2, 3);
+        r1.maskClosed(0, 10);
+        Roaring r2 = Roaring::bitmapOf(3, 1, 2, 3);
+        assert_true(r1 == r2);
+    }
+    {
+        // maskClosed: empty bitmap, no effect
+        Roaring r1;
+        r1.maskClosed(2, 5);
+        assert_true(r1.isEmpty());
+    }
+}
+
 DEFINE_TEST(test_cpp_add_range_closed_64) {
     {
         // 32-bit integers
@@ -2187,6 +2243,7 @@ int main() {
         cmocka_unit_test(test_cpp_add_remove_checked_64),
         cmocka_unit_test(test_cpp_add_range),
         cmocka_unit_test(test_cpp_remove_range),
+        cmocka_unit_test(test_cpp_mask),
         cmocka_unit_test(test_cpp_add_range_closed_64),
         cmocka_unit_test(test_cpp_add_range_open_64),
         cmocka_unit_test(test_cpp_add_range_closed_large_64),


### PR DESCRIPTION
Related to #419

## Summary
Adds two convenience methods to the `Roaring` class in `roaring.hh`:

- **`mask(uint64_t min, uint64_t max)`** — keeps only values in the half-open interval `[min, max)`, equivalent to two consecutive `removeRange` calls
- **`maskClosed(uint32_t min, uint32_t max)`** — keeps only values in the closed interval `[min, max]`, equivalent to two consecutive `removeRangeClosed` calls

The method signatures follow the existing convention in the codebase: open intervals use `uint64_t` (matching `removeRange` and `addRange`), closed intervals use `uint32_t` (matching `removeRangeClosed` and `addRangeClosed`).

Both methods guard against calling `maximum()` on an empty bitmap.

## Tests
Added `test_cpp_mask` in `tests/cpp_unit.cpp` covering:
- Basic masking with values inside and outside the range
- `min == max` edge case
- Range covering all elements
- Empty bitmap
- Both `mask` and `maskClosed` variants

All 67 tests pass.

## AI Usage Disclosure
I used AI assistance during development. I reviewed and understood all code before submission and can explain my implementation choices.