### PR TITLE
Add riscv generic architecture detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ of the latest hardware. Roaring bitmaps are already available on a variety of pl
 # Requirements
 
 - Linux, macOS, FreeBSD, Windows (MSYS2 and Microsoft Visual studio).
-- We test the library with ARM, x64/x86 and POWER processors. We support big endian systems.
+- We test the library with ARM, x64/x86 and POWER processors. We support big endian systems, and generic scalar builds also work on other architectures such as RISC-V.
 - Recent C compiler supporting the C11 standard (GCC 7 or better, LLVM 8 or better (clang), Xcode 11 or better, Microsoft Visual Studio 2022 or better, Intel oneAPI Compiler 2023.2 or better), there is also an optional C++ class that requires a C++ compiler supporting the C++11 standard. We support [Fil-C, the memory-safe C/C++ compiler](https://fil-c.org).
 - CMake (to contribute to the project, users can rely on amalgamation/unity builds if they do not wish to use CMake).
 - The CMake system assumes that git is available.
-- Under x64 systems, the library provides runtime dispatch so that optimized functions are called based on the detected CPU features. It works with GCC, clang (version 9 and up) and Visual Studio (2017 and up). Other systems (e.g., ARM) do not need runtime dispatch.
+- Under x64 systems, the library provides runtime dispatch so that optimized functions are called based on the detected CPU features. It works with GCC, clang (version 9 and up) and Visual Studio (2017 and up). Other systems (e.g., ARM and RISC-V) do not need runtime dispatch and use the generic path unless a dedicated SIMD backend is added.
 
 
 

--- a/include/roaring/isadetection.h
+++ b/include/roaring/isadetection.h
@@ -11,7 +11,10 @@
  */
 #ifndef ROARING_ISADETECTION_H
 #define ROARING_ISADETECTION_H
-#if defined(__x86_64__) || defined(_M_AMD64)  // x64
+
+#include <roaring/portability.h>
+
+#if CROARING_IS_X64  // x64
 
 #ifndef CROARING_COMPILER_SUPPORTS_AVX512
 #ifdef __has_include
@@ -49,5 +52,5 @@ int croaring_hardware_support(void);
 }
 }  // extern "C" { namespace roaring { namespace internal {
 #endif
-#endif  // x64
+#endif  // CROARING_IS_X64
 #endif  // ROARING_ISADETECTION_H

