### PR TITLE
feat: Add Roaring64 run optimization and portable serialization methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,8 +533,8 @@ The C++ interface is provided via the `roaring.hh` (32-bit), `roaring64map.hh`, 
   - Check if the bitmap is empty.
 - `void clear()`
   - Remove all elements.
-- `void runOptimize()`
-  - Convert internal containers to run containers for better compression.
+- `bool runOptimize()`
+  - Convert internal containers to run containers for better compression. Returns `true` if the result has at least one run container.
 - `void setCopyOnWrite(bool enable)`
   - Enable or disable copy-on-write mode for fast/shallow copies.
 - `bool operator==(const Roaring&) const` / `bool operator==(const Roaring64Map&) const`
@@ -562,11 +562,11 @@ The C++ interface is provided via the `roaring.hh` (32-bit), `roaring64map.hh`, 
 ## Serialization and Deserialization
 - `size_t getSizeInBytes() const`
   - Get the size in bytes for serialization.
-- `void write(char* buf) const`
-  - Serialize the bitmap to a buffer.
+- `size_t write(char* buf) const`
+  - Serialize the bitmap to a buffer. Returns how many bytes were written.
 - `static Roaring read(const char* buf, bool portable = true)`
   - Deserialize a bitmap from a buffer.
-- `static Roaring readSafe(const char* buf, size_t maxbytes, bool portable = true)`
+- `static Roaring readSafe(const char* buf, size_t maxbytes)`
   - Safe deserialization (will not read past `maxbytes`).
 
 ## Bulk Operations

--- a/cpp/roaring/roaring64.hh
+++ b/cpp/roaring/roaring64.hh
@@ -440,6 +440,50 @@ class Roaring64 {
         return api::roaring64_bitmap_shrink_to_fit(roaring);
     }
 
