### PR TITLE
Help GCC vectorize array-container iterator bulk reads

### DIFF
--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -460,8 +460,10 @@ bool container_iterator_read_into_uint32(const container_t *c, uint8_t typecode,
             const array_container_t *ac = const_CAST_array(c);
             uint32_t num_values =
                 minimum_uint32(ac->cardinality - it->index, count);
+            // Hoist so GCC can vectorize the uint16->uint32 widen-or.
+            const uint16_t *src = ac->array + it->index;
             for (uint32_t i = 0; i < num_values; i++) {
-                buf[i] = high16 | ac->array[it->index + i];
+                buf[i] = high16 | src[i];
             }
             *consumed += num_values;
             it->index += num_values;
@@ -549,8 +551,10 @@ bool container_iterator_read_into_uint64(const container_t *c, uint8_t typecode,
             const array_container_t *ac = const_CAST_array(c);
             uint32_t num_values =
                 minimum_uint32(ac->cardinality - it->index, count);
+            // Hoist so GCC can vectorize the uint16->uint64 widen-or.
+            const uint16_t *src = ac->array + it->index;
             for (uint32_t i = 0; i < num_values; i++) {
-                buf[i] = high48 | ac->array[it->index + i];
+                buf[i] = high48 | src[i];
             }
             *consumed += num_values;
             it->index += num_values;
@@ -637,8 +641,10 @@ bool container_iterator_read_backward_into_uint32(
             const array_container_t *ac = const_CAST_array(c);
             uint32_t num_values =
                 minimum_uint32((uint32_t)(it->index + 1), count);
+            // Walk backwards so GCC can vectorize the uint16->uint32 widen-or.
+            const uint16_t *src = ac->array + it->index + 1;
             for (uint32_t i = 0; i < num_values; i++) {
-                buf[i] = high16 | ac->array[it->index - i];
+                buf[i] = high16 | *--src;
             }
             *consumed += num_values;
             it->index -= num_values;
@@ -726,8 +732,10 @@ bool container_iterator_read_backward_into_uint64(
             const array_container_t *ac = const_CAST_array(c);
             uint32_t num_values =
                 minimum_uint32((uint32_t)(it->index + 1), count);
+            // Walk backwards so GCC can vectorize the uint16->uint64 widen-or.
+            const uint16_t *src = ac->array + it->index + 1;
             for (uint32_t i = 0; i < num_values; i++) {
-                buf[i] = high48 | ac->array[it->index - i];
+                buf[i] = high48 | *--src;
             }
             *consumed += num_values;
             it->index -= num_values;


### PR DESCRIPTION
GCC 14.3 will not vectorize the array-container bulk-read loops in `container_iterator_read_into_uint{32,64}` and the matching backward fills. `-fopt-info-vec-missed` reports `no vectype for stmt` (uint64) or `relevant phi not supported` (uint32) on

```c
buf[i] = high48 | ac->array[it->index + i];
```

The neighboring run-container fills already vectorize; they never load through a struct-field index.

### Cause

The address expression `ac->array[it->index ± i]` keeps `it->index` in the GIMPLE data-ref, so the vectorizer never forms a simple pointer induction for the `uint16 → uint32/uint64` widening store.

Hoisting the pointer is enough for the forward loops:

```c
const uint16_t *src = ac->array + it->index;
for (uint32_t i = 0; i < num_values; i++) {
    buf[i] = high48 | src[i];
}
```

The backward loops (`ac->array[it->index - i]`) still fail with a negative stride after a hoist. A decrementing pointer, started one past the current element so it never goes before `array[0]`, is the form GCC 14 accepts:

```c
const uint16_t *src = ac->array + it->index + 1;
for (uint32_t i = 0; i < num_values; i++) {
    buf[i] = high48 | *--src;
}
```

`restrict`, `#pragma GCC ivdep`, OpenMP simd, and `-march=native` do not rescue the original form. Reverse-store / two-pass variants either miss or only vectorize the widen half.

### What GCC emits (x86-64-v3, AVX2)

Forward: `vpmovzxwd` + `vpmovzxdq` + `vpor`, 16 elements per iteration.
Backward: the same, after `vperm2i128` + `vpshufb` to reverse the loaded `uint16`s.

### Isolated loop, Xeon Gold 6548N, gcc 14.3, `-O3`

Forward uint64 widen-or, ns/call:

| n | original | hoisted | speedup |
| --- | --- | --- | --- |
| 16 | 8.5 | 3.2 | 2.7× |
| 64 | 22.7 | 10.9 | 2.1× |
| 256 | 105 | 42 | 2.5× |
| 4096 | 1601 | 662 | 2.4× |

Backward uint64, same machine:

| n | original | `*--src` | speedup |
| --- | --- | --- | --- |
| 16 | 6.3 | 3.5 | 1.8× |
| 64 | 22.2 | 12.1 | 1.8× |
| 4096 | 1383 | 737 | 1.9× |

No other `base[it->index ± i]` fill loops remain in `src/` or `include/`.

Verified on big4 with `toplevel_unit` (169 tests, including `test_read_backward_uint32_iterator_array`) and `roaring64_unit` (74 tests, including `test_iterator_read_backward`).