--- a/include/roaring/misc/configreport.h
+++ b/include/roaring/misc/configreport.h
@@ -237,13 +237,17 @@ static inline void tellmeall() {
 #if CROARING_IS_BIG_ENDIAN
     printf("# big-endian system detected\n");
 #endif /* CROARING_IS_BIG_ENDIAN */
-#if defined(__x86_64__) || defined(_M_X64) || defined(__amd64__)
+#if CROARING_IS_X64
     printf("# x64 processor detected\n");
+#elif defined(CROARING_IS_RISCV64)
+    printf("# RISC-V 64-bit processor detected\n");
+#elif defined(CROARING_IS_RISCV)
+    printf("# RISC-V processor detected\n");
 #elif defined(__arm__) || defined(__aarch64__) || defined(__arm64__) || \
     defined(_M_ARM) || defined(_M_ARM64)
     printf("# ARM processor detected\n");
 #else
-    printf("# Non-X64, non-ARM processor\n");
+    printf("# Non-x64, non-ARM, non-RISC-V processor\n");
 #endif /* architecture detection */
 #if defined(__clang__)
     printf("# compiler: clang %d.%d.%d\n", __clang_major__, __clang_minor__,

--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -85,7 +85,14 @@ extern "C" {  // portability definitions are in global scope, not a namespace
 #endif  // __restrict__
 #endif  // CROARING_REGULAR_VISUAL_STUDIO
 
-#if defined(__x86_64__) || defined(_M_X64)
+#if defined(__riscv) || defined(_M_RISCV32) || defined(_M_RISCV64)
+#define CROARING_IS_RISCV 1
+
+#if (defined(__riscv_xlen) && (__riscv_xlen == 64)) || defined(_M_RISCV64)
+#define CROARING_IS_RISCV64 1
+#endif
+
+#elif defined(__x86_64__) || defined(_M_X64)
 // we have an x64 processor
 #define CROARING_IS_X64 1
 

--- a/src/isadetection.c
+++ b/src/isadetection.c
@@ -109,7 +109,7 @@ unsigned int CROARING_AVX512_REQUIRED =
      CROARING_AVX512VBMI2 | CROARING_AVX512BITALG | CROARING_AVX512VPOPCNTDQ);
 #endif
 
-#if defined(__x86_64__) || defined(_M_AMD64)  // x64
+#if CROARING_IS_X64  // x64
 
 static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx,
                          uint32_t *edx) {
@@ -257,7 +257,7 @@ static inline uint32_t dynamic_croaring_detect_supported_architectures(void) {
 
 #endif  // end SIMD extension detection code
 
-#if defined(__x86_64__) || defined(_M_AMD64)  // x64
+#if CROARING_IS_X64  // x64
 
 #if CROARING_ATOMIC_IMPL == CROARING_ATOMIC_IMPL_CPP
 static inline uint32_t croaring_detect_supported_architectures(void) {
@@ -339,7 +339,7 @@ int croaring_hardware_support(void) {
 }
 #endif
 
-#endif  // defined(__x86_64__) || defined(_M_AMD64) // x64
+#endif  // CROARING_IS_X64 // x64
 #ifdef __cplusplus
 }
 }


### PR DESCRIPTION
## Why

CRoaring already has portable generic kernels for non-x64 targets, so `riscv64` should conservatively resolve to that path until a dedicated RISC-V SIMD backend exists. However, some ISA detection code still checked raw host x64 macros directly instead of going through `portability.h`. During forced-target or cross-target validation, that allowed host `x86_64` state to leak into preprocessing and incorrectly preserve x64 runtime-dispatch or AVX assumptions for a `riscv64` target.

## What changed

- Add explicit `CROARING_IS_RISCV` and `CROARING_IS_RISCV64` target markers in `include/roaring/portability.h`, with precedence over x64 detection.
- Make `include/roaring/isadetection.h` include `portability.h` and gate x64-only AVX-512 support logic on `CROARING_IS_X64` instead of raw `__x86_64__` checks.
- Switch `src/isadetection.c` to the centralized `CROARING_IS_X64` target guard so forced or cross-target `riscv64` validation no longer falls back into the x64 runtime-dispatch path.
- Extend `include/roaring/misc/configreport.h` to report RISC-V explicitly instead of lumping it into the generic "non-x64, non-ARM" bucket.
- Update `README.md` to document that RISC-V currently uses the existing generic scalar path and does not participate in x64 runtime dispatch.

## Verification

- Ran the native CMake/Ninja static-library build successfully:
  - `cmake -S . -B build-native -G Ninja -DROARING_USE_CPM=OFF -DENABLE_ROARING_TESTS=OFF -DROARING_DISABLE_AVX512=ON`
  - `cmake --build build-native --parallel 4`
- Ran the simulated `riscv64` CMake/Ninja static-library build successfully:
  - `cmake -S . -B build-riscv-sim -G Ninja -DROARING_USE_CPM=OFF -DENABLE_ROARING_TESTS=OFF -DROARING_DISABLE_AVX512=ON -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=riscv64 -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY`
  - `cmake --build build-riscv-sim --parallel 4`
- Preprocessed `roaring/portability.h` with `-D__riscv=1 -D__riscv_xlen=64` and confirmed it now emits `CROARING_IS_RISCV` and `CROARING_IS_RISCV64`, without defining `CROARING_IS_X64`.
- Preprocessed `roaring/isadetection.h` with the same forced `riscv64` macros and confirmed it no longer emits `CROARING_COMPILER_SUPPORTS_AVX512`, `ROARING_SUPPORTS_AVX2`, or `ROARING_SUPPORTS_AVX512`.
- Compiled forced-`riscv64` smoke translation units for:
  - `src/isadetection.c`
  - `src/array_util.c`
  - `src/containers/bitset.c`
- Checked the simulated `riscv64` build script and confirmed there are no `-msse*`, `-mavx*`, `/arch:AVX*`, or `march=arm*` flags injected into `build-riscv-sim/build.ninja`.
- Cross-built and installed the static library with the real `riscv64` toolchain in `dockcross/linux-riscv64`.
- Configured and built a separate consumer project against the installed package with `find_package(roaring REQUIRED)`.
- Verified the produced executable with:
  - `file`
  - `readelf -h`
- Ran the resulting binary under `qemu-riscv64` and confirmed the expected output:
  - `cardinality = 900`

## Notes

This is a conservative portability patch. It does not add RVV or any other dedicated RISC-V SIMD backend. The goal is to make `riscv64` resolve cleanly to CRoaring's existing generic implementation and to stop host x64 ISA assumptions from leaking into RISC-V validation.