### PR TITLE
Make roaring64_iterator_value/has_value inline

### DIFF
--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -35,6 +35,15 @@ typedef uint64_t roaring64_leaf_t;
  */
 typedef struct roaring64_iterator_s roaring64_iterator_t;
 
+/** The leading members of `roaring64_iterator_t`, so that
+ * `roaring64_iterator_value()` and `roaring64_iterator_has_value()` can be
+ * read without a call. The iterator itself stays opaque; do not declare one of
+ * these, and do not rely on the layout beyond these two members. */
+typedef struct roaring64_iterator_public_s {
+    uint64_t value;
+    bool has_value;
+} roaring64_iterator_public_t;
+
 /**
  * A bit of context usable with `roaring64_bitmap_*_bulk()` functions.
  *
@@ -768,14 +777,22 @@ void roaring64_iterator_free(roaring64_iterator_t *it);
 /**
  * Returns true if the iterator currently points to a value. If so, calling
  * `roaring64_iterator_value()` returns the value.
+ *
+ * A pointer to a structure, suitably converted, points to its initial member
+ * (C17 6.7.2.1p15), and `roaring64_iterator_public_t` is the initial member of
+ * `roaring64_iterator_t`, so this reads the field directly.
  */
-bool roaring64_iterator_has_value(const roaring64_iterator_t *it);
+inline bool roaring64_iterator_has_value(const roaring64_iterator_t *it) {
+    return ((const roaring64_iterator_public_t *)it)->has_value;
+}
 
 /**
  * Returns the value the iterator currently points to. Should only be called if
  * `roaring64_iterator_has_value()` returns true.
  */