+    /**
+     * How many bytes are required to serialize this bitmap.
+     */
+    size_t getSizeInBytes() const noexcept {
+        return api::roaring64_bitmap_portable_size_in_bytes(roaring);
+    }
+
+    /**
+     * Write a bitmap to a char buffer, which should refer to at least
+     * getSizeInBytes() allocated bytes. Returns how many bytes were written.
+     * Only the portable format is supported.
+     */
+    size_t write(char* buf) const noexcept {
+        return api::roaring64_bitmap_portable_serialize(roaring, buf);
+    }
+
+    /**
+     * Read a bitmap from a serialized version, placing no limit on how many
+     * bytes are read. See also readSafe. May throw std::runtime_error.
+     */
+    static Roaring64 read(const char* buf) { return readSafe(buf, SIZE_MAX); }
+
+    /**
+     * Read a bitmap from a serialized version, reading no more than maxbytes
+     * bytes. The result is usable only if the input follows the format
+     * specification. May throw std::runtime_error.
+     */
+    static Roaring64 readSafe(const char* buf, size_t maxbytes) {
+        roaring64_bitmap_t* result =
+            api::roaring64_bitmap_portable_deserialize_safe(buf, maxbytes);
+        if (result == nullptr) {
+            ROARING_TERMINATE("failed alloc while reading");
+        }
+        return Roaring64(result);
+    }
+
+    /**
+     * Compute how many bytes would be read by readSafe. Returns 0 if the
+     * serialized data is invalid.
+     */
+    static size_t serializedSizeInBytesSafe(const char* buf, size_t maxbytes) {
+        return api::roaring64_bitmap_portable_deserialize_size(buf, maxbytes);
+    }
+
     typedef Roaring64ConstIterator const_iterator;
 
     /**

--- a/cpp/roaring/roaring64.hh
+++ b/cpp/roaring/roaring64.hh
@@ -414,6 +414,32 @@ class Roaring64 {
         return Roaring64(result);
     }
 
+    /**
+     * Remove run-length encoding even when it is more space efficient.
+     * Return whether a change was applied.
+     */
+    bool removeRunCompression() noexcept {
+        return api::roaring64_bitmap_remove_run_compression(roaring);
+    }
+
+    /**
+     * Convert array and bitmap containers to run containers when it is more
+     * efficient; also convert from run containers when more space efficient.
+     * Returns true if the result has at least one run container.
+     * Additional savings might be possible by calling shrinkToFit().
+     */
+    bool runOptimize() noexcept {
+        return api::roaring64_bitmap_run_optimize(roaring);
+    }
+
+    /**
+     * If needed, reallocate memory to shrink the memory usage.
+     * Returns the number of bytes saved.
+     */
+    size_t shrinkToFit() noexcept {
+        return api::roaring64_bitmap_shrink_to_fit(roaring);
+    }
+
     typedef Roaring64ConstIterator const_iterator;
 
     /**

--- a/tests/cpp_roaring64_unit.cpp
+++ b/tests/cpp_roaring64_unit.cpp
@@ -241,6 +241,58 @@ DEFINE_TEST(test_cpp_r64_bidirectional) {
     assert_true(rev_empty.empty());
 }
 
+DEFINE_TEST(test_cpp_r64_run_optimize) {
+    Roaring64 r;
+    const uint64_t sparse = uint64_t(1) << 40;
+    r.add(sparse);
+    assert_false(r.runOptimize());
+
+    for (uint64_t i = 0; i < 30000; ++i) {
+        r.add(i);
+    }
+    assert_true(r.runOptimize());
+
+    assert_int_equal(r.cardinality(), 30001);
+    assert_true(r.contains(0));
+    assert_true(r.contains(29999));
+    assert_false(r.contains(30000));
+    assert_true(r.contains(sparse));
+}
+
+DEFINE_TEST(test_cpp_r64_remove_run_compression) {
+    Roaring64 r;
+    for (uint64_t i = 0; i < 30000; ++i) {
+        r.add(i);
+    }
+    assert_true(r.runOptimize());
+    assert_true(r.removeRunCompression());
+    assert_false(r.removeRunCompression());
+    assert_true(r.runOptimize());
+
+    assert_int_equal(r.cardinality(), 30000);
+    assert_true(r.contains(0));
+    assert_true(r.contains(29999));
+    assert_false(r.contains(30000));
+}
+
+DEFINE_TEST(test_cpp_r64_shrink_to_fit) {
+    Roaring64 r;
+    for (uint64_t i = 0; i < 1000; ++i) {
+        r.add(i << 32);  // one container per value
+    }
+    for (uint64_t i = 500; i < 1000; ++i) {
+        r.remove(i << 32);
+    }
+    assert_true(r.shrinkToFit() > 0);  // slack from the removed containers
+
+    assert_int_equal(r.cardinality(), 500);
+    assert_true(r.contains(0));
+    assert_true(r.contains(uint64_t(499) << 32));
+    assert_false(r.contains(uint64_t(500) << 32));
+
+    assert_int_equal(r.shrinkToFit(), 0);
+}
+
 DEFINE_TEST(test_cpp_r64_random_vs_set) {
     doublechecked::Roaring64 r;
     std::vector<uint64_t> added;  // values that have been added
@@ -273,12 +325,27 @@ DEFINE_TEST(test_cpp_r64_random_vs_set) {
             r.add(v);
             added.push_back(v);
         }
+        // Periodically apply a post-processing step to the bitset
+        switch (next() % 15) {
+            case 0:
+                r.removeRunCompression();
+                break;
+            case 1:
+                r.runOptimize();
+                break;
+            case 2:
+                r.shrinkToFit();
+                break;
+            default:
+                break;
+        }
         if ((i % 500) == 0) {
             (void)r.cardinality();
             if (!added.empty()) {
                 (void)r.contains(added[next() % added.size()]);
             }
             (void)r.isEmpty();
+            r.validate();
         }
     }
     r.validate();  // manually validate
@@ -299,6 +366,9 @@ int main() {
         cmocka_unit_test(test_cpp_r64_set_ops),
         cmocka_unit_test(test_cpp_r64_iteration),
         cmocka_unit_test(test_cpp_r64_bidirectional),
+        cmocka_unit_test(test_cpp_r64_run_optimize),
+        cmocka_unit_test(test_cpp_r64_remove_run_compression),
+        cmocka_unit_test(test_cpp_r64_shrink_to_fit),
         cmocka_unit_test(test_cpp_r64_random_vs_set),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/cpp_roaring64_unit.cpp
+++ b/tests/cpp_roaring64_unit.cpp
@@ -2,17 +2,23 @@
  * Unit tests for the C++ roaring::Roaring64 class (ART-based 64-bit bitmap).
  */
 #include <cstdint>
+#include <cstring>
+#include <fstream>
 #include <iterator>
+#include <string>
 #include <type_traits>
 #include <vector>
 
 #include <roaring/roaring64.h>  // C API for comparison
 #include <roaring/roaring64.hh>
+#include <roaring/roaring64map.hh>
 
+#include "config.h"
 #include "roaring64_checked.hh"
 #include "test.h"
 
 using roaring::Roaring64;
+using roaring::Roaring64Map;
 
 static_assert(std::is_nothrow_move_constructible<Roaring64>::value,
               "Expected Roaring64 to be nothrow move constructible");
@@ -293,6 +299,147 @@ DEFINE_TEST(test_cpp_r64_shrink_to_fit) {
     assert_int_equal(r.shrinkToFit(), 0);
 }
 
