### PR TITLE
Speed up array container union: remove qsort from the SIMD tail, add an AVX-512 bitonic merge

### DIFF
--- a/include/roaring/array_util.h
+++ b/include/roaring/array_util.h
@@ -309,6 +309,17 @@ size_t union_uint32(const uint32_t *set_1, size_t size_1, const uint32_t *set_2,
 uint32_t union_vector16(const uint16_t *set_1, uint32_t size_1,
                         const uint16_t *set_2, uint32_t size_2,
                         uint16_t *buffer);
+
+#if CROARING_COMPILER_SUPPORTS_AVX512
+/**
+ * AVX-512 union of two sorted uint16 arrays, using a Batcher bitonic merge
+ * network over 32 lanes. Same contract as union_vector16: `buffer` must have
+ * room for size_1 + size_2 values.
+ */
+uint32_t avx512_union_uint16(const uint16_t *set_1, uint32_t size_1,
+                             const uint16_t *set_2, uint32_t size_2,
+                             uint16_t *buffer);
+#endif  // CROARING_COMPILER_SUPPORTS_AVX512
 /**
  * A fast SSE-based XOR function.
  */

--- a/include/roaring/array_util.h
+++ b/include/roaring/array_util.h
@@ -320,6 +320,7 @@ uint32_t avx512_union_uint16(const uint16_t *set_1, uint32_t size_1,
                              const uint16_t *set_2, uint32_t size_2,
                              uint16_t *buffer);
 #endif  // CROARING_COMPILER_SUPPORTS_AVX512
+
 /**
  * A fast SSE-based XOR function.
  */

--- a/src/array_util.c
+++ b/src/array_util.c
@@ -1746,6 +1746,171 @@ CROARING_UNTARGET_AVX2
  */
 
 /**
+ * Start of the AVX-512 16-bit union code.
+ *
+ * union_vector16 above merges 8 lanes at a time with an odd-even transposition
+ * network: 8 dependent min/max stages per 8 output values, which measures at
+ * ~2.3 cycles per input element -- no better than the scalar union_uint16.
+ *
+ * With AVX-512 we can merge 32+32 lanes with a Batcher bitonic network: one
+ * reverse plus 5 compare-exchange stages per sorted half, i.e. ~4x fewer
+ * operations per output value. This needs cross-lane 16-bit permutes (vpermw,
+ * vpermt2w) and a 16-bit compress store (vpcompressw); AVX2 has none of these,
+ * so the algorithm is genuinely AVX-512-only rather than a wider rerun of the
+ * SSE code.
+ */
+#if CROARING_COMPILER_SUPPORTS_AVX512
+
+CROARING_TARGET_AVX512
+
+// A compare-exchange at distance d pairs lane i with lane i^d and keeps the
+// smaller value in whichever lane has its d-bit clear. `hi` selects the lanes
+// whose d-bit is set.
+static inline __m512i avx512_cx16(__m512i v, __m512i t, __mmask32 hi) {
+    return _mm512_mask_mov_epi16(_mm512_min_epu16(v, t), hi,
+                                 _mm512_max_epu16(v, t));
+}
+
+// Sort a bitonic 32-lane sequence into ascending order. Each distance has a
+// dedicated cheap shuffle, so no stage needs a full vpermw.
+static inline __m512i avx512_bitonic_sort32(__m512i v) {
+    v = avx512_cx16(v, _mm512_shuffle_i64x2(v, v, 0x4E), 0xFFFF0000u);  // d=16
+    v = avx512_cx16(v, _mm512_shuffle_i64x2(v, v, 0xB1), 0xFF00FF00u);  // d=8
+    v = avx512_cx16(v, _mm512_shuffle_epi32(v, 0x4E), 0xF0F0F0F0u);     // d=4
+    v = avx512_cx16(v, _mm512_shuffle_epi32(v, 0xB1), 0xCCCCCCCCu);     // d=2
+    v = avx512_cx16(v, _mm512_rol_epi32(v, 16), 0xAAAAAAAAu);           // d=1
+    return v;
+}
+
+// Merge two ascending 32-lane vectors: *lo receives the 32 smallest values in
+// ascending order, *hi the 32 largest, also ascending.
+static inline void avx512_bitonic_merge32(__m512i a, __m512i b, __m512i *lo,
+                                          __m512i *hi) {
+    static const uint16_t revtab[32] = {
+        31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
+        15, 14, 13, 12, 11, 10, 9,  8,  7,  6,  5,  4,  3,  2,  1,  0};
+    __m512i br = _mm512_permutexvar_epi16(
+        _mm512_loadu_si512((const __m512i *)revtab), b);
+    *lo = avx512_bitonic_sort32(_mm512_min_epu16(a, br));
+    *hi = avx512_bitonic_sort32(_mm512_max_epu16(a, br));
+}
+
+// Write the values of the ascending vector `v` that differ from their
+// predecessor, where the predecessor of lane 0 is *last. Updates *last to the
+// largest value emitted and returns how many values were written.
+static inline int avx512_emit_unique16(__m512i v, uint16_t *out,
+                                       uint16_t *last) {
+    static const uint16_t shift1[32] = {
+        32, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
+        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30};
+    __m512i prev = _mm512_permutex2var_epi16(
+        v, _mm512_loadu_si512((const __m512i *)shift1),
+        _mm512_set1_epi16((short)*last));
+    __mmask32 keep = _mm512_cmpneq_epi16_mask(v, prev);
+    _mm512_mask_compressstoreu_epi16(out, keep, v);
+    *last = (uint16_t)_mm_extract_epi16(_mm512_extracti32x4_epi32(v, 3), 7);
+    return (int)roaring_hamming(keep);
+}
+
+/**
+ * A one-pass AVX-512 union of two sorted uint16 arrays.
+ *
+ * As with union_vector16, the caller must guarantee that `output` has room for
+ * size_1 + size_2 values. Partial overlap of `output` with the inputs is
+ * tolerated in exactly the same way union_vector16 tolerates it (see the long
+ * comment in array_run_container_inplace_union): after consuming p1 + p2 whole
+ * 32-lane blocks this routine has written at most 32*(p1+p2) - 32 values,
+ * because one merged block is always held back in `vmax`. The output pointer
+ * therefore stays strictly behind the read pointers.
+ */
+uint32_t avx512_union_uint16(const uint16_t *array1, uint32_t length1,
+                             const uint16_t *array2, uint32_t length2,
+                             uint16_t *output) {
+    const uint32_t W = 32;  // lanes per 512-bit register
+    if (length1 < W || length2 < W) {
+        return (uint32_t)union_uint16(array1, length1, array2, length2, output);
+    }
+    const uint32_t blocks1 = length1 / W, blocks2 = length2 / W;
+    uint32_t p1 = 0, p2 = 0;
+    uint16_t *out = output;
+    __m512i vmin, vmax;
+
+    avx512_bitonic_merge32(_mm512_loadu_si512((const __m512i *)array1),
+                           _mm512_loadu_si512((const __m512i *)array2), &vmin,
+                           &vmax);
+    p1 = 1;
+    p2 = 1;
+    // Lane 0 of the very first block has no predecessor. Seeding `last` with a
+    // value that differs from it in one bit keeps the first value.
+    uint16_t last =
+        (uint16_t)(_mm_extract_epi16(_mm512_castsi512_si128(vmin), 0) ^ 1);
+    out += avx512_emit_unique16(vmin, out, &last);
+
+    while (p1 < blocks1 && p2 < blocks2) {
+        // Which side advances is essentially unpredictable, so select the
+        // source pointer without branching.
+        const uint16_t *pa = array1 + W * p1;
+        const uint16_t *pb = array2 + W * p2;
+        const uint32_t take1 = (*pa <= *pb) ? 1 : 0;
+        const __m512i v =
+            _mm512_loadu_si512((const __m512i *)(take1 ? pa : pb));
+        p1 += take1;
+        p2 += 1 - take1;
+        avx512_bitonic_merge32(v, vmax, &vmin, &vmax);
+        out += avx512_emit_unique16(vmin, out, &last);
+    }
+
+    // The ragged tail: the values still held in vmax, plus at most W-1 leftover
+    // values from the exhausted side, plus the rest of the other side. Two
+    // two-way merges branch-predict far better than one three-way merge.
+    //
+    // vmax can hold the same value twice (once from each input), so it goes
+    // through avx512_emit_unique16 rather than a raw store: that dedups within
+    // the block and against `last` at the same time. Every remaining tail value
+    // is >= last and the tail is sorted, so for the two scalar inputs only the
+    // very first value can still duplicate `last`.
+    uint16_t pending[32];
+    uint16_t pending_last = last;
+    size_t npending =
+        (size_t)avx512_emit_unique16(vmax, pending, &pending_last);
+
+    const uint16_t *rest1 = array1 + W * p1, *rest2 = array2 + W * p2;
+    size_t nrest1 = length1 - W * p1, nrest2 = length2 - W * p2;
+    const uint16_t *shortrest, *longrest;
+    size_t nshort, nlong;
+    if (p1 == blocks1) {
+        shortrest = rest1;
+        nshort = nrest1;
+        longrest = rest2;
+        nlong = nrest2;
+    } else {
+        shortrest = rest2;
+        nshort = nrest2;
+        longrest = rest1;
+        nlong = nrest1;
+    }
+    if (nshort > 0 && shortrest[0] == last) {
+        shortrest++;
+        nshort--;
+    }
+    if (nlong > 0 && longrest[0] == last) {
+        longrest++;
+        nlong--;
+    }
+
+    uint16_t merged[2 * 32];  // <= W pending + (W-1) leftover
+    size_t nmerged = union_uint16(pending, npending, shortrest, nshort, merged);
+    out += union_uint16(merged, nmerged, longrest, nlong, out);
+    return (uint32_t)(out - output);
+}
+CROARING_UNTARGET_AVX512
+#endif  // CROARING_COMPILER_SUPPORTS_AVX512
+
+/**
+ * End of the AVX-512 16-bit union code.
+ */
+
+/**
  * Start of SIMD 16-bit XOR code
  */
 
@@ -1989,7 +2154,20 @@ size_t fast_union_uint16(const uint16_t *set_1, size_t size_1,
                          const uint16_t *set_2, size_t size_2,
                          uint16_t *buffer) {
 #if CROARING_IS_X64
-    if (croaring_hardware_support() & ROARING_SUPPORTS_AVX2) {
+    const unsigned support = (unsigned)croaring_hardware_support();
+#if CROARING_COMPILER_SUPPORTS_AVX512
+    if (support & ROARING_SUPPORTS_AVX512) {
+        // compute union with smallest array first
+        if (size_1 < size_2) {
+            return avx512_union_uint16(set_1, (uint32_t)size_1, set_2,
+                                       (uint32_t)size_2, buffer);
+        } else {
+            return avx512_union_uint16(set_2, (uint32_t)size_2, set_1,
+                                       (uint32_t)size_1, buffer);
+        }
+    }
+#endif  // CROARING_COMPILER_SUPPORTS_AVX512
+    if (support & ROARING_SUPPORTS_AVX2) {
         // compute union with smallest array first
         if (size_1 < size_2) {
             return union_vector16(set_1, (uint32_t)size_1, set_2,

--- a/src/array_util.c
+++ b/src/array_util.c
@@ -1822,12 +1822,25 @@ static inline int avx512_emit_unique16(__m512i v, uint16_t *out,
  * 32-lane blocks this routine has written at most 32*(p1+p2) - 32 values,
  * because one merged block is always held back in `vmax`. The output pointer
  * therefore stays strictly behind the read pointers.
+ *
+ * That bound is exactly tight rather than merely satisfied: in the worst case
+ * the final merge below writes its last value to precisely the slot the last
+ * input value was read from. Anything that reduces how much the tail holds back
+ * -- shrinking `pending`, emitting `vmax` sooner -- silently breaks aliased
+ * callers, so re-derive the bound before changing the buffering here.
  */
 uint32_t avx512_union_uint16(const uint16_t *array1, uint32_t length1,
                              const uint16_t *array2, uint32_t length2,
                              uint16_t *output) {
     const uint32_t W = 32;  // lanes per 512-bit register
     if (length1 < W || length2 < W) {
+        // Not enough on one side to fill a block. union_vector16 keeps
+        // vectorizing at 8-lane granularity, so it still beats the scalar
+        // merge once there is a worthwhile amount of data on the other side;
+        // below that its own fixed overhead dominates.
+        if (length1 + length2 >= 64) {
+            return union_vector16(array1, length1, array2, length2, output);
+        }
         return (uint32_t)union_uint16(array1, length1, array2, length2, output);
     }
     const uint32_t blocks1 = length1 / W, blocks2 = length2 / W;
@@ -1900,7 +1913,16 @@ uint32_t avx512_union_uint16(const uint16_t *array1, uint32_t length1,
 
     uint16_t merged[2 * 32];  // <= W pending + (W-1) leftover
     size_t nmerged = union_uint16(pending, npending, shortrest, nshort, merged);
-    out += union_uint16(merged, nmerged, longrest, nlong, out);
+    // When the small side held fewer than two blocks the loop above ran at most
+    // once, so `longrest` can still be most of the larger input. Finishing that
+    // scalar would give away more than the block loop won, hence the same
+    // 8-lane handoff as in the short-input case.
+    if (nlong >= 64) {
+        out += union_vector16(merged, (uint32_t)nmerged, longrest,
+                              (uint32_t)nlong, out);
+    } else {
+        out += union_uint16(merged, nmerged, longrest, nlong, out);
+    }
     return (uint32_t)(out - output);
 }
 CROARING_UNTARGET_AVX512

--- a/src/array_util.c
+++ b/src/array_util.c
@@ -1641,9 +1641,19 @@ static inline uint32_t unique(uint16_t *out, uint32_t len) {
     return pos;
 }
 
-// use with qsort, could be avoided
-static int uint16_compare(const void *a, const void *b) {
-    return (*(uint16_t *)a - *(uint16_t *)b);
+// Sort a very short run of uint16 values in place. The callers below feed this
+// at most 16 values; calling qsort() for that costs more in glibc merge-sort
+// setup, function-pointer compares and memmove traffic than the sort itself.
+static inline void sort_uint16_short(uint16_t *z, uint32_t n) {
+    for (uint32_t i = 1; i < n; i++) {
+        uint16_t v = z[i];
+        uint32_t j = i;
+        while (j > 0 && z[j - 1] > v) {
+            z[j] = z[j - 1];
+            j--;
+        }
+        z[j] = v;
+    }
 }
 
 CROARING_TARGET_AVX2
@@ -1712,7 +1722,7 @@ uint32_t union_vector16(const uint16_t *array1, uint32_t length1,
         memcpy(buffer + leftoversize, array1 + 8 * pos1,
                (length1 - 8 * len1) * sizeof(uint16_t));
         leftoversize += length1 - 8 * len1;
-        qsort(buffer, leftoversize, sizeof(uint16_t), uint16_compare);
+        sort_uint16_short(buffer, leftoversize);
 
         leftoversize = unique(buffer, leftoversize);
         len += (uint32_t)union_uint16(buffer, leftoversize, array2 + 8 * pos2,
@@ -1721,7 +1731,7 @@ uint32_t union_vector16(const uint16_t *array1, uint32_t length1,
         memcpy(buffer + leftoversize, array2 + 8 * pos2,
                (length2 - 8 * len2) * sizeof(uint16_t));
         leftoversize += length2 - 8 * len2;
-        qsort(buffer, leftoversize, sizeof(uint16_t), uint16_compare);
+        sort_uint16_short(buffer, leftoversize);
         leftoversize = unique(buffer, leftoversize);
         len += (uint32_t)union_uint16(buffer, leftoversize, array1 + 8 * pos1,
                                       length1 - 8 * pos1, output);
@@ -1853,7 +1863,7 @@ uint32_t xor_vector16(const uint16_t *array1, uint32_t length1,
                    (length2 - 8 * pos2) * sizeof(uint16_t));
             len += (length2 - 8 * pos2);
         } else {
-            qsort(buffer, leftoversize, sizeof(uint16_t), uint16_compare);
+            sort_uint16_short(buffer, leftoversize);
             leftoversize = unique_xor(buffer, leftoversize);
             len += xor_uint16(buffer, leftoversize, array2 + 8 * pos2,
                               length2 - 8 * pos2, output);
@@ -1867,7 +1877,7 @@ uint32_t xor_vector16(const uint16_t *array1, uint32_t length1,
                    (length1 - 8 * pos1) * sizeof(uint16_t));
             len += (length1 - 8 * pos1);
         } else {
-            qsort(buffer, leftoversize, sizeof(uint16_t), uint16_compare);
+            sort_uint16_short(buffer, leftoversize);
             leftoversize = unique_xor(buffer, leftoversize);
             len += xor_uint16(buffer, leftoversize, array1 + 8 * pos1,
                               length1 - 8 * pos1, output);


### PR DESCRIPTION
Array container unions were the slowest of the array kernels by a wide margin, and neither of the two reasons was the one I expected. This fixes both.

Measurements are on a Xeon Gold 6548N (Emerald Rapids, `avx512vbmi2` / `vpopcntdq` / `bitalg`), glibc 2.39, gcc 14.3.

### Background: where the time actually goes

Cost per input element of the balanced array-container kernels on master:

| kernel | cycles/element |
| --- | --- |
| `intersect_vector16` | 0.50 |
| `difference_vector16` | 0.44 |
| **`union_vector16`** | **2.28** |
| **`xor_vector16`** | **2.51** |

Intersection is essentially at the hardware limit — `PCMPISTRM` retires 64 comparisons in ~3 cycles, and any AVX-512 all-pairs replacement needs 32 `vpermw` + 32 `vpcmpw`, all of which contend for port 5, costing ≥2 cycles/element. I prototyped and rejected two other AVX-512 candidates for the same reason: a 16-wide gather-based binary search for `intersect_skewed_uint16` (0.63–1.44x, gather throughput dominates) and a `vpconflictd`-based scatter for `bitset_set_list` (0.63–0.75x — the existing `bts` loop already runs at 1.45 cycles/element and beats scatter). Union and XOR were the real outliers.

### Commit 1: `qsort()` in the union/xor tails

`union_vector16()` and `xor_vector16()` finish by sorting a leftover buffer of **at most 16 `uint16` values**, and call `qsort()` to do it. On glibc that is a merge sort behind a function pointer, with its own temporary allocation and `memmove` traffic.

Profiling `union_vector16` on 64-element inputs attributes **53% of its cycles to that tail**: `msort_with_tmp` 23.8%, `memmove` 18.5%, `uint16_compare` 5.2%, `qsort_r` 2.4%.

The cost is fixed, ~80–130ns per call regardless of input length. That is enough to make `union_vector16` **slower than the scalar `union_uint16` it replaces at every size up to 2048 elements** — so on current master, dispatching to the SSE union is a pessimization on this machine except at the very largest container sizes.

An inline insertion sort over ≤16 values removes it. This one is portable and helps every target, not just x86.

### Commit 2: AVX-512 bitonic merge

`union_vector16` uses an 8-lane odd-even transposition network — 8 dependent min/max stages per 8 output values. That is O(n) stages per vector, so simply widening the registers buys nothing.

Replaced with a Batcher bitonic merge over 32 lanes: reverse one input, one min/max pair, then 5 compare-exchange stages per sorted half. Each distance has a cheap dedicated shuffle (`vshufi64x2`, `vpshufd`, `vprold`), so only the reverse needs a full `vpermw`. Dedup folds into one `vpcompressw` masked store against the previous lane. Result: ~1.3 cycles/element.

This is genuinely AVX-512-specific rather than a wider rerun of the SSE code — it needs cross-lane 16-bit permutes (`vpermw`, `vpermt2w`) and a 16-bit compress store (`vpcompressw`, AVX512_VBMI2), none of which exist in AVX2. Inputs below one 32-lane block fall through to `union_uint16`.

Kernel in isolation, n vs n, vs `union_vector16`: **8.6x** at n=32, 2.4x at 128, 2.0x at 512, 1.9x at 1024, 1.9x at 4096.

### End-to-end

`roaring_bitmap_or` over bitmaps whose containers are array containers of the given size (32 containers, min-of-15 rounds, pinned core, idle machine), ns:

| values/container | master | this PR | commit 1 alone | total |
| --- | --- | --- | --- | --- |
| 8 | 4147 | 1422 | 2.75x | **2.92x** |
| 24 | 5270 | 2096 | 2.47x | **2.51x** |
| 64 | 7259 | 3257 | 1.78x | **2.23x** |
| 256 | 18068 | 8827 | 1.40x | **2.05x** |
| 1024 | 49042 | 27324 | 1.09x | **1.79x** |
| 3000 | 124479 | 124306 | 1.00x | 1.00x |

`roaring_bitmap_or_inplace` moves 1.30x–2.28x over the same range.

Below 32 values/container the AVX-512 kernel is not used, so those rows are commit 1 alone. At 3000 values/container nothing changes because the union crosses the 4096-value threshold and converts to a bitset container. `or_many` is unchanged at every size — it goes through `lazy_or` with bitset conversion, so it never reaches this kernel.

### On the existing microbenchmarks

I ran the `microbenchmarks/bench` suite across four datasets and am deliberately **not** quoting it as evidence. It reported `SuccessiveUnion` at 0.91–0.94, but the same runs also moved `ContainsColdHigh` (0.67–0.69) and `AddOffset32771` (0.77–0.83), neither of which calls `fast_union_uint16` — so those runs carry layout/contention artifacts at a magnitude that swamps the signal. Two separate issues make that suite a poor instrument here, both worth addressing independently of this PR:

- `load_synthetic()` builds 30,000 bitmaps at startup, and at the default `--benchmark_min_time` that setup is ~37% of the process. The `binarySearch` (15–19%) and `__memmove_avx512` (10–16%) that top every profile are setup, not the kernel under test.
- `SuccessiveUnion` spends ~33% of its time in the allocator (`malloc_consolidate` 10%, `unlink_chunk` 9.4%, `_int_malloc` 8.2%), and its array containers are mostly under 32 values.

### Validation

- Correctness: 3078 randomized shapes against `union_uint16` (lengths 0..4096 including block boundaries 31/32/33, universes 200/4096/65536 so duplicate-heavy inputs are covered), 0 mismatches.
- Full `ctest` (26 suites) passes under gcc, clang, `ROARING_SANITIZE`, `ROARING_SANITIZE_UNDEFINED`, `-DROARING_DISABLE_AVX512=ON`, the amalgamation build, and arm64 (macOS).
- No new compiler warnings; formatted with clang-format 17 to match CI.

### Note on aliasing

`fast_union_uint16` is called with partially overlapping input and output from `array_run_container_inplace_union`. The new kernel preserves that contract the same way `union_vector16` does: after consuming `p1 + p2` whole blocks it has written at most `32*(p1+p2) - 32` values, because one merged block is always held back in `vmax`, so the write pointer stays strictly behind both read pointers. The tail does its two-way merges reading before writing.

### Follow-up, not in this PR

`vpternlogq` gives a 3-input bitset OR at **1.66x** over pairwise for 2 sources, 1.33x for 4, 1.14x for 8 — AVX2 has no equivalent. `roaring_bitmap_or_many` currently accumulates strictly pairwise via `lazy_or_inplace`, so it leaves that on the table. It needs a 3-input container-level op plus pairing in `or_many`, so it is a real change rather than a drop-in, but it is the thing that would move `TotalUnionHeap`.