-uint64_t roaring64_iterator_value(const roaring64_iterator_t *it);
+inline uint64_t roaring64_iterator_value(const roaring64_iterator_t *it) {
+    return ((const roaring64_iterator_public_t *)it)->value;
+}
 
 /**
  * Advance the iterator. If there is a new value, then

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -61,6 +61,24 @@ typedef struct roaring64_iterator_s {
     // in the forward direction. If false, there are no more values in the
     // backward direction.
     bool saturated_forward;
+
+    // Forward-iteration cache for bitset containers. `container_iterator_next`
+    // recomputes the word index from `container_it.index`, reloads the word
+    // and re-masks it for every value; keeping the remaining bits of the
+    // current word here turns that into a `tzcnt` and a `blsr`. Array and run
+    // containers already advance by a single increment and gain nothing from
+    // a cache, so they stay on the ordinary path.
+    //
+    // Every field is a pure function of the ART position and
+    // `container_it.index`, so the cache describes where the iterator is
+    // exactly when both still match what it was built from. `fast_type` is
+    // BITSET_CONTAINER_TYPE, or 0 when there is no usable cache.
+    const art_val_t *fast_art_value;
+    const uint64_t *fast_words;
+    uint64_t fast_word;
+    uint32_t fast_wordindex;
+    int32_t fast_index;
+    uint8_t fast_type;
 } roaring64_iterator_t;
 
 static inline bool is_frozen64(const roaring64_bitmap_t *r) {
@@ -182,6 +200,36 @@ static inline int compare_high48(art_key_chunk_t key1[],
     return art_compare_keys(key1, key2);
 }
 
+// Cache the current container so advance() need not re-read the ART leaf,
+// reload the container pointer, or (for bitsets) re-mask the current word.
+// Called after any positioning that sets container_it.index.
+// fast_type is 0 when there is no usable cache (run containers, exhausted).
+static inline void roaring64_iterator_prime(roaring64_iterator_t *it) {
+    it->fast_type = 0;
+    if (it->art_it.value == NULL) {
+        return;
+    }
+    leaf_t leaf = (leaf_t)*it->art_it.value;
+    if (get_typecode(leaf) != BITSET_CONTAINER_TYPE) {
+        return;
+    }
+    const bitset_container_t *bc =
+        const_CAST_bitset(get_container(it->r, leaf));
+    int32_t index = it->container_it.index;
+    uint32_t wordindex = (uint32_t)index >> 6;
+    uint32_t bit = (uint32_t)index & 63u;
+    uint64_t word = bc->words[wordindex];
+    // Bits strictly after the current value in this word. A shift of 64 is
+    // undefined, so the last bit of a word is a special case.
+    it->fast_word =
+        (bit == 63u) ? UINT64_C(0) : (word & (UINT64_MAX << (bit + 1)));
+    it->fast_words = bc->words;
+    it->fast_wordindex = wordindex;
+    it->fast_index = index;
+    it->fast_art_value = it->art_it.value;
+    it->fast_type = BITSET_CONTAINER_TYPE;
+}
+
 static inline bool roaring64_iterator_init_at_leaf_first(
     roaring64_iterator_t *it) {
     it->high48 = combine_key(it->art_it.key, 0);
@@ -190,7 +238,9 @@ static inline bool roaring64_iterator_init_at_leaf_first(
     it->container_it = container_init_iterator(get_container(it->r, leaf),
                                                get_typecode(leaf), &low16);
     it->value = it->high48 | low16;
-    return (it->has_value = true);
+    it->has_value = true;
+    roaring64_iterator_prime(it);
+    return true;
 }
 
 static inline bool roaring64_iterator_init_at_leaf_last(
@@ -201,7 +251,9 @@ static inline bool roaring64_iterator_init_at_leaf_last(
     it->container_it = container_init_iterator_last(get_container(it->r, leaf),
                                                     get_typecode(leaf), &low16);
     it->value = it->high48 | low16;
-    return (it->has_value = true);
+    it->has_value = true;
+    roaring64_iterator_prime(it);
+    return true;
 }
 
 static inline roaring64_iterator_t *roaring64_iterator_init_at(
@@ -217,6 +269,7 @@ static inline roaring64_iterator_t *roaring64_iterator_init_at(
         }
     } else {
         it->saturated_forward = first;
+        it->fast_type = 0;
     }
     return it;
 }
@@ -2793,7 +2846,19 @@ uint64_t roaring64_iterator_value(const roaring64_iterator_t *it) {
     return it->value;
 }
 
-bool roaring64_iterator_advance(roaring64_iterator_t *it) {
+// The current container is exhausted: step the ART to the next leaf.
+static inline bool roaring64_iterator_next_leaf(roaring64_iterator_t *it) {
+    if (art_iterator_next(&it->art_it)) {
+        return roaring64_iterator_init_at_leaf_first(it);
+    }
+    it->saturated_forward = true;
+    it->fast_type = 0;
+    return (it->has_value = false);
+}
+
+// Everything `advance` needs when the bitset cache does not describe where the
+// iterator is: a restart, or a step through the container iterator.
+static inline bool roaring64_iterator_advance_slow(roaring64_iterator_t *it) {
     if (it->art_it.value == NULL) {
         if (it->saturated_forward) {
             return (it->has_value = false);
@@ -2802,17 +2867,48 @@ bool roaring64_iterator_advance(roaring64_iterator_t *it) {
         return it->has_value;
     }
     leaf_t leaf = (leaf_t)*it->art_it.value;
+    uint8_t typecode = get_typecode(leaf);
     uint16_t low16 = (uint16_t)it->value;
-    if (container_iterator_next(get_container(it->r, leaf), get_typecode(leaf),
+    if (container_iterator_next(get_container(it->r, leaf), typecode,
                                 &it->container_it, &low16)) {
         it->value = it->high48 | low16;
+        it->has_value = true;
+        if (typecode == BITSET_CONTAINER_TYPE) {
+            // Only reached when the cache was stale, i.e. something else moved
+            // the cursor. Array and run containers never have a cache, and
+            // priming them would cost a leaf load per value.
+            roaring64_iterator_prime(it);
+        }
+        return true;
+    }
+    return roaring64_iterator_next_leaf(it);
+}
+
+bool roaring64_iterator_advance(roaring64_iterator_t *it) {
+    // Matching both the leaf and `container_it.index` is enough to know the
+    // cache describes where the iterator actually is: within a container the
+    // index determines the position. Anything that moved the cursor --
+    // `previous`, `move_equalorlarger`, any of the `read` variants -- moved one
+    // of them, and drops through to the slow path, which rebuilds the cache.
+    if (it->fast_type != 0 && it->fast_art_value == it->art_it.value &&
+        it->fast_index == it->container_it.index) {
+        uint64_t word = it->fast_word;
+        uint32_t wi = it->fast_wordindex;
+        while (word == 0) {
+            if (++wi >= BITSET_CONTAINER_SIZE_IN_WORDS) {
+                return roaring64_iterator_next_leaf(it);
+            }
+            word = it->fast_words[wi];
+            it->fast_wordindex = wi;
+        }
+        uint32_t index = wi * 64 + (uint32_t)roaring_trailing_zeroes(word);
+        it->fast_word = word & (word - 1);
+        it->fast_index = (int32_t)index;
+        it->container_it.index = (int32_t)index;
+        it->value = it->high48 | index;
         return (it->has_value = true);
     }
-    if (art_iterator_next(&it->art_it)) {
-        return roaring64_iterator_init_at_leaf_first(it);
-    }
-    it->saturated_forward = true;
-    return (it->has_value = false);
+    return roaring64_iterator_advance_slow(it);
 }
 
 bool roaring64_iterator_previous(roaring64_iterator_t *it) {
@@ -2829,12 +2925,15 @@ bool roaring64_iterator_previous(roaring64_iterator_t *it) {
     if (container_iterator_prev(get_container(it->r, leaf), get_typecode(leaf),
                                 &it->container_it, &low16)) {
         it->value = it->high48 | low16;
-        return (it->has_value = true);
+        it->has_value = true;
+        it->fast_type = 0;
+        return true;
     }
     if (art_iterator_prev(&it->art_it)) {
         return roaring64_iterator_init_at_leaf_last(it);
     }
     it->saturated_forward = false;  // Saturated backward.
+    it->fast_type = 0;
     return (it->has_value = false);
 }
 
@@ -2849,6 +2948,7 @@ bool roaring64_iterator_move_equalorlarger(roaring64_iterator_t *it,
         if (!art_iterator_lower_bound(&it->art_it, val_high48)) {
             // Only smaller keys found.
             it->saturated_forward = true;
+            it->fast_type = 0;
             return (it->has_value = false);
         }
         it->high48 = combine_key(it->art_it.key, 0);
@@ -2864,11 +2964,14 @@ bool roaring64_iterator_move_equalorlarger(roaring64_iterator_t *it,
                 get_container(it->r, leaf), get_typecode(leaf),
                 &it->container_it, &low16, val_low16)) {
             it->value = it->high48 | low16;
-            return (it->has_value = true);
+            it->has_value = true;
+            it->fast_type = 0;
+            return true;
         }
         // Only smaller entries in this container, move to the next.
         if (!art_iterator_next(&it->art_it)) {
             it->saturated_forward = true;
+            it->fast_type = 0;
             return (it->has_value = false);
         }
     }
@@ -2897,6 +3000,7 @@ uint64_t roaring64_iterator_read(roaring64_iterator_t *it, uint64_t *buf,
         if (has_value) {
             it->has_value = true;
             it->value = it->high48 | low16;
+            it->fast_type = 0;
             assert(consumed == count);
             return consumed;
         }
@@ -2905,6 +3009,7 @@ uint64_t roaring64_iterator_read(roaring64_iterator_t *it, uint64_t *buf,
             roaring64_iterator_init_at_leaf_first(it);
         } else {
             it->saturated_forward = true;
+            it->fast_type = 0;
         }
     }
     return consumed;

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stdarg.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -48,13 +49,16 @@ typedef roaring64_leaf_t leaf_t;
 
 // Iterator struct to hold iteration state.
 typedef struct roaring64_iterator_s {
+    // Must stay first, and must stay a `roaring64_iterator_public_t`: the
+    // inline `roaring64_iterator_value` / `roaring64_iterator_has_value` in
+    // the public header reach these two members by converting a
+    // `roaring64_iterator_t *` to a pointer to its initial member.
+    roaring64_iterator_public_t pub;
+
     const roaring64_bitmap_t *r;
     art_iterator_t art_it;
     roaring_container_iterator_t container_it;
     uint64_t high48;  // Key that art_it points to.
-
-    uint64_t value;
-    bool has_value;
 
     // If has_value is false, then the iterator is saturated. This field
     // indicates the direction of saturation. If true, there are no more values
@@ -237,8 +241,8 @@ static inline bool roaring64_iterator_init_at_leaf_first(
     uint16_t low16 = 0;
     it->container_it = container_init_iterator(get_container(it->r, leaf),
                                                get_typecode(leaf), &low16);
-    it->value = it->high48 | low16;
-    it->has_value = true;
+    it->pub.value = it->high48 | low16;
+    it->pub.has_value = true;
     roaring64_iterator_prime(it);
     return true;
 }
@@ -250,8 +254,8 @@ static inline bool roaring64_iterator_init_at_leaf_last(
     uint16_t low16 = 0;
     it->container_it = container_init_iterator_last(get_container(it->r, leaf),
                                                     get_typecode(leaf), &low16);
-    it->value = it->high48 | low16;
-    it->has_value = true;
+    it->pub.value = it->high48 | low16;
+    it->pub.has_value = true;
     roaring64_iterator_prime(it);
     return true;
 }
@@ -260,8 +264,8 @@ static inline roaring64_iterator_t *roaring64_iterator_init_at(
     const roaring64_bitmap_t *r, roaring64_iterator_t *it, bool first) {
     it->r = r;
     it->art_it = art_init_iterator((art_t *)&r->art, first);
-    it->has_value = it->art_it.value != NULL;
-    if (it->has_value) {
+    it->pub.has_value = it->art_it.value != NULL;
+    if (it->pub.has_value) {
         if (first) {
             roaring64_iterator_init_at_leaf_first(it);
         } else {
@@ -2838,13 +2842,11 @@ roaring64_iterator_t *roaring64_iterator_copy(const roaring64_iterator_t *it) {
 
 void roaring64_iterator_free(roaring64_iterator_t *it) { roaring_free(it); }
 
-bool roaring64_iterator_has_value(const roaring64_iterator_t *it) {
-    return it->has_value;
-}
+CROARING_STATIC_ASSERT(offsetof(roaring64_iterator_t, pub) == 0,
+                       "the public members must be first in the iterator");
 
-uint64_t roaring64_iterator_value(const roaring64_iterator_t *it) {
-    return it->value;
-}
+extern inline bool roaring64_iterator_has_value(const roaring64_iterator_t *it);
+extern inline uint64_t roaring64_iterator_value(const roaring64_iterator_t *it);
 
 // The current container is exhausted: step the ART to the next leaf.
 static inline bool roaring64_iterator_next_leaf(roaring64_iterator_t *it) {
@@ -2853,7 +2855,7 @@ static inline bool roaring64_iterator_next_leaf(roaring64_iterator_t *it) {
     }
     it->saturated_forward = true;
     it->fast_type = 0;
-    return (it->has_value = false);
+    return (it->pub.has_value = false);
 }
 
 // Everything `advance` needs when the bitset cache does not describe where the
@@ -2861,18 +2863,18 @@ static inline bool roaring64_iterator_next_leaf(roaring64_iterator_t *it) {
 static inline bool roaring64_iterator_advance_slow(roaring64_iterator_t *it) {
     if (it->art_it.value == NULL) {
         if (it->saturated_forward) {
-            return (it->has_value = false);
+            return (it->pub.has_value = false);
         }
         roaring64_iterator_init_at(it->r, it, /*first=*/true);