+DEFINE_TEST(test_cpp_r64_run_compression) {
+    Roaring64 r;
+    for (uint64_t i = 100; i <= 10000; i++) {
+        r.add(i);
+    }
+    size_t size_origin = r.getSizeInBytes();
+    bool has_run = r.runOptimize();
+    size_t size_optimized = r.getSizeInBytes();
+    assert_true(has_run);
+    assert_true(size_origin > size_optimized);
+    bool removed = r.removeRunCompression();
+    assert_true(removed);
+    size_t size_removed = r.getSizeInBytes();
+    assert_true(size_removed > size_optimized);
+}
+
+DEFINE_TEST(test_cpp_r64_serialization) {
+    Roaring64 r{1, 2, uint64_t(1) << 33, uint64_t(1) << 50,
+                14000000000000000100ull};
+
+    size_t expected = r.getSizeInBytes();
+    std::vector<char> buf(expected);
+    assert_int_equal(r.write(buf.data()), expected);
+
+    assert_true(Roaring64::readSafe(buf.data(), buf.size()) == r);
+    assert_true(Roaring64::read(buf.data()) == r);
+
+    assert_int_equal(
+        Roaring64::serializedSizeInBytesSafe(buf.data(), buf.size()), expected);
+    // a truncated buffer is rejected
+    assert_int_equal(
+        Roaring64::serializedSizeInBytesSafe(buf.data(), buf.size() - 1), 0);
+}
+
+DEFINE_TEST(test_cpp_r64_serialization_empty) {
+    Roaring64 empty;
+    std::vector<char> buf(empty.getSizeInBytes());
+    assert_int_equal(empty.write(buf.data()), buf.size());
+
+    Roaring64 back = Roaring64::readSafe(buf.data(), buf.size());
+    assert_true(back.isEmpty());
+    assert_true(back == empty);
+}
+
+DEFINE_TEST(test_cpp_r64_serialization_containers) {
+    Roaring64 r;
+    r.add(uint64_t(1) << 50);  // array container
+    for (uint64_t i = 0; i < 20000; i += 2) {
+        r.add(i);  // bitset container
+    }
+    for (uint64_t i = 100000; i < 130000; ++i) {
+        r.add(i);  // run container
+    }
+    assert_true(r.runOptimize());
+
+    std::vector<char> buf(r.getSizeInBytes());
+    assert_int_equal(r.write(buf.data()), buf.size());
+    assert_true(Roaring64::readSafe(buf.data(), buf.size()) == r);
+}
+
+DEFINE_TEST(test_cpp_r64_serialization_matches_roaring64map) {
+    // the portable format is shared, so the buffers are interchangeable
+    const uint64_t vals[] = {1, 2, uint64_t(1) << 33, uint64_t(1) << 50,
+                             14000000000000000100ull};
+    Roaring64 r(5, vals);
+    Roaring64Map m;
+    for (uint64_t v : vals) {
+        m.add(v);
+    }
+
+    std::vector<char> from_r(r.getSizeInBytes());
+    r.write(from_r.data());
+    std::vector<char> from_m(m.getSizeInBytes());
+    m.write(from_m.data());
+
+    assert_int_equal(from_r.size(), from_m.size());
+    assert_true(memcmp(from_r.data(), from_m.data(), from_r.size()) == 0);
+
+    Roaring64Map m_read = Roaring64Map::readSafe(from_r.data(), from_r.size());
+    assert_true(m_read == m);
+
+    Roaring64 r_read = Roaring64::readSafe(from_m.data(), from_m.size());
+    assert_true(r_read == r);
+}
+
+// Returns true on success, false on exception. The files were written by
+// Roaring64Map, which shares the portable format.
+static bool deserialize64(const std::string& filename) {
+    std::ifstream in(TEST_DATA_DIR + filename, std::ios::binary);
+    std::vector<char> buf1(std::istreambuf_iterator<char>(in), {});
+    Roaring64 r;
+#if ROARING_EXCEPTIONS
+    try {
+        r = Roaring64::readSafe(buf1.data(), buf1.size());
+    } catch (...) {
+        return false;
+    }
+#else   // ROARING_EXCEPTIONS
+    r = Roaring64::readSafe(buf1.data(), buf1.size());
+#endif  // ROARING_EXCEPTIONS
+    std::vector<char> buf2(r.getSizeInBytes());
+    assert_int_equal(buf1.size(), buf2.size());
+    assert_int_equal(r.write(buf2.data()), buf2.size());
+    assert_memory_equal(buf1.data(), buf2.data(), buf1.size());
+    return true;
+}
+
+DEFINE_TEST(test_cpp_r64_deserialize_empty) {
+    assert_true(deserialize64("64mapempty.bin"));
+}
+
+DEFINE_TEST(test_cpp_r64_deserialize_32bit_vals) {
+    assert_true(deserialize64("64map32bitvals.bin"));
+}
+
+DEFINE_TEST(test_cpp_r64_deserialize_spread_vals) {
+    assert_true(deserialize64("64mapspreadvals.bin"));
+}
+
+DEFINE_TEST(test_cpp_r64_deserialize_high_vals) {
+    assert_true(deserialize64("64maphighvals.bin"));
+}
+
+#if ROARING_EXCEPTIONS
+DEFINE_TEST(test_cpp_r64_deserialize_empty_input) {
+    assert_false(deserialize64("64mapemptyinput.bin"));
+}
+
+DEFINE_TEST(test_cpp_r64_deserialize_size_too_small) {
+    assert_false(deserialize64("64mapsizetoosmall.bin"));
+}
+
+DEFINE_TEST(test_cpp_r64_deserialize_invalid_size) {
+    assert_false(deserialize64("64mapinvalidsize.bin"));
+}
+
+DEFINE_TEST(test_cpp_r64_deserialize_key_too_small) {
+    assert_false(deserialize64("64mapkeytoosmall.bin"));
+}
+#endif
+
 DEFINE_TEST(test_cpp_r64_random_vs_set) {
     doublechecked::Roaring64 r;
     std::vector<uint64_t> added;  // values that have been added
@@ -350,6 +497,10 @@ DEFINE_TEST(test_cpp_r64_random_vs_set) {
     }
     r.validate();  // manually validate
 
+    std::vector<char> buf(r.getSizeInBytes());
+    assert_int_equal(r.write(buf.data()), buf.size());
+    assert_true(Roaring64::readSafe(buf.data(), buf.size()) == r.plain);
+
     // exercise clear
     r.clear();
     assert_true(r.isEmpty());
@@ -369,6 +520,21 @@ int main() {
         cmocka_unit_test(test_cpp_r64_run_optimize),
         cmocka_unit_test(test_cpp_r64_remove_run_compression),
         cmocka_unit_test(test_cpp_r64_shrink_to_fit),
+        cmocka_unit_test(test_cpp_r64_run_compression),
+        cmocka_unit_test(test_cpp_r64_serialization),
+        cmocka_unit_test(test_cpp_r64_serialization_empty),
+        cmocka_unit_test(test_cpp_r64_serialization_containers),
+        cmocka_unit_test(test_cpp_r64_serialization_matches_roaring64map),
+        cmocka_unit_test(test_cpp_r64_deserialize_empty),
+        cmocka_unit_test(test_cpp_r64_deserialize_32bit_vals),
+        cmocka_unit_test(test_cpp_r64_deserialize_spread_vals),
+        cmocka_unit_test(test_cpp_r64_deserialize_high_vals),
+#if ROARING_EXCEPTIONS
+        cmocka_unit_test(test_cpp_r64_deserialize_empty_input),
+        cmocka_unit_test(test_cpp_r64_deserialize_size_too_small),
+        cmocka_unit_test(test_cpp_r64_deserialize_invalid_size),
+        cmocka_unit_test(test_cpp_r64_deserialize_key_too_small),
+#endif
         cmocka_unit_test(test_cpp_r64_random_vs_set),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/roaring64_checked.hh
+++ b/tests/roaring64_checked.hh
@@ -88,6 +88,10 @@ class Roaring64 {
 
     size_t shrinkToFit() { return plain.shrinkToFit(); }
 
+    size_t write(char* buf) const { return plain.write(buf); }
+
+    size_t getSizeInBytes() const { return plain.getSizeInBytes(); }
+
     // Manually validates the full contents against the reference set.
     void validate() const {
         assert_int_equal(plain.cardinality(), check.size());

--- a/tests/roaring64_checked.hh
+++ b/tests/roaring64_checked.hh
@@ -82,6 +82,12 @@ class Roaring64 {
         return ans;
     }
 
+    bool removeRunCompression() { return plain.removeRunCompression(); }
+
+    bool runOptimize() { return plain.runOptimize(); }
+
+    size_t shrinkToFit() { return plain.shrinkToFit(); }
+
     // Manually validates the full contents against the reference set.
     void validate() const {
         assert_int_equal(plain.cardinality(), check.size());


### PR DESCRIPTION
Parts of #846.

Added:
- `removeRunCompression`
- `runOptimize`
- `shrinkToFit`
- `getSizeInBytes`
- `write`
- `read`
- `readSafe`
- `serializedSizeInBytesSafe`

All are thin wrappers over the matching methods of C API.

Note: One signature difference from `Roaring64Map`. `write`, `read` and `getSizeInBytes` take no `bool portable` parameter, because `roaring64.h` exposes only the portable format.