### PR TITLE
Rename quad pointer local in array_container_contains for Zig translate-c

### DIFF
--- a/include/roaring/containers/array.h
+++ b/include/roaring/containers/array.h
@@ -381,24 +381,24 @@ inline bool array_container_contains(const array_container_t *arr,
     int32_t lo = (carr[(base + 1) * gap - 1] < pos) ? base + 1 : base;
 
     if (lo < num_blocks) {
-        const uint16_t *blk = carr + lo * gap;
+        const uint16_t *quad_ptr = carr + lo * gap;
 #ifdef CROARING_USENEON
         uint16x8_t needle = vdupq_n_u16(pos);
-        uint16x8_t v0 = vld1q_u16(blk);
-        uint16x8_t v1 = vld1q_u16(blk + 8);
+        uint16x8_t v0 = vld1q_u16(quad_ptr);
+        uint16x8_t v1 = vld1q_u16(quad_ptr + 8);
         uint16x8_t hit =
             vorrq_u16(vceqq_u16(v0, needle), vceqq_u16(v1, needle));
         return vmaxvq_u16(hit) != 0;
 #elif defined(CROARING_IS_X64)
         __m128i needle = _mm_set1_epi16((short)pos);
-        __m128i v0 = _mm_loadu_si128((const __m128i *)blk);
-        __m128i v1 = _mm_loadu_si128((const __m128i *)(blk + 8));
+        __m128i v0 = _mm_loadu_si128((const __m128i *)quad_ptr);
+        __m128i v1 = _mm_loadu_si128((const __m128i *)(quad_ptr + 8));
         __m128i hit = _mm_or_si128(_mm_cmpeq_epi16(v0, needle),
                                    _mm_cmpeq_epi16(v1, needle));
         return _mm_movemask_epi8(hit) != 0;
 #else
         for (int32_t j = 0; j < gap; j++) {
-            if (blk[j] >= pos) return blk[j] == pos;
+            if (quad_ptr[j] >= pos) return quad_ptr[j] == pos;
         }
         return false;
 #endif


### PR DESCRIPTION
Split out of #818 (which is being broken into small, single-purpose PRs).

Renames a local pointer in `array_container_contains` (`blk` → `quad_ptr`). Pure local rename, no behavior change. It works around a real Zig `translate-c` bug, so consumers building CRoaring's headers via `zig translate-c` (e.g. wasm32) on affected Zig versions get valid Zig.

## Why it's needed (reproducible)

Standalone reproduction: **https://github.com/stereobooster/zig-0.13-translate-c-blk-repro** (`./reproduce.sh`).

`translate-c` lowers C pointer arithmetic into a labeled Zig block whose default label is `blk`. When a C local is *also* named `blk`, the disambiguation renames the label to `blk_1` but also corrupts the variable reference, emitting invalid Zig:

```
$ zig translate-c -target wasm32-wasi array_container_contains_blk.c > out.zig
$ zig ast-check out.zig
out.zig:162:48: error: use of undeclared identifier 'blk_1'
```

The offending generated line (the second `blk_1` should be the variable `blk`):

```zig
if (tmp >= 0) break :blk_1 blk_1 + @as(usize, @intCast(tmp)) else ...
```

Renaming the C local to `quad_ptr` (this PR) removes the clash and `zig ast-check` passes.

## Affected Zig versions (verified)

| Zig | `blk` (current) | `quad_ptr` (this PR) |
|-----|-----------------|----------------------|
| 0.13.0 | ❌ invalid Zig | ✅ |
| 0.14.1 | ❌ | ✅ |
| 0.15.2 | ❌ | ✅ |
| 0.16.0 | ✅ (fixed upstream) | ✅ |

The bug is present in **Zig 0.13–0.15** and was **fixed upstream in 0.16.0**. This rename is a zero-cost, behavior-preserving change that unblocks consumers still on 0.13–0.15; reviewers may reasonably consider it optional given the upstream fix.

---
*AI usage disclosure (per `AI_USAGE_POLICY.md`):* this change was prepared with significant AI assistance (Claude Code), including the linked Zig reproduction, which I ran and verified across Zig 0.13.0/0.14.1/0.15.2/0.16.0. It is opened as a **draft**; I am reviewing it personally before marking it ready for review, I remain the author and am accountable for the contribution, and I can answer questions about it. The commits also carry a `Co-Authored-By` trailer noting the AI assistance.