-        return it->has_value;
+        return it->pub.has_value;
     }
     leaf_t leaf = (leaf_t)*it->art_it.value;
     uint8_t typecode = get_typecode(leaf);
-    uint16_t low16 = (uint16_t)it->value;
+    uint16_t low16 = (uint16_t)it->pub.value;
     if (container_iterator_next(get_container(it->r, leaf), typecode,
                                 &it->container_it, &low16)) {
-        it->value = it->high48 | low16;
-        it->has_value = true;
+        it->pub.value = it->high48 | low16;
+        it->pub.has_value = true;
         if (typecode == BITSET_CONTAINER_TYPE) {
             // Only reached when the cache was stale, i.e. something else moved
             // the cursor. Array and run containers never have a cache, and
@@ -2905,8 +2907,8 @@ bool roaring64_iterator_advance(roaring64_iterator_t *it) {
         it->fast_word = word & (word - 1);
         it->fast_index = (int32_t)index;
         it->container_it.index = (int32_t)index;
-        it->value = it->high48 | index;
-        return (it->has_value = true);
+        it->pub.value = it->high48 | index;
+        return (it->pub.has_value = true);
     }
     return roaring64_iterator_advance_slow(it);
 }
@@ -2915,17 +2917,17 @@ bool roaring64_iterator_previous(roaring64_iterator_t *it) {
     if (it->art_it.value == NULL) {
         if (!it->saturated_forward) {
             // Saturated backward.
-            return (it->has_value = false);
+            return (it->pub.has_value = false);
         }
         roaring64_iterator_init_at(it->r, it, /*first=*/false);
-        return it->has_value;
+        return it->pub.has_value;
     }
     leaf_t leaf = (leaf_t)*it->art_it.value;
-    uint16_t low16 = (uint16_t)it->value;
+    uint16_t low16 = (uint16_t)it->pub.value;
     if (container_iterator_prev(get_container(it->r, leaf), get_typecode(leaf),
                                 &it->container_it, &low16)) {
-        it->value = it->high48 | low16;
-        it->has_value = true;
+        it->pub.value = it->high48 | low16;
+        it->pub.has_value = true;
         it->fast_type = 0;
         return true;
     }
@@ -2934,14 +2936,14 @@ bool roaring64_iterator_previous(roaring64_iterator_t *it) {
     }
     it->saturated_forward = false;  // Saturated backward.
     it->fast_type = 0;
-    return (it->has_value = false);
+    return (it->pub.has_value = false);
 }
 
 bool roaring64_iterator_move_equalorlarger(roaring64_iterator_t *it,
                                            uint64_t val) {
     uint8_t val_high48[ART_KEY_BYTES];
     uint16_t val_low16 = split_key(val, val_high48);
-    if (!it->has_value || it->high48 != (val & 0xFFFFFFFFFFFF0000)) {
+    if (!it->pub.has_value || it->high48 != (val & 0xFFFFFFFFFFFF0000)) {
         // The ART iterator is before or after the high48 bits of `val` (or
         // beyond the ART altogether), so we need to move to a leaf with a
         // key equal or greater.
@@ -2949,7 +2951,7 @@ bool roaring64_iterator_move_equalorlarger(roaring64_iterator_t *it,
             // Only smaller keys found.
             it->saturated_forward = true;
             it->fast_type = 0;
-            return (it->has_value = false);
+            return (it->pub.has_value = false);
         }
         it->high48 = combine_key(it->art_it.key, 0);
         // Fall through to the next if statement.
@@ -2959,12 +2961,12 @@ bool roaring64_iterator_move_equalorlarger(roaring64_iterator_t *it,
         // We're at equal high bits, check if a suitable value can be found
         // in this container.
         leaf_t leaf = (leaf_t)*it->art_it.value;
-        uint16_t low16 = (uint16_t)it->value;
+        uint16_t low16 = (uint16_t)it->pub.value;
         if (container_iterator_lower_bound(
                 get_container(it->r, leaf), get_typecode(leaf),
                 &it->container_it, &low16, val_low16)) {
-            it->value = it->high48 | low16;
-            it->has_value = true;
+            it->pub.value = it->high48 | low16;
+            it->pub.has_value = true;
             it->fast_type = 0;
             return true;
         }
@@ -2972,7 +2974,7 @@ bool roaring64_iterator_move_equalorlarger(roaring64_iterator_t *it,
         if (!art_iterator_next(&it->art_it)) {
             it->saturated_forward = true;
             it->fast_type = 0;
-            return (it->has_value = false);
+            return (it->pub.has_value = false);
         }
     }
 
@@ -2984,10 +2986,10 @@ bool roaring64_iterator_move_equalorlarger(roaring64_iterator_t *it,
 uint64_t roaring64_iterator_read(roaring64_iterator_t *it, uint64_t *buf,
                                  uint64_t count) {
     uint64_t consumed = 0;
-    while (it->has_value && consumed < count) {
+    while (it->pub.has_value && consumed < count) {
         uint32_t container_consumed;
         leaf_t leaf = (leaf_t)*it->art_it.value;
-        uint16_t low16 = (uint16_t)it->value;
+        uint16_t low16 = (uint16_t)it->pub.value;
         uint32_t container_count = UINT32_MAX;
         if (count - consumed < (uint64_t)UINT32_MAX) {
             container_count = count - consumed;
@@ -2998,14 +3000,14 @@ uint64_t roaring64_iterator_read(roaring64_iterator_t *it, uint64_t *buf,
         consumed += container_consumed;
         buf += container_consumed;
         if (has_value) {
-            it->has_value = true;
-            it->value = it->high48 | low16;
+            it->pub.has_value = true;
+            it->pub.value = it->high48 | low16;
             it->fast_type = 0;
             assert(consumed == count);
             return consumed;
         }
-        it->has_value = art_iterator_next(&it->art_it);
-        if (it->has_value) {
+        it->pub.has_value = art_iterator_next(&it->art_it);
+        if (it->pub.has_value) {
             roaring64_iterator_init_at_leaf_first(it);
         } else {
             it->saturated_forward = true;
@@ -3018,10 +3020,10 @@ uint64_t roaring64_iterator_read(roaring64_iterator_t *it, uint64_t *buf,
 uint64_t roaring64_iterator_read_backward(roaring64_iterator_t *it,
                                           uint64_t *buf, uint64_t count) {
     uint64_t consumed = 0;
-    while (it->has_value && consumed < count) {
+    while (it->pub.has_value && consumed < count) {
         uint32_t container_consumed;
         leaf_t leaf = *it->art_it.value;
-        uint16_t low16 = (uint16_t)it->value;
+        uint16_t low16 = (uint16_t)it->pub.value;
         uint32_t container_count = UINT32_MAX;
         if (count - consumed < (uint64_t)UINT32_MAX) {
             container_count = count - consumed;
@@ -3032,13 +3034,13 @@ uint64_t roaring64_iterator_read_backward(roaring64_iterator_t *it,
         consumed += container_consumed;
         buf += container_consumed;
         if (has_value) {
-            it->has_value = true;
-            it->value = it->high48 | low16;
+            it->pub.has_value = true;
+            it->pub.value = it->high48 | low16;
             assert(consumed == count);
             return consumed;
         }
-        it->has_value = art_iterator_prev(&it->art_it);
-        if (it->has_value) {
+        it->pub.has_value = art_iterator_prev(&it->art_it);
+        if (it->pub.has_value) {
             roaring64_iterator_init_at_leaf_last(it);
         } else {
             it->saturated_forward = false;
@@ -3051,10 +3053,10 @@ size_t roaring64_iterator_read_ranges(roaring64_iterator_t *it,
                                       roaring64_range_closed_t *buf,
                                       size_t count) {
     size_t ret = 0;
-    while (it->has_value && ret < count) {
-        buf[ret].min = it->value;
+    while (it->pub.has_value && ret < count) {
+        buf[ret].min = it->pub.value;
         for (;;) {
-            uint16_t low16 = (uint16_t)it->value;
+            uint16_t low16 = (uint16_t)it->pub.value;
             leaf_t leaf = (leaf_t)*it->art_it.value;
             bool container_has_more;
             uint16_t run_end_low16 = container_iterator_find_run_end(
@@ -3063,12 +3065,12 @@ size_t roaring64_iterator_read_ranges(roaring64_iterator_t *it,
             buf[ret].max = it->high48 | run_end_low16;
 
             if (container_has_more) {
-                it->value = it->high48 | low16;
+                it->pub.value = it->high48 | low16;
                 break;
             }
             // Move to next leaf
-            it->has_value = art_iterator_next(&it->art_it);
-            if (it->has_value) {
+            it->pub.has_value = art_iterator_next(&it->art_it);
+            if (it->pub.has_value) {
                 roaring64_iterator_init_at_leaf_first(it);
             } else {
                 it->saturated_forward = true;
@@ -3076,7 +3078,8 @@ size_t roaring64_iterator_read_ranges(roaring64_iterator_t *it,
             }
             // Continue merging only if the run reached the container
             // boundary and the next leaf starts exactly at max+1.
-            if (run_end_low16 != UINT16_MAX || it->value != buf[ret].max + 1) {
+            if (run_end_low16 != UINT16_MAX ||
+                it->pub.value != buf[ret].max + 1) {
                 break;
             }
         }
@@ -3089,10 +3092,10 @@ size_t roaring64_iterator_read_prev_ranges(roaring64_iterator_t *it,
                                            roaring64_range_closed_t *buf,
                                            size_t count) {
     size_t ret = 0;
-    while (it->has_value && ret < count) {
-        buf[ret].max = it->value;
+    while (it->pub.has_value && ret < count) {
+        buf[ret].max = it->pub.value;
         for (;;) {
-            uint16_t low16 = (uint16_t)it->value;
+            uint16_t low16 = (uint16_t)it->pub.value;
             leaf_t leaf = (leaf_t)*it->art_it.value;
             bool container_has_more;
             uint16_t run_start_low16 = container_iterator_find_run_start(
@@ -3101,12 +3104,12 @@ size_t roaring64_iterator_read_prev_ranges(roaring64_iterator_t *it,
             buf[ret].min = it->high48 | run_start_low16;
 
             if (container_has_more) {
-                it->value = it->high48 | low16;
+                it->pub.value = it->high48 | low16;
                 break;
             }
             // Move to previous leaf
-            it->has_value = art_iterator_prev(&it->art_it);
-            if (it->has_value) {
+            it->pub.has_value = art_iterator_prev(&it->art_it);
+            if (it->pub.has_value) {
                 roaring64_iterator_init_at_leaf_last(it);
             } else {
                 it->saturated_forward = false;
@@ -3114,7 +3117,7 @@ size_t roaring64_iterator_read_prev_ranges(roaring64_iterator_t *it,
             }
             // Continue merging only if the run reached the container
             // boundary and the previous leaf ends exactly at min-1.
-            if (run_start_low16 != 0 || it->value != buf[ret].min - 1) {
+            if (run_start_low16 != 0 || it->pub.value != buf[ret].min - 1) {
                 break;
             }
         }

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -2250,6 +2250,70 @@ DEFINE_TEST(test_iterator_advance) {
     roaring64_bitmap_free(r);
 }
 
+DEFINE_TEST(test_iterator_fast_path) {
+    // Exercises the bitset fast path in roaring64_iterator_advance, and the
+    // paths that must invalidate it. Mixed container kinds so the cache is
+    // built, skipped and rebuilt as the iterator crosses leaves.
+    roaring64_bitmap_t* r = roaring64_bitmap_create();
+    // Dense enough to become a bitset in one high48.
+    for (uint32_t i = 0; i < 4097; ++i) {
+        roaring64_bitmap_add(r, i);
+    }
+    // Sparse array container in another high48.
+    for (uint32_t i = 0; i < 10; ++i) {
+        roaring64_bitmap_add(r, (1ULL << 32) + i * 100);
+    }
+    // A long run in a third high48.
+    roaring64_bitmap_add_range_closed(r, 1ULL << 48, (1ULL << 48) + 10000);
+    roaring64_bitmap_run_optimize(r);
+
+    uint64_t card = roaring64_bitmap_get_cardinality(r);
+    std::vector<uint64_t> expected(card);
+    roaring64_bitmap_to_uint64_array(r, expected.data());
+
+    roaring64_iterator_t* it = roaring64_iterator_create(r);
+    size_t i = 0;
+    while (roaring64_iterator_has_value(it)) {
+        assert_int_equal(roaring64_iterator_value(it), expected[i]);
+        i++;
+        roaring64_iterator_advance(it);
+    }
+    assert_int_equal(i, expected.size());
+
+    // previous() after a long forward walk must still be correct.
+    roaring64_iterator_reinit(r, it);
+    for (size_t k = 0; k < 5000; ++k) {
+        assert_true(roaring64_iterator_advance(it));
+    }
+    assert_int_equal(roaring64_iterator_value(it), expected[5000]);
+    assert_true(roaring64_iterator_previous(it));
+    assert_int_equal(roaring64_iterator_value(it), expected[4999]);
+    assert_true(roaring64_iterator_advance(it));
+    assert_int_equal(roaring64_iterator_value(it), expected[5000]);
+
+    // read() moves container_it without going through advance(); a later
+    // advance() must not reuse the cache built before it.
+    roaring64_iterator_reinit(r, it);
+    std::vector<uint64_t> buf(100);
+    uint64_t n = roaring64_iterator_read(it, buf.data(), 100);
+    assert_int_equal(n, 100);
+    assert_true(roaring64_iterator_has_value(it));
+    assert_int_equal(roaring64_iterator_value(it), expected[100]);
+    assert_true(roaring64_iterator_advance(it));
+    assert_int_equal(roaring64_iterator_value(it), expected[101]);
+
+    // move_equalorlarger() likewise.
+    roaring64_iterator_reinit(r, it);
+    assert_true(roaring64_iterator_advance(it));
+    assert_true(roaring64_iterator_move_equalorlarger(it, expected[2000]));
+    assert_int_equal(roaring64_iterator_value(it), expected[2000]);
+    assert_true(roaring64_iterator_advance(it));
+    assert_int_equal(roaring64_iterator_value(it), expected[2001]);
+
+    roaring64_iterator_free(it);
+    roaring64_bitmap_free(r);
+}
+
 DEFINE_TEST(test_iterator_previous) {
     roaring64_bitmap_t* r = roaring64_bitmap_create();
     std::vector<uint64_t> values;
@@ -2950,6 +3014,7 @@ int main() {
         cmocka_unit_test(test_iterator_reinit_last),
         cmocka_unit_test(test_iterator_copy),
         cmocka_unit_test(test_iterator_advance),
+        cmocka_unit_test(test_iterator_fast_path),
         cmocka_unit_test(test_iterator_previous),
         cmocka_unit_test(test_iterator_move_equalorlarger),
         cmocka_unit_test(test_iterator_read),


### PR DESCRIPTION
## Summary

`roaring64_iterator_value()` and `roaring64_iterator_has_value()` are one-line field reads behind an out-of-line call, because `roaring64_iterator_t` is opaque. The 32-bit iterator has no such cost: its type is public and callers read `it->has_value` / `it->current_value` directly. On a scalar iteration loop these two calls are now the dominant per-value cost — larger than the container step itself.

This splits the two public members into a `roaring64_iterator_public_t` and makes it the **initial member** of `roaring64_iterator_t`, which stays opaque. A pointer to a structure, suitably converted, points to its initial member (C17 6.7.2.1p15), so the accessors can be `inline` in the header without the rest of the layout becoming public and without `roaring64.h` having to include `art.h`. A `CROARING_STATIC_ASSERT` pins the offset.

The functions keep external definitions via `extern inline`, the same pattern `roaring.h` and `containers.h` already use, so binaries linked against the old library still resolve both symbols.

**No caller changes.** Existing code calling `roaring64_iterator_has_value()` / `roaring64_iterator_value()` gets this by recompiling. The benchmarks are untouched.

Stacked on #864.

## Benchmarks

Xeon Gold 6548N, gcc `-O3 -march=native`, pinned to one core. ns per value over CRoaring's realdata sets, `has_value()` + `value()` + `advance()` per value, with the benchmark source identical in every column.

| dataset | master | #864 | this PR | total |
|---|---:|---:|---:|---:|
| census1881 (array/run) | 3.270 | 3.428 | 2.198 | **1.49×** |
| census-income (bitset) | 5.021 | 3.765 | 2.362 | **2.13×** |
| weather_sept_85 (bitset) | 5.129 | 3.888 | 2.493 | **2.06×** |

The middle column is #864 alone, where census1881 pays ~5% for a cache validity check its containers never use. Removing the two calls per value more than covers it, so every data set ends up ahead.

## Alternative considered

Making the whole struct public (so callers could stack-allocate and read fields directly) is faster to write but drags `art.h` into the public API and freezes `sizeof(art_iterator_t)` — so `ART_KEY_BYTES` and the iterator frame count could never change again. It also breaks the amalgamation, since `art.h` is in `ALL_PRIVATE_H`. The approach here keeps the ABI surface to the first 16 bytes and gets the same per-value win; the only thing given up is stack allocation, and the removed `malloc` is negligible next to the per-value cost.

## Test plan

- [x] full `ctest` suite (27/27)
- [x] amalgamation build, C and C++
- [x] clang-format 17
- [x] both symbols still exported from `libroaring.a` (`extern inline`)
- [x] 240k-operation randomized differential test against a sorted-array reference, clean under ASan and UBSan
- [x] mutation check: the static assertion fires if the public members are moved off offset 0
