### PR TITLE
feat: Implement containsRange family in Roaring64Map

### DIFF
--- a/cpp/roaring/roaring.hh
+++ b/cpp/roaring/roaring.hh
@@ -282,7 +282,7 @@ class Roaring {
         return api::roaring_bitmap_remove_range_closed(&roaring, min, max);
     }
 
-        /**
+    /**
      * Keep only values in the half-open interval [min, max).
      * Equivalent to two consecutive removeRange calls.
      */

--- a/cpp/roaring/roaring64map.hh
+++ b/cpp/roaring/roaring64map.hh
@@ -494,7 +494,82 @@ class Roaring64Map {
         return iter->second.contains(lowBytes(x));
     }
 
-    // TODO: implement `containsRange`
+    /**
+     * Returns true if all values in the half-open interval [min, max) are
+     * present.
+     */
+    bool containsRange(uint64_t min, uint64_t max) const {
+        if (min >= max) {
+            return true;
+        }
+        return containsRangeClosed(min, max - 1);
+    }
+
+    /**
+     * Returns true if all values in the closed interval [min, max] are present.
+     */
+    bool containsRangeClosed(uint32_t min, uint32_t max) const {
+        auto iter = roarings.find(0);
+        if (iter == roarings.end()) {
+            return min > max;
+        }
+        return iter->second.containsRangeClosed(min, max);
+    }
+
+    /**
+     * Returns true if all values in the closed interval [min, max] are present.
+     */
+    bool containsRangeClosed(uint64_t min, uint64_t max) const {
+        if (min > max) {
+            return true;
+        }
+        uint32_t start_high = highBytes(min);
+        uint32_t start_low = lowBytes(min);
+        uint32_t end_high = highBytes(max);
+        uint32_t end_low = lowBytes(max);
+
+        // We put std::numeric_limits<>::max in parentheses to avoid a
+        // clash with the Windows.h header under Windows.
+        const uint32_t uint32_max = (std::numeric_limits<uint32_t>::max)();
+
+        // If start == end, check it in one call.
+        if (start_high == end_high) {
+            auto iter = roarings.find(start_high);
+            if (iter == roarings.end()) {
+                return false;
+            }
+            return iter->second.containsRangeClosed(start_low, end_low);
+        }
+
+        // Otherwise the range spans multiple bitmaps.
+        auto iter = roarings.find(start_high);
+        if (iter == roarings.end()) {
+            return false;
+        }
+
+        // 1. The first bitmap must contain [start_low, uint32_max].
+        if (!iter->second.containsRangeClosed(start_low, uint32_max)) {
+            return false;
+        }
+
+        // 2. Every intermediate bitmap must contain [0, uint32_max] (full).
+        for (uint32_t high = start_high + 1; high != end_high; ++high) {
+            ++iter;
+            if (iter == roarings.end() || iter->first != high) {
+                return false;
+            }
+            if (!iter->second.containsRangeClosed(0, uint32_max)) {
+                return false;
+            }
+        }
+
+        // 3. The last bitmap must contain [0, end_low].
+        ++iter;
+        if (iter == roarings.end() || iter->first != end_high) {
+            return false;
+        }
+        return iter->second.containsRangeClosed(0, end_low);
+    }
 
     /**
      * Compute the intersection of the current bitmap and the provided bitmap,

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -64,8 +64,8 @@
 #ifdef __GLIBC__
 #include <malloc.h>  // this should never be needed but there are some reports that it is needed.
 #endif
-// alignas/alignof are keywords in C++ and in C23+, where <stdalign.h> is deprecated.
-// Only include it for C11..C17.
+// alignas/alignof are keywords in C++ and in C23+, where <stdalign.h> is
+// deprecated. Only include it for C11..C17.
 #if !defined(__cplusplus) && \
     (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L)
 #include <stdalign.h>

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -252,6 +252,12 @@ bool roaring64_bitmap_contains_range(const roaring64_bitmap_t *r, uint64_t min,
                                      uint64_t max);
 
 /**
+ * Returns true if all values in the range [min, max] are present.
+ */
+bool roaring64_bitmap_contains_range_closed(const roaring64_bitmap_t *r,
+                                            uint64_t min, uint64_t max);
+
+/**
  * Check if an item is present using context from a previous insert or search
  * for faster search.
  *

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -561,12 +561,20 @@ bool roaring64_bitmap_contains_range(const roaring64_bitmap_t *r, uint64_t min,
     if (min >= max) {
         return true;
     }
+    return roaring64_bitmap_contains_range_closed(r, min, max - 1);
+}
+
+bool roaring64_bitmap_contains_range_closed(const roaring64_bitmap_t *r,
+                                            uint64_t min, uint64_t max) {
+    if (min > max) {
+        return true;
+    }
 
     uint8_t min_high48[ART_KEY_BYTES];
     uint16_t min_low16 = split_key(min, min_high48);
     uint8_t max_high48[ART_KEY_BYTES];
     uint16_t max_low16 = split_key(max, max_high48);
-    uint64_t max_high48_bits = (max - 1) & 0xFFFFFFFFFFFF0000;  // Inclusive
+    uint64_t max_high48_bits = max & 0xFFFFFFFFFFFF0000;
 
     art_iterator_t it = art_lower_bound((art_t *)&r->art, min_high48);
     if (it.value == NULL || combine_key(it.key, 0) > min) {
@@ -592,7 +600,7 @@ bool roaring64_bitmap_contains_range(const roaring64_bitmap_t *r, uint64_t min,
         }
         uint32_t container_max = 0xFFFF + 1;  // Exclusive
         if (compare_high48(it.key, max_high48) == 0) {
-            container_max = max_low16;
+            container_max = (uint32_t)max_low16 + 1;
         }
 
         // For the first and last containers we use container_contains_range,

--- a/tests/cpp_random_unit.cpp
+++ b/tests/cpp_random_unit.cpp
@@ -340,9 +340,12 @@ DEFINE_TEST(random_doublecheck_test) {
         out.maximum();
         out.contains(rand());
         out.containsRange(rand(), rand());
+        out.containsRangeClosed(rand(), rand());
         for (int i = -50; i < 50; ++i) {
             out.contains(gravity + i);
-            out.containsRange(gravity + i, rand() % 25);
+            out.containsRange(gravity + i, gravity + i + (rand() % 25));
+            out.containsRangeClosed(gravity + i,
+                                    gravity + i + (rand() % 25));
         }
 
         // When doing random intersections, the tendency is that sets will
@@ -478,8 +481,14 @@ DEFINE_TEST(random_doublecheck_test_64) {
         out.isEmpty();
         out.minimum();
         out.maximum();
+        out.contains(uint64_t(rand()));
+        out.containsRange(uint64_t(rand()), uint64_t(rand()));
+        out.containsRangeClosed(uint64_t(rand()), uint64_t(rand()));
         for (int i = -50; i < 50; ++i) {
             out.contains(gravity64 + i);
+            out.containsRange(gravity64 + i, gravity64 + i + (rand() % 25));
+            out.containsRangeClosed(gravity64 + i,
+                                    gravity64 + i + (rand() % 25));
         }
 
         // When doing random intersections, the tendency is that sets will

--- a/tests/cpp_random_unit.cpp
+++ b/tests/cpp_random_unit.cpp
@@ -344,8 +344,7 @@ DEFINE_TEST(random_doublecheck_test) {
         for (int i = -50; i < 50; ++i) {
             out.contains(gravity + i);
             out.containsRange(gravity + i, gravity + i + (rand() % 25));
-            out.containsRangeClosed(gravity + i,
-                                    gravity + i + (rand() % 25));
+            out.containsRangeClosed(gravity + i, gravity + i + (rand() % 25));
         }
 
         // When doing random intersections, the tendency is that sets will

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -1015,6 +1015,106 @@ DEFINE_TEST(test_cpp_add_range_open_large_64) {
     }
 }
 
+DEFINE_TEST(test_cpp_contains_range_closed_64) {
+    {
+        // Empty bitmap.
+        Roaring64Map r;
+        assert_false(r.containsRangeClosed(uint64_t(1), uint64_t(10)));
+        assert_true(r.containsRangeClosed(uint64_t(10), uint64_t(1)));
+    }
+    {
+        // 32-bit overload (fast path for high=0 bucket)
+        Roaring64Map r;
+        r.addRangeClosed(uint32_t(1), uint32_t(10));
+        assert_true(r.containsRangeClosed(uint32_t(1), uint32_t(10)));
+        assert_false(r.containsRangeClosed(uint32_t(1), uint32_t(11)));
+        assert_true(r.containsRangeClosed(uint32_t(5), uint32_t(4)));
+        // No high=0 bucket
+        Roaring64Map empty;
+        assert_false(empty.containsRangeClosed(uint32_t(0), uint32_t(0)));
+        assert_true(empty.containsRangeClosed(uint32_t(5), uint32_t(4)));
+    }
+    {
+        // Single-bucket range with non-zero high.
+        auto b1 = uint64_t(1) << 32;
+        Roaring64Map r;
+        r.addRangeClosed(b1 + 1, b1 + 10);
+        assert_true(r.containsRangeClosed(b1 + 1, b1 + 10));
+        assert_false(r.containsRangeClosed(b1, b1 + 10));
+        assert_false(r.containsRangeClosed(b1 + 1, b1 + 11));
+    }
+    {
+        // Range spanning two inner bitmaps.
+        auto b1 = uint64_t(1) << 32;
+        Roaring64Map r;
+        r.addRangeClosed(b1 - 10, b1 + 10);
+        assert_true(r.containsRangeClosed(b1 - 10, b1 + 10));
+        assert_false(r.containsRangeClosed(b1 - 11, b1 + 10));
+        assert_false(r.containsRangeClosed(b1 - 10, b1 + 11));
+    }
+    {
+        // Range spanning three inner bitmaps.
+        auto b1 = uint64_t(1) << 32;
+        auto b2 = uint64_t(2) << 32;
+        Roaring64Map r;
+        r.addRangeClosed(b1 - 1, b2 + 1);
+        assert_true(r.containsRangeClosed(b1 - 1, b2 + 1));
+        // Remove a value from the middle bucket.
+        r.remove(b1 + 42);
+        assert_false(r.containsRangeClosed(b1 - 1, b2 + 1));
+    }
+    {
+        // Start bucket full, one full bucket missing in the middle, end
+        // bucket partial.
+        auto b0 = uint64_t(0);
+        auto b2 = uint64_t(2) << 32;
+        auto uint32_max = (std::numeric_limits<uint32_t>::max)();
+        Roaring64Map r;
+        r.addRangeClosed(b0, b0 + uint32_max);
+        r.addRangeClosed(b2, b2 + 5);
+        assert_false(r.containsRangeClosed(b0, b2 + 5));
+    }
+    {
+        // Start bucket full; query extends one value past it into an absent
+        // bucket.
+        auto b0 = uint64_t(0);
+        auto b1 = uint64_t(1) << 32;
+        auto uint32_max = (std::numeric_limits<uint32_t>::max)();
+        Roaring64Map r;
+        r.addRangeClosed(b0, b0 + uint32_max);
+        assert_false(r.containsRangeClosed(b0, b1));
+    }
+    {
+        // Range with max == UINT64_MAX.
+        Roaring64Map r;
+        r.add(UINT64_MAX - 2);
+        r.add(UINT64_MAX - 1);
+        r.add(UINT64_MAX);
+        assert_true(r.containsRangeClosed(UINT64_MAX - 2, UINT64_MAX));
+        r.remove(UINT64_MAX);
+        assert_false(r.containsRangeClosed(UINT64_MAX - 2, UINT64_MAX));
+    }
+}
+
+DEFINE_TEST(test_cpp_contains_range_64) {
+    {
+        // Empty range.
+        Roaring64Map r;
+        assert_true(r.containsRange(uint64_t(5), uint64_t(5)));
+        assert_true(r.containsRange(uint64_t(10), uint64_t(1)));
+        assert_false(r.containsRange(uint64_t(1), uint64_t(10)));
+    }
+    {
+        // Half-open range spanning two inner bitmaps.
+        auto b1 = uint64_t(1) << 32;
+        Roaring64Map r;
+        r.addRange(b1 - 10, b1 + 10);
+        assert_true(r.containsRange(b1 - 10, b1 + 10));
+        assert_false(r.containsRange(b1 - 10, b1 + 11));
+        assert_false(r.containsRange(b1 - 11, b1 + 10));
+    }
+}
+
 DEFINE_TEST(test_cpp_add_many) {
     std::vector<uint32_t> values = {9999, 123, 0xFFFFFFFF, 0xFFFFFFF7, 9999};
     Roaring r1;
@@ -2201,13 +2301,22 @@ DEFINE_TEST(test_cpp_deserialize_64_key_too_small) {
 #endif
 
 DEFINE_TEST(test_cpp_contains_range_interleaved_containers) {
+    {
     Roaring roaring;
-    // Range from last position in first container up to second position in 3rd
-    // container.
+        // Range from last position in first container up to second position in
+        // 3rd container.
     roaring.addRange(0xFFFF, 0x1FFFF + 2);
-    // Query from last position in 2nd container up to second position in 4th
-    // container. There is no 4th container in the bitmap.
-    roaring.containsRange(0x1FFFF, 0x2FFFF + 2);
+        // Query from last position in 2nd container up to second position in
+        // 4th container. There is no 4th container in the bitmap.
+        assert_false(roaring.containsRange(0x1FFFF, 0x2FFFF + 2));
+    }
+    {
+        // 64-bit version through Roaring64Map.
+        auto b1 = uint64_t(1) << 32;
+        Roaring64Map r;
+        r.addRange(b1 + 0xFFFF, b1 + 0x1FFFF + 2);
+        assert_false(r.containsRange(b1 + 0x1FFFF, b1 + 0x2FFFF + 2));
+    }
 }
 
 // Test that it is pointed to the new map, see
@@ -2248,6 +2357,8 @@ int main() {
         cmocka_unit_test(test_cpp_add_range_open_64),
         cmocka_unit_test(test_cpp_add_range_closed_large_64),
         cmocka_unit_test(test_cpp_add_range_open_large_64),
+        cmocka_unit_test(test_cpp_contains_range_closed_64),
+        cmocka_unit_test(test_cpp_contains_range_64),
         cmocka_unit_test(test_cpp_add_many),
         cmocka_unit_test(test_cpp_add_many_64),
         cmocka_unit_test(test_cpp_add_range_closed_combinatoric_64),

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -2302,10 +2302,10 @@ DEFINE_TEST(test_cpp_deserialize_64_key_too_small) {
 
 DEFINE_TEST(test_cpp_contains_range_interleaved_containers) {
     {
-    Roaring roaring;
+        Roaring roaring;
         // Range from last position in first container up to second position in
         // 3rd container.
-    roaring.addRange(0xFFFF, 0x1FFFF + 2);
+        roaring.addRange(0xFFFF, 0x1FFFF + 2);
         // Query from last position in 2nd container up to second position in
         // 4th container. There is no 4th container in the bitmap.
         assert_false(roaring.containsRange(0x1FFFF, 0x2FFFF + 2));

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -590,6 +590,86 @@ DEFINE_TEST(test_contains_range) {
     }
 }
 
+DEFINE_TEST(test_contains_range_closed) {
+    {
+        // Empty bitmap.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        assert_false(roaring64_bitmap_contains_range_closed(r, 1, 10));
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Empty range (min > max).
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        roaring64_bitmap_add_range_closed(r, 1, 10);
+        assert_true(roaring64_bitmap_contains_range_closed(r, 5, 4));
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Single-value range (min == max).
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        roaring64_bitmap_add(r, 5);
+        assert_true(roaring64_bitmap_contains_range_closed(r, 5, 5));
+        assert_false(roaring64_bitmap_contains_range_closed(r, 4, 4));
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Range within one container.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        roaring64_bitmap_add_range_closed(r, 1, 10);
+        assert_true(roaring64_bitmap_contains_range_closed(r, 1, 10));
+        assert_false(roaring64_bitmap_contains_range_closed(r, 1, 11));
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Range across two containers.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        roaring64_bitmap_add_range_closed(r, 1, (1 << 16) + 10);
+        assert_true(
+            roaring64_bitmap_contains_range_closed(r, 1, (1 << 16) + 10));
+        assert_true(
+            roaring64_bitmap_contains_range_closed(r, 1, (1 << 16) - 1));
+        assert_false(
+            roaring64_bitmap_contains_range_closed(r, 1, (1 << 16) + 11));
+        assert_false(
+            roaring64_bitmap_contains_range_closed(r, 0, (1 << 16) + 10));
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Range across three containers.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        roaring64_bitmap_add_range_closed(r, 1, (2 << 16) + 10);
+        assert_true(
+            roaring64_bitmap_contains_range_closed(r, 1, (2 << 16) + 10));
+        assert_false(
+            roaring64_bitmap_contains_range_closed(r, 1, (2 << 16) + 11));
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Container missing from range.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        roaring64_bitmap_add_range_closed(r, 1, (1 << 16) - 2);
+        roaring64_bitmap_add_range_closed(r, (2 << 16), (3 << 16) - 2);
+        assert_false(
+            roaring64_bitmap_contains_range_closed(r, 1, (3 << 16) - 2));
+        roaring64_bitmap_free(r);
+    }
+    {
+        // Range fully inside max container, including UINT64_MAX.
+        roaring64_bitmap_t* r = roaring64_bitmap_create();
+        assert_false(roaring64_bitmap_contains_range_closed(r, UINT64_MAX - 2,
+                                                            UINT64_MAX));
+        roaring64_bitmap_add(r, UINT64_MAX);
+        roaring64_bitmap_add(r, UINT64_MAX - 1);
+        assert_false(roaring64_bitmap_contains_range_closed(r, UINT64_MAX - 2,
+                                                            UINT64_MAX));
+        roaring64_bitmap_add(r, UINT64_MAX - 2);
+        // closed variant: UINT64_MAX endpoint required.
+        assert_true(roaring64_bitmap_contains_range_closed(r, UINT64_MAX - 2,
+                                                           UINT64_MAX));
+        roaring64_bitmap_free(r);
+    }
+}
+
 DEFINE_TEST(test_select) {
     roaring64_bitmap_t* r = roaring64_bitmap_create();
     for (uint64_t i = 0; i < 100; ++i) {
@@ -2823,6 +2903,7 @@ int main() {
         cmocka_unit_test(test_add_many),
         cmocka_unit_test(test_add_range_closed),
         cmocka_unit_test(test_contains_range),
+        cmocka_unit_test(test_contains_range_closed),
         cmocka_unit_test(test_contains_bulk),
         cmocka_unit_test(test_select),
         cmocka_unit_test(test_rank),

--- a/tests/roaring64map_checked.hh
+++ b/tests/roaring64map_checked.hh
@@ -229,6 +229,61 @@ class Roaring64Map {
         return ans;
     }
 
+    bool containsRange(uint64_t min, uint64_t max) const {
+        bool ans = plain.containsRange(min, max);
+
+        auto it = check.find(min);
+        if (min >= max)
+            assert_true(ans == true);
+        else if (it == check.end())
+            assert_true(ans == false);
+        else {
+            uint64_t last = min;
+            while (++it != check.end() && last + 1 == *it && *it < max)
+                last = *it;
+            assert_true(ans == (last == max - 1));
+        }
+
+        return ans;
+    }
+
+    bool containsRangeClosed(uint32_t min, uint32_t max) const {
+        bool ans = plain.containsRangeClosed(min, max);
+
+        auto it = check.find(uint64_t(min));
+        if (min > max)
+            assert_true(ans == true);
+        else if (it == check.end())
+            assert_true(ans == false);
+        else {
+            uint64_t last = min;
+            uint64_t max64 = max;
+            while (++it != check.end() && last + 1 == *it && *it <= max64)
+                last = *it;
+            assert_true(ans == (last == max64));
+        }
+
+        return ans;
+    }
+
+    bool containsRangeClosed(uint64_t min, uint64_t max) const {
+        bool ans = plain.containsRangeClosed(min, max);
+
+        auto it = check.find(min);
+        if (min > max)
+            assert_true(ans == true);
+        else if (it == check.end())
+            assert_true(ans == false);
+        else {
+            uint64_t last = min;
+            while (++it != check.end() && last + 1 == *it && *it <= max)
+                last = *it;
+            assert_true(ans == (last == max));
+        }
+
+        return ans;
+    }
+
     // This method is exclusive to `doublechecked::Roaring64Map`
     //
     bool does_std_set_match_roaring() const {

--- a/tests/roaring_checked.hh
+++ b/tests/roaring_checked.hh
@@ -192,6 +192,25 @@ class Roaring {
         return ans;
     }
 
+    bool containsRangeClosed(uint32_t min, uint32_t max) const {
+        bool ans = plain.containsRangeClosed(min, max);
+
+        auto it = check.find(min);
+        if (min > max)
+            assert_true(ans == true);
+        else if (it == check.end())
+            assert_true(ans == false);
+        else {
+            uint64_t last = min;
+            uint64_t max64 = max;
+            while (++it != check.end() && last + 1 == *it && *it <= max64)
+                last = *it;
+            assert_true(ans == (last == max64));
+        }
+
+        return ans;
+    }
+
     // This method is exclusive to `doublechecked::Roaring`
     //
     bool does_std_set_match_roaring() const {


### PR DESCRIPTION
Related: #597.

Implements `Roaring64Map::containsRange` (previously marked as TODO).

The closed variant is also added on both C and C++ implementation for API symmetry with the 32-bit roaring and with other roaring64 closed range operations (e.g., `roaring64_bitmap_add_range_closed`, `roaring64_bitmap_remove_range_closed`, `roaring64_bitmap_flip_closed_inplace`).

APIs added:
- C: `roaring64_bitmap_contains_range_closed`
- C++ (`Roaring64Map`): `containsRange`, `containsRangeClosed(uint32_t, uint32_t)`,
  `containsRangeClosed(uint64_t, uint64_t)`

Note: Please review the three commits separately, the last one is a lint-only commit.