### PR TITLE
Prevent users from relying on old cmocka

### DIFF
--- a/.github/workflows/ubuntu-c23-ci.yml
+++ b/.github/workflows/ubuntu-c23-ci.yml
@@ -1,0 +1,36 @@
+name: Ubuntu-C23-CI
+
+'on':
+  - push
+  - pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: ubuntu-c23-${{ matrix.compiler.cc }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - { cc: gcc, cxx: g++ }
+          - { cc: clang, cxx: clang++ }
+
+    env:
+      CC: ${{ matrix.compiler.cc }}
+      CXX: ${{ matrix.compiler.cxx }}
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Build and Test (C23 / C++23)
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_C_STANDARD=23 -DCMAKE_CXX_STANDARD=23 -DCMAKE_INSTALL_PREFIX:PATH=destination -DENABLE_ROARING_TESTS=ON -DROARING_UNSAFE_FROZEN_TESTS=ON ..
+          cmake --build .
+          ctest . --output-on-failure
+          cmake --install .
+          cd ../tests/installation/find && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=../../../build/destination .. && cmake --build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,12 @@ project(RoaringBitmap
   DESCRIPTION "Roaring bitmaps in C (and C++)"
   LANGUAGES CXX C
 )
-set (CMAKE_C_STANDARD 11)
-set (CMAKE_CXX_STANDARD 11)
+if (NOT DEFINED CMAKE_C_STANDARD)
+  set (CMAKE_C_STANDARD 11)
+endif()
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+  set (CMAKE_CXX_STANDARD 11)
+endif()
 
 include(GNUInstallDirs)
 

--- a/tests/test.h
+++ b/tests/test.h
@@ -57,6 +57,11 @@ extern "C" {
 //
 #ifdef __cplusplus
 #define DEFINE_TEST(name) static void name(void **)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+// In C23, `void name()` declares a function taking no arguments, which is
+// incompatible with cmocka's `void (*)(void **)`. C23 lets us name the
+// parameter and mark it unused to keep the cmocka-compatible signature.
+#define DEFINE_TEST(name) static void name([[maybe_unused]] void **state)
 #else
 #define DEFINE_TEST(name) static void name()
 #endif

--- a/tools/cmake/FindCTargets.cmake
+++ b/tools/cmake/FindCTargets.cmake
@@ -9,7 +9,7 @@ if (ENABLE_ROARING_TESTS AND NOT EMSCRIPTEN)
       OPTIONS "UNIT_TESTING ON"
     )
   else()
-    find_package(cmocka REQUIRED)
+    find_package(cmocka 2.0.0 REQUIRED)
   endif()
 endif()
 


### PR DESCRIPTION
By default, we pull our own dependencies, but some users deactivate this function (`ROARING_USE_CPM`), and they rely on system libraries (e.g., `cmocka`), unfortunately they may have old librairies which will break their build.

Thus, we require cmocka 2 for everyone from now on.

I have also added two changes related to C23: a CI test and a new macro definition (to avoid warnings).

Fixes https://github.com/RoaringBitmap/CRoaring/issues/830

