### PR TITLE
Update shebang line in amalgamation.sh

### DIFF
--- a/amalgamation.sh
+++ b/amalgamation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ########################################################################
 # Generates an "amalgamation build" for roaring. Inspired by similar
 # script used by whefs.


### PR DESCRIPTION
Some distros (e.g. NixOS) have `bash` at `/usr/bin/env bash` instead.