### PR TITLE
Build-C-as-C++ Patches

### DIFF
--- a/include/roaring/roaring_types.h
+++ b/include/roaring/roaring_types.h
@@ -19,7 +19,7 @@
 #ifdef __cplusplus
 extern "C" {
 namespace roaring {
-namespace api {
+namespace internal {
 #endif
 
 /**
@@ -38,13 +38,19 @@ namespace api {
 extern "C++" {
 struct container_s {};
 }
-#define ROARING_CONTAINER_T ::roaring::api::container_s
+#define ROARING_CONTAINER_T ::roaring::internal::container_s
 #else
 #define ROARING_CONTAINER_T void  // no compile-time checking
 #endif
 
 #define ROARING_FLAG_COW UINT8_C(0x1)
 #define ROARING_FLAG_FROZEN UINT8_C(0x2)
+
+#ifdef __cplusplus
+}  // end namespace internal (but still in namespace roaring)
+using internal::container_s;  // use scoped to this namespace block
+namespace api {                        // begin API namespace
+#endif
 
 /**
  * Roaring arrays are array-based key-value pairs having containers as values
@@ -153,7 +159,7 @@ typedef struct roaring_container_iterator_s {
 #ifdef __cplusplus
 }
 }
-}  // extern "C" { namespace roaring { namespace api {
+}  // extern "C" { namespace roaring { namespace internal {
 #endif
 
 #endif /* ROARING_TYPES_H */

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -11,7 +11,7 @@
 #ifdef __cplusplus
 extern "C" {
 namespace roaring {
-namespace internal {
+namespace api {  // bitset_t was once internal, but made public in the API
 #endif
 
 extern inline void bitset_print(const bitset_t *b);

--- a/src/bitset_util.c
+++ b/src/bitset_util.c
@@ -17,10 +17,9 @@
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 #ifdef __cplusplus
-using namespace ::roaring::internal;
 extern "C" {
 namespace roaring {
-namespace api {
+namespace internal {
 #endif
 
 #if CROARING_IS_X64
@@ -1143,7 +1142,7 @@ void bitset_flip_list(uint64_t *words, const uint16_t *list, uint64_t length) {
 #ifdef __cplusplus
 }
 }
-}  // extern "C" { namespace roaring { namespace api {
+}  // extern "C" { namespace roaring { namespace internal {
 #endif
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop

--- a/src/containers/run.c
+++ b/src/containers/run.c
@@ -34,7 +34,9 @@ extern inline bool run_container_nonzero_cardinality(const run_container_t *rc);
 extern inline int32_t run_container_serialized_size_in_bytes(int32_t num_runs);
 extern inline run_container_t *run_container_create_range(uint32_t start,
                                                           uint32_t stop);
-extern inline int run_container_cardinality(const run_container_t *run);
+
+// not `extern inline` (defined below in this file)
+int run_container_cardinality(const run_container_t *run);
 
 bool run_container_add(run_container_t *run, uint16_t pos) {
     int32_t index = interleavedBinarySearch(run->runs, run->n_runs, pos);

--- a/tests/add_offset.c
+++ b/tests/add_offset.c
@@ -12,6 +12,7 @@
 
 #ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
 using namespace roaring::internal;
+using namespace roaring::misc;
 #endif
 
 #include "test.h"

--- a/tests/c_example1.c
+++ b/tests/c_example1.c
@@ -7,6 +7,11 @@
 
 #include "test.h"
 
+#ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
+using namespace roaring::api;
+using namespace roaring::misc;
+#endif
+
 bool roaring_iterator_sumall(uint32_t value, void *param) {
     *(uint32_t *)param += value;
     return true;  // iterate till the end

--- a/tests/cbitset_unit.c
+++ b/tests/cbitset_unit.c
@@ -6,6 +6,10 @@
 
 #include "test.h"
 
+#ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
+using namespace roaring::api;
+#endif
+
 int compute_cardinality(bitset_t *b) {
     size_t k = 0;
     for (size_t i = 0; bitset_next_set_bit(b, &i); i++) {

--- a/tests/container_comparison_unit.c
+++ b/tests/container_comparison_unit.c
@@ -17,6 +17,7 @@
 
 #ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
 using namespace roaring::internal;
+using namespace roaring::misc;
 #endif
 
 #include "test.h"

--- a/tests/cpp_example1.cpp
+++ b/tests/cpp_example1.cpp
@@ -4,6 +4,7 @@
 #include "roaring/roaring64map.hh"
 
 using namespace roaring;
+
 int main() {
     Roaring r1;
     for (uint32_t i = 100; i < 1000; i++) {

--- a/tests/cpp_unit.cpp
+++ b/tests/cpp_unit.cpp
@@ -1066,7 +1066,6 @@ DEFINE_TEST(test_cpp_contains_range_closed_64) {
         // bucket partial.
         auto b0 = uint64_t(0);
         auto b2 = uint64_t(2) << 32;
-        auto uint32_max = (std::numeric_limits<uint32_t>::max)();
         Roaring64Map r;
         r.addRangeClosed(b0, b0 + uint32_max);
         r.addRangeClosed(b2, b2 + 5);
@@ -1077,7 +1076,6 @@ DEFINE_TEST(test_cpp_contains_range_closed_64) {
         // bucket.
         auto b0 = uint64_t(0);
         auto b1 = uint64_t(1) << 32;
-        auto uint32_max = (std::numeric_limits<uint32_t>::max)();
         Roaring64Map r;
         r.addRangeClosed(b0, b0 + uint32_max);
         assert_false(r.containsRangeClosed(b0, b1));

--- a/tests/format_portability_unit.c
+++ b/tests/format_portability_unit.c
@@ -11,6 +11,11 @@
 #include <roaring/misc/configreport.h>
 #include <roaring/roaring.h>
 
+#ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
+using namespace roaring::internal;
+using namespace roaring::misc;
+#endif
+
 #include "config.h"
 #include "test.h"
 

--- a/tests/mixed_container_unit.c
+++ b/tests/mixed_container_unit.c
@@ -18,6 +18,7 @@
 
 #ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
 using namespace roaring::internal;
+using namespace roaring::misc;
 #endif
 
 #include "test.h"

--- a/tests/realdata_unit.c
+++ b/tests/realdata_unit.c
@@ -11,6 +11,7 @@
 
 #ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
 using namespace roaring::internal;
+using namespace roaring::misc;
 #endif
 
 #include "../benchmarks/numbersfromtextfiles.h"

--- a/tests/robust_deserialization_unit.c
+++ b/tests/robust_deserialization_unit.c
@@ -11,6 +11,11 @@
 #include <roaring/misc/configreport.h>
 #include <roaring/roaring.h>
 
+#ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
+using namespace roaring::internal;
+using namespace roaring::misc;
+#endif
+
 #include "config.h"
 #include "test.h"
 

--- a/tests/run_container_unit.c
+++ b/tests/run_container_unit.c
@@ -12,6 +12,7 @@
 
 #ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
 using namespace roaring::internal;
+using namespace roaring::misc;
 #endif
 
 #include "test.h"

--- a/tests/threads_unit.cpp
+++ b/tests/threads_unit.cpp
@@ -5,6 +5,8 @@
 #include <roaring/misc/configreport.h>
 #include <roaring/roaring.h>
 
+using namespace roaring::internal;
+
 // We are mostly running this test to check for data races using thread
 // sanitizer.
 void run(roaring_bitmap_t **rarray) {

--- a/tests/toplevel_unit.c
+++ b/tests/toplevel_unit.c
@@ -13,6 +13,7 @@
 
 #ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
 using namespace roaring::internal;
+using namespace roaring::misc;
 #endif
 
 #include "test.h"

--- a/tests/util_unit.c
+++ b/tests/util_unit.c
@@ -13,6 +13,7 @@
 
 #ifdef __cplusplus  // stronger type checking errors if C built in C++ mode
 using namespace roaring::internal;
+using namespace roaring::misc;
 #endif
 
 #include "test.h"


### PR DESCRIPTION
As per [C++ core guidelines CPL.2](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rcpl-subset), it's best for C code to be buildable with a C++ compiler.  *(my codebase using CRoaring has to build as both C99+ and C++11+)*.  Because of this I had contributed some of the necessary changes to CRoaring to achieve that some years ago.

At that time, I also slipped in some "experimental" ideas involving how `container_t*` could be a `void*` in C, but in C++ it could use the "empty base class optimization" with the container subclasses inheriting from it.  This meant it would be type checked more strongly if built as C++...so that you got the benefit of typed inheritance...only allowing containers to be passed to `container_t*` vs arbitrary pointers.

It was the *start* of a good idea, but only the start *(and the way I did it then was often more clutter than it provided benefit, as well as an ABI break with C-built code in some compilers in some circumstances)*.  Those ideas have evolved into a **vastly** richer framework now... which may be applied to many problems.  Including solving your [memory allocation failures/propagation](https://github.com/RoaringBitmap/CRoaring/issues/630) in a "Rust-like" way, by using the type system to annotate the return values of routines that can fail, and forcing compile-time errors when triage is not performed:

  https://needful.metaeducation.com/

This new model removes the wacky C++ from CRoaring's codebase entirely; the "enhancements" are in a repository that only those who wish to build with instrumentation "install".  It becomes a tool that you sideload in certain developer/CI builds--not part of CRoaring itself.  *(Your focus on "amalgamation" demonstrates you are interested in pragmatic packaging, and Needful is also very pragmatic: removing the clutter, while delivering the benefit.)*

Which is good: e.g. in my fork I've eliminated of all the below kind of junk, while delivering the actual value that a "C++ enhanced build" was theoretically supposed to provide:

https://github.com/RoaringBitmap/CRoaring/blob/d60ba3f447341a088bc8041277f6017f65787261/include/roaring/containers/container_defs.h#L73-L88

https://github.com/RoaringBitmap/CRoaring/blob/d60ba3f447341a088bc8041277f6017f65787261/include/roaring/containers/array.h#L54-L56

(etc.)  This is all gone, replaced by a ([via a single `downcast` operator](https://needful.metaeducation.com/cast#downcast-allows-mutable-source-to-const-target)), that's just `#define downcast (void*)` in the baseline C distribution (and [minor magic](https://github.com/metaeducation/needful/blob/f18e92891e656bf9fbb26e800eaffed34ebcb49b/needful.h#L160-L217) in non-enhanced C++ builds)... but [metaprogramming sorcery](https://github.com/metaeducation/needful-enhanced/blob/main/needful-casts.hpp) once you sideload the C++ enhanced files.  It detects the target type implicitly without you having to say what it is and validates the inheritance relationship, it won't downcast const pointers to non-const, it won't cast double-pointers to single ones, it can compile-time restrict the allowed to and from casts, or runtime validate the bit patterns based on what you're casting to what, and so on and so forth...

---

But to get the ball rolling to show you what I mean, the atrophy in C++ builds has to be fixed first.  Here are some (I hope) uncontroversial patches to start with.