### PR TITLE
Pack the roaring64 iterator's hot fields into one cache line

### DIFF
--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -52,22 +52,20 @@ typedef roaring64_leaf_t leaf_t;
 
 // Iterator struct to hold iteration state.
 typedef struct roaring64_iterator_s {
+    // The order here is deliberate: everything `roaring64_iterator_advance`
+    // touches per value is packed into the first 64 bytes, and `art_it` --
+    // 136 bytes, of which only `art_it.value` is read per value -- is last.
+    // Putting `art_it` earlier pushes the rest past the first cache line and
+    // costs ~18% on a scalar iteration loop.
+
     // Must stay first, and must stay a `roaring64_iterator_public_t`: the
     // inline `roaring64_iterator_value` / `roaring64_iterator_has_value` in
     // the public header reach these two members by converting a
     // `roaring64_iterator_t *` to a pointer to its initial member.
     roaring64_iterator_public_t pub;
 
-    const roaring64_bitmap_t *r;
-    art_iterator_t art_it;
-    roaring_container_iterator_t container_it;
     uint64_t high48;  // Key that art_it points to.
-
-    // If has_value is false, then the iterator is saturated. This field
-    // indicates the direction of saturation. If true, there are no more values
-    // in the forward direction. If false, there are no more values in the
-    // backward direction.
-    bool saturated_forward;
+    roaring_container_iterator_t container_it;
 
     // Forward-iteration cache for bitset containers. `container_iterator_next`
     // recomputes the word index from `container_it.index`, reloads the word
@@ -80,12 +78,21 @@ typedef struct roaring64_iterator_s {
     // `container_it.index`, so the cache describes where the iterator is
     // exactly when both still match what it was built from. `fast_type` is
     // BITSET_CONTAINER_TYPE, or 0 when there is no usable cache.
+    uint32_t fast_wordindex;
     const art_val_t *fast_art_value;
     const uint64_t *fast_words;
     uint64_t fast_word;
-    uint32_t fast_wordindex;
     int32_t fast_index;
     uint8_t fast_type;
+
+    // If has_value is false, then the iterator is saturated. This field
+    // indicates the direction of saturation. If true, there are no more values
+    // in the forward direction. If false, there are no more values in the
+    // backward direction.
+    bool saturated_forward;
+
+    const roaring64_bitmap_t *r;
+    art_iterator_t art_it;
 } roaring64_iterator_t;
 
 static inline bool is_frozen64(const roaring64_bitmap_t *r) {


### PR DESCRIPTION
## Summary

Making the public members the initial member of `roaring64_iterator_t` (#865) left `art_iterator_t` sitting between them and everything else. `art_iterator_t` is 136 bytes, so `container_it`, `high48` and the whole bitset cache ended up past offset 160, and a scalar `advance()` touched three or four cache lines per value instead of one.

This moves `art_it` and the bitmap pointer to the end of the struct. Only `art_it.value` is read per value; the 112-byte `frames` array is touched at leaf transitions. Everything `advance()` uses per value now fits in the first 64 bytes.

Pure field reordering — no logic change. The public members stay first, so the inline accessors are unaffected and the `CROARING_STATIC_ASSERT` on their offset still holds.

## Why it matters

Callers that include the header get the inline accessors and were never affected. Callers that link the exported symbols — every language binding — pay the per-value path in full, and there `IterateAll64` on sparse, array/run-heavy data had regressed 15% against the pre-#864 baseline.

Xeon Gold 6548N, zig 0.16.0 ReleaseFast, pinned, median of 3, µs. Measured through a caller that links the symbols rather than including the header, so this isolates the per-value path.

| dataset | before the iterator work | current master | this PR |
|---|---:|---:|---:|
| census1881 (array/run) | 4758 | 5491 | **4584** |
| census-income (bitset) | 40334 | 34325 | 35162 |
| weather_sept_85 (bitset) | 77186 | 66586 | 67274 |

census1881 goes from 15% behind the old baseline to 4% ahead of it. The dense sets give back 1–2% of their gain there, which is at the edge of run-to-run noise on this host.

Callers that *do* include the header (so the accessors inline) are not hurt either — on this path the dense sets gain as well. Same harness, identical flags, ns per value on `has_value()` + `value()` + `advance()`:

| dataset | current master | this PR |
|---|---:|---:|
| census1881 | 2.195 | 2.256 |
| census-income | 3.242 | **2.512** |
| weather_sept_85 | 3.238 | **2.663** |

So the only cost anywhere is ~3% on census1881 for header-including callers, against 22–29% gains on the dense sets and the removal of a 15% regression for everyone else.

Hardware counters on census1881 corroborate the mechanism rather than just the timing:

| | IPC | L1-dcache-load-misses |
|---|---:|---:|
| before the iterator work | 4.25 | 2.49M |
| current master | 4.22 | 2.63M |
| this PR | **4.63** | **2.27M** |

Highest IPC and fewest misses of the three, which is what a cache-line packing change should look like.

## What I ruled out

- **Build layout.** Adding dead code to `roaring64.c` in 0–4 increments moves this benchmark by ±1.5%, so the 15% is not code placement.
- **Toolchain.** The same harness built with gcc, clang and `zig cc` shows master equal to or faster than the old baseline; only the per-value path in a non-inlining caller regressed.
- **Replacing the leaf-pointer check with a `high48` comparison** (to keep the guard entirely out of `art_it`). Same struct layout, and it measured ~18% *worse* on census1881, so it is not in this PR.

## Test plan

- [x] full `ctest` suite (27/27)
- [x] amalgamation build, C and C++
- [x] clang-format 17
- [x] 240k-operation randomized differential test against a sorted-array reference, clean under ASan and UBSan
