### PR TITLE
Speed up roaring64 deserialization, and add a portable frozen view

### DIFF
--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -4031,6 +4031,42 @@ static void register_ser_deser(std::vector<Entry> &out) {
                 e.reusable_state = true;
                 out.push_back(std::move(e));
             }
+            // r64PortableDeserializeFrozen
+            {
+                Entry e;
+                e.name = "synthetic/r64PortableDeserializeFrozen/" + ptag;
+                e.description =
+                    "roaring64_bitmap_portable_deserialize_frozen(buf, size) "
+                    "+ free per iteration (payloads alias the buffer).";
+                e.setup = [count, step]() -> void * {
+                    auto *s = new serState;
+                    s->r = roaring64_bitmap_create();
+                    for (size_t i = 0; i < count; ++i)
+                        roaring64_bitmap_add(s->r, i * step);
+                    s->buf.resize(
+                        roaring64_bitmap_portable_size_in_bytes(s->r));
+                    roaring64_bitmap_portable_serialize(s->r, s->buf.data());
+                    return s;
+                };
+                e.run = [](void *sv) -> int64_t {
+                    auto *s = static_cast<serState *>(sv);
+                    roaring64_bitmap_t *r2 =
+                        roaring64_bitmap_portable_deserialize_frozen(
+                            s->buf.data(), s->buf.size());
+                    int64_t ok = r2 ? 1 : 0;
+                    if (r2) roaring64_bitmap_free(r2);
+                    return ok;
+                };
+                e.teardown = [](void *sv) {
+                    auto *s = static_cast<serState *>(sv);
+                    roaring64_bitmap_free(s->r);
+                    delete s;
+                };
+                e.ops_per_run = static_cast<int64_t>(count);
+                e.inner_reps = 5;
+                e.reusable_state = true;
+                out.push_back(std::move(e));
+            }
             // r64FrozenDeserialize
             {
                 Entry e;

--- a/cpp/roaring/roaring64.hh
+++ b/cpp/roaring/roaring64.hh
@@ -484,6 +484,21 @@ class Roaring64 {
         return api::roaring64_bitmap_portable_deserialize_size(buf, maxbytes);
     }
 
+    /**
+     * Read a bitmap from a portable serialized buffer as a read-only view of
+     * the container payloads. See
+     * roaring64_bitmap_portable_deserialize_frozen(). May throw
+     * std::runtime_error.
+     */
+    static Roaring64 readSafeFrozen(const char* buf, size_t maxbytes) {
+        roaring64_bitmap_t* result =
+            api::roaring64_bitmap_portable_deserialize_frozen(buf, maxbytes);
+        if (result == nullptr) {
+            ROARING_TERMINATE("failed alloc while reading frozen portable");
+        }
+        return Roaring64(result);
+    }
+
     typedef Roaring64ConstIterator const_iterator;
 
     /**

--- a/cpp/roaring/roaring64.hh
+++ b/cpp/roaring/roaring64.hh
@@ -487,14 +487,18 @@ class Roaring64 {
     /**
      * Read a bitmap from a portable serialized buffer as a read-only view of
      * the container payloads. See
-     * roaring64_bitmap_portable_deserialize_frozen(). May throw
-     * std::runtime_error.
+     * roaring64_bitmap_portable_deserialize_frozen(): the buffer must outlive
+     * the returned bitmap, which must not be modified, and untrusted input
+     * should be checked with internal_validate() before use.
+     *
+     * Terminates (ROARING_TERMINATE) if the buffer cannot be read, which
+     * covers both a malformed buffer and an allocation failure.
      */
     static Roaring64 readSafeFrozen(const char* buf, size_t maxbytes) {
         roaring64_bitmap_t* result =
             api::roaring64_bitmap_portable_deserialize_frozen(buf, maxbytes);
         if (result == nullptr) {
-            ROARING_TERMINATE("failed alloc while reading frozen portable");
+            ROARING_TERMINATE("failed to read frozen portable bitmap");
         }
         return Roaring64(result);
     }

--- a/include/roaring/containers/bitset.h
+++ b/include/roaring/containers/bitset.h
@@ -56,6 +56,10 @@ typedef struct bitset_container_s bitset_container_t;
 /* Create a new bitset. Return NULL in case of failure. */
 bitset_container_t *bitset_container_create(void);
 
+/* Create a bitset without zeroing the words. Caller must overwrite `words`
+ * before the container is used. Return NULL in case of failure. */
+bitset_container_t *bitset_container_create_uninitialized(void);
+
 /* Free memory. */
 void bitset_container_free(bitset_container_t *bitset);
 

--- a/include/roaring/containers/containers.h
+++ b/include/roaring/containers/containers.h
@@ -2451,6 +2451,7 @@ roaring_container_iterator_t container_init_iterator_last(const container_t *c,
  * Moves the iterator to the next entry. Returns true and sets `value` if a
  * value is present.
  */
+CROARING_ALLOW_UNALIGNED
 inline bool container_iterator_next(const container_t *c, uint8_t typecode,
                                     roaring_container_iterator_t *it,
                                     uint16_t *value) {
@@ -2519,6 +2520,7 @@ inline bool container_iterator_next(const container_t *c, uint8_t typecode,
  * Moves the iterator to the previous entry. Returns true and sets `value` if a
  * value is present.
  */
+CROARING_ALLOW_UNALIGNED
 inline bool container_iterator_prev(const container_t *c, uint8_t typecode,
                                     roaring_container_iterator_t *it,
                                     uint16_t *value) {

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -653,6 +653,30 @@ roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_safe(const char *buf,
                                                                size_t maxbytes);
 
 /**
+ * Read a bitmap from a portable serialized buffer as a read-only view of the
+ * container payloads. Headers and the ART index are allocated; bitset/array/run
+ * payloads alias `buf` and are not copied.
+ *
+ * In case of failure, NULL is returned. The function will not read beyond
+ * `maxbytes`.
+ *
+ * The returned bitmap must only be used in a readonly manner. It must be
+ * freed with `roaring64_bitmap_free()`. The backing buffer must not be freed
+ * or modified while it backs the bitmap.
+ *
+ * This function is endian-sensitive. If you have a big-endian system (e.g., a
+ * mainframe IBM s390x), in-place viewing of the little-endian portable format
+ * is not compatible. This is not a bug, it is by design: payloads are used
+ * as they sit in the buffer. The 32-bit
+ * `roaring_bitmap_portable_deserialize_frozen` has the same limitation.
+ *
+ * Unaligned payload accesses are possible; the bitset kernels use unaligned
+ * loads.
+ */
+roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_frozen(
+    const char *buf, size_t maxbytes);
+
+/**
  * Returns the number of bytes required to serialize this bitmap in a "frozen"
  * format. This is not compatible with any other serialization formats.
  *

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -680,11 +680,10 @@ roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_safe(const char *buf,
  * after that is the bitmap considered safe for use. We also recommend
  * checksumming the serialized data; CRoaring does not provide checksumming.
  *
- * This function is endian-sensitive. If you have a big-endian system (e.g., a
- * mainframe IBM s390x), in-place viewing of the little-endian portable format
- * is not compatible. This is not a bug, it is by design: payloads are used
- * as they sit in the buffer. The 32-bit
- * `roaring_bitmap_portable_deserialize_frozen` has the same limitation.
+ * Returns NULL on a big-endian system (e.g., a mainframe IBM s390x). The
+ * portable format is little-endian and this function uses the payload bytes
+ * where they sit, so there is no correct in-place view of them there; use
+ * `roaring64_bitmap_portable_deserialize_safe()`, which converts as it copies.
  *
  * Container payloads are used where they sit in the buffer, so they may be
  * unaligned. Every access path is either SIMD with unaligned loads or marked

--- a/include/roaring/roaring64.h
+++ b/include/roaring/roaring64.h
@@ -661,8 +661,24 @@ roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_safe(const char *buf,
  * `maxbytes`.
  *
  * The returned bitmap must only be used in a readonly manner. It must be
- * freed with `roaring64_bitmap_free()`. The backing buffer must not be freed
- * or modified while it backs the bitmap.
+ * freed with `roaring64_bitmap_free()`. The backing buffer must outlive the
+ * bitmap and must not be freed or modified while it backs it. Calling any
+ * mutating function on the result is undefined behavior: its container array
+ * and headers live in a single allocation, so growing it would reallocate an
+ * interior pointer.
+ *
+ * The function itself is safe in the sense that it will not read beyond
+ * (buf, maxbytes). However, as with
+ * `roaring64_bitmap_portable_deserialize_safe()`, a bitmap read from garbage
+ * may not be in a valid state, and subsequent operations on it may not lead
+ * to sensible results: array containers must be sorted, and run containers
+ * sorted and non-overlapping, which is guaranteed only when the input came
+ * from a real serialized bitmap.
+ *
+ * If the source is untrusted, you should call
+ * `roaring64_bitmap_internal_validate` on the result before using it. Only
+ * after that is the bitmap considered safe for use. We also recommend
+ * checksumming the serialized data; CRoaring does not provide checksumming.
  *
  * This function is endian-sensitive. If you have a big-endian system (e.g., a
  * mainframe IBM s390x), in-place viewing of the little-endian portable format
@@ -670,8 +686,9 @@ roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_safe(const char *buf,
  * as they sit in the buffer. The 32-bit
  * `roaring_bitmap_portable_deserialize_frozen` has the same limitation.
  *
- * Unaligned payload accesses are possible; the bitset kernels use unaligned
- * loads.
+ * Container payloads are used where they sit in the buffer, so they may be
+ * unaligned. Every access path is either SIMD with unaligned loads or marked
+ * `CROARING_ALLOW_UNALIGNED`.
  */
 roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_frozen(
     const char *buf, size_t maxbytes);

--- a/include/roaring/roaring_types.h
+++ b/include/roaring/roaring_types.h
@@ -45,6 +45,8 @@ struct container_s {};
 
 #define ROARING_FLAG_COW UINT8_C(0x1)
 #define ROARING_FLAG_FROZEN UINT8_C(0x2)
+// 64-bit only: ART node arrays alias a frozen buffer (do not art_free).
+#define ROARING_FLAG_FROZEN_ART UINT8_C(0x4)
 
 /**
  * Roaring arrays are array-based key-value pairs having containers as values

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -59,8 +59,7 @@ void bitset_container_set_all(bitset_container_t *bitset) {
     bitset->cardinality = (1 << 16);
 }
 
-/* Create a new bitset. Return NULL in case of failure. */
-bitset_container_t *bitset_container_create(void) {
+static bitset_container_t *bitset_container_allocate(void) {
     bitset_container_t *bitset =
         (bitset_container_t *)roaring_malloc(sizeof(bitset_container_t));
 
@@ -85,7 +84,23 @@ bitset_container_t *bitset_container_create(void) {
         roaring_free(bitset);
         return NULL;
     }
-    bitset_container_clear(bitset);
+    return bitset;
+}
+
+/* Create a new bitset. Return NULL in case of failure. */
+bitset_container_t *bitset_container_create(void) {
+    bitset_container_t *bitset = bitset_container_allocate();
+    if (bitset) {
+        bitset_container_clear(bitset);
+    }
+    return bitset;
+}
+
+bitset_container_t *bitset_container_create_uninitialized(void) {
+    bitset_container_t *bitset = bitset_container_allocate();
+    if (bitset) {
+        bitset->cardinality = 0;
+    }
     return bitset;
 }
 

--- a/src/containers/containers.c
+++ b/src/containers/containers.c
@@ -299,6 +299,7 @@ extern inline container_t *container_andnot(const container_t *c1,
                                             uint8_t type2,
                                             uint8_t *result_type);
 
+CROARING_ALLOW_UNALIGNED
 roaring_container_iterator_t container_init_iterator(const container_t *c,
                                                      uint8_t typecode,
                                                      uint16_t *value) {
@@ -338,6 +339,7 @@ roaring_container_iterator_t container_init_iterator(const container_t *c,
     }
 }
 
+CROARING_ALLOW_UNALIGNED
 roaring_container_iterator_t container_init_iterator_last(const container_t *c,
                                                           uint8_t typecode,
                                                           uint16_t *value) {
@@ -417,6 +419,7 @@ bool container_iterator_lower_bound(const container_t *c, uint8_t typecode,
     }
 }
 
+CROARING_ALLOW_UNALIGNED
 bool container_iterator_read_into_uint32(const container_t *c, uint8_t typecode,
                                          roaring_container_iterator_t *it,
                                          uint32_t high16, uint32_t *buf,
@@ -508,6 +511,7 @@ bool container_iterator_read_into_uint32(const container_t *c, uint8_t typecode,
     }
 }
 
+CROARING_ALLOW_UNALIGNED
 bool container_iterator_read_into_uint64(const container_t *c, uint8_t typecode,
                                          roaring_container_iterator_t *it,
                                          uint64_t high48, uint64_t *buf,
@@ -599,6 +603,7 @@ bool container_iterator_read_into_uint64(const container_t *c, uint8_t typecode,
     }
 }
 
+CROARING_ALLOW_UNALIGNED
 bool container_iterator_read_backward_into_uint32(
     const container_t *c, uint8_t typecode, roaring_container_iterator_t *it,
     uint32_t high16, uint32_t *buf, uint32_t count, uint32_t *consumed,
@@ -690,6 +695,7 @@ bool container_iterator_read_backward_into_uint32(
     }
 }
 
+CROARING_ALLOW_UNALIGNED
 bool container_iterator_read_backward_into_uint64(
     const container_t *c, uint8_t typecode, roaring_container_iterator_t *it,
     uint64_t high48, uint64_t *buf, uint32_t count, uint32_t *consumed,

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -99,6 +99,28 @@ static inline bool is_frozen64(const roaring64_bitmap_t *r) {
     return r->flags & ROARING_FLAG_FROZEN;
 }
 
+static inline bool is_frozen_art64(const roaring64_bitmap_t *r) {
+    return r->flags & ROARING_FLAG_FROZEN_ART;
+}
+
+typedef union {
+    bitset_container_t bitset;
+    array_container_t array;
+    run_container_t run;
+} frozen_container_header_t;
+
+static void *arena_alloc(char **arena, size_t num_bytes) {
+    char *res = *arena;
+    *arena += num_bytes;
+    return res;
+}
+
+static char *arena_pad(char *cursor, const char *base, size_t alignment) {
+    uint64_t off = (uint64_t)(cursor - base);
+    uint64_t aligned = (off + alignment - 1) & ~(uint64_t)(alignment - 1);
+    return (char *)base + aligned;
+}
+
 // Splits the given uint64 key into high 48 bit and low 16 bit components.
 // Expects high48_out to be of length ART_KEY_BYTES.
 static inline uint16_t split_key(uint64_t key, uint8_t high48_out[]) {
@@ -198,6 +220,37 @@ static leaf_t add_container(roaring64_bitmap_t *r, container_t *container,
     uint64_t index = allocate_index(r);
     set_container_at(r, index, container, typecode);
     return create_leaf(index, typecode);
+}
+
+static void ensure_container_capacity(roaring64_bitmap_t *r, uint64_t extra) {
+    uint64_t needed = r->first_free + extra;
+    if (needed <= r->capacity) {
+        return;
+    }
+    uint64_t new_capacity = r->capacity;
+    if (new_capacity == 0) {
+        new_capacity = 2;
+    }
+    while (new_capacity < needed) {
+        uint64_t grown;
+        if (new_capacity < 1024) {
+            grown = 2 * new_capacity;
+        } else {
+            grown = new_capacity + new_capacity / 4;
+        }
+        if (grown <= new_capacity) {
+            new_capacity = needed;
+            break;
+        }
+        new_capacity = grown;
+    }
+    uint64_t increase = new_capacity - r->capacity;
+    r->containers = (container_t **)roaring_realloc(
+        r->containers, new_capacity * sizeof(container_t *));
+    memset(r->containers + r->capacity, 0, increase * sizeof(container_t *));
+    r->typecodes = (uint8_t *)roaring_realloc(r->typecodes,
+                                              new_capacity * sizeof(uint8_t));
+    r->capacity = new_capacity;
 }
 
 static void remove_container(roaring64_bitmap_t *r, leaf_t leaf) {
@@ -313,21 +366,22 @@ void roaring64_bitmap_free(roaring64_bitmap_t *r) {
     if (!r) {
         return;
     }
+    if (is_frozen64(r)) {
+        // Headers, containers[], and typecodes[] live in the same allocation
+        // as `r`. Payloads alias a caller buffer.
+        if (!is_frozen_art64(r)) {
+            art_free(&r->art);
+        }
+        roaring_free(r);
+        return;
+    }
     art_iterator_t it = art_init_iterator(&r->art, /*first=*/true);
     while (it.value != NULL) {
         leaf_t leaf = (leaf_t)*it.value;
-        if (is_frozen64(r)) {
-            // Only free the container itself, not the buffer-backed contents
-            // within.
-            roaring_free(get_container(r, leaf));
-        } else {
-            container_free(get_container(r, leaf), get_typecode(leaf));
-        }
+        container_free(get_container(r, leaf), get_typecode(leaf));
         art_iterator_next(&it);
     }
-    if (!is_frozen64(r)) {
-        art_free(&r->art);
-    }
+    art_free(&r->art);
     roaring_free(r->containers);
     roaring_free(r->typecodes);
     roaring_free(r);
@@ -399,6 +453,7 @@ static void move_from_roaring32_offset(roaring64_bitmap_t *dst,
                                        uint32_t high_bits) {
     uint64_t key_base = ((uint64_t)high_bits) << 32;
     uint32_t r32_size = ra_get_size(&src->high_low_container);
+    ensure_container_capacity(dst, r32_size);
     for (uint32_t i = 0; i < r32_size; ++i) {
         uint16_t key = ra_get_key_at_index(&src->high_low_container, i);
         uint8_t typecode;
@@ -2429,22 +2484,26 @@ roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_safe(
         previous_high32 = high32;
 
         // Read the 32-bit Roaring bitmaps representing the least
-        // significant bits of a set of elements.
-        size_t bitmap32_size = roaring_bitmap_portable_deserialize_size(
-            buf, maxbytes - read_bytes);
-        if (bitmap32_size == 0) {
-            roaring64_bitmap_free(r);
-            return NULL;
-        }
-
-        roaring_bitmap_t *bitmap32 = roaring_bitmap_portable_deserialize_safe(
-            buf, maxbytes - read_bytes);
+        // significant bits of a set of elements. ra_portable_deserialize
+        // already reports bytes consumed, so we do not walk the 32-bit
+        // format a second time with deserialize_size.
+        roaring_bitmap_t *bitmap32 =
+            (roaring_bitmap_t *)roaring_malloc(sizeof(roaring_bitmap_t));
         if (bitmap32 == NULL) {
             roaring64_bitmap_free(r);
             return NULL;
         }
-        buf += bitmap32_size;
-        read_bytes += bitmap32_size;
+        size_t bytesread = 0;
+        bool is_ok = ra_portable_deserialize(&bitmap32->high_low_container, buf,
+                                             maxbytes - read_bytes, &bytesread);
+        if (!is_ok) {
+            roaring_free(bitmap32);
+            roaring64_bitmap_free(r);
+            return NULL;
+        }
+        roaring_bitmap_set_copy_on_write(bitmap32, false);
+        buf += bytesread;
+        read_bytes += bytesread;
 
         // While we don't attempt to validate much, we must ensure that there
         // is no duplication in the high 48 bits - inserting into the ART
@@ -2673,22 +2732,67 @@ size_t roaring64_bitmap_frozen_serialize(const roaring64_bitmap_t *r,
     return buf - initial_buf;
 }
 
-static container_t *container_frozen_view(uint8_t typecode, uint32_t elem_count,
-                                          const uint64_t **bitsets,
-                                          const uint16_t **arrays,
-                                          const rle16_t **runs) {
+static roaring64_bitmap_t *alloc_frozen_bitmap(
+    uint64_t capacity, frozen_container_header_t **headers_out) {
+    if (capacity > SIZE_MAX / sizeof(frozen_container_header_t)) {
+        return NULL;
+    }
+    size_t ptrs = (size_t)capacity * sizeof(container_t *);
+    size_t codes = (size_t)capacity * sizeof(uint8_t);
+    size_t headers = (size_t)capacity * sizeof(frozen_container_header_t);
+    size_t pad = alignof(container_t *) + alignof(frozen_container_header_t);
+    if (sizeof(roaring64_bitmap_t) > SIZE_MAX - ptrs ||
+        sizeof(roaring64_bitmap_t) + ptrs > SIZE_MAX - codes ||
+        sizeof(roaring64_bitmap_t) + ptrs + codes > SIZE_MAX - headers ||
+        sizeof(roaring64_bitmap_t) + ptrs + codes + headers > SIZE_MAX - pad) {
+        return NULL;
+    }
+    size_t sz = sizeof(roaring64_bitmap_t) + ptrs + codes + headers + pad;
+    char *base = (char *)roaring_malloc(sz);
+    if (base == NULL) {
+        return NULL;
+    }
+    char *cursor = base;
+    roaring64_bitmap_t *r =
+        (roaring64_bitmap_t *)arena_alloc(&cursor, sizeof(roaring64_bitmap_t));
+    art_init_cleared(&r->art);
+    r->flags = ROARING_FLAG_FROZEN;
+    r->capacity = capacity;
+    r->first_free = 0;
+    cursor = arena_pad(cursor, base, alignof(container_t *));
+    if (capacity == 0) {
+        r->containers = NULL;
+        r->typecodes = NULL;
+        if (headers_out != NULL) {
+            *headers_out = NULL;
+        }
+        return r;
+    }
+    r->containers = (container_t **)arena_alloc(&cursor, ptrs);
+    memset(r->containers, 0, ptrs);
+    r->typecodes = (uint8_t *)arena_alloc(&cursor, codes);
+    cursor = arena_pad(cursor, base, alignof(frozen_container_header_t));
+    frozen_container_header_t *hdrs =
+        (frozen_container_header_t *)arena_alloc(&cursor, headers);
+    if (headers_out != NULL) {
+        *headers_out = hdrs;
+    }
+    return r;
+}
+
+static container_t *container_frozen_view_at(
+    frozen_container_header_t *header, uint8_t typecode, uint32_t elem_count,
+    const uint64_t **bitsets, const uint16_t **arrays, const rle16_t **runs) {
     switch (typecode) {
         case BITSET_CONTAINER_TYPE: {
-            bitset_container_t *c = (bitset_container_t *)roaring_malloc(
-                sizeof(bitset_container_t));
+            bitset_container_t *c = &header->bitset;
             c->cardinality = elem_count;
             c->words = (uint64_t *)*bitsets;
             *bitsets += BITSET_CONTAINER_SIZE_IN_WORDS;
             return (container_t *)c;
         }
         case ARRAY_CONTAINER_TYPE: {
-            array_container_t *c =
-                (array_container_t *)roaring_malloc(sizeof(array_container_t));
+            array_container_t *c = &header->array;
             c->cardinality = elem_count;
             c->capacity = elem_count;
             c->array = (uint16_t *)*arrays;
@@ -2696,19 +2800,15 @@ static container_t *container_frozen_view(uint8_t typecode, uint32_t elem_count,
             return (container_t *)c;
         }
         case RUN_CONTAINER_TYPE: {
-            run_container_t *c =
-                (run_container_t *)roaring_malloc(sizeof(run_container_t));
+            run_container_t *c = &header->run;
             c->n_runs = elem_count;
             c->capacity = elem_count;
             c->runs = (rle16_t *)*runs;
             *runs += elem_count;
             return (container_t *)c;
         }
-        default: {
-            assert(false);
-            roaring_unreachable;
+        default:
             return NULL;
-        }
     }
 }
 
@@ -2721,42 +2821,33 @@ roaring64_bitmap_t *roaring64_bitmap_frozen_view(const char *buf,
         return NULL;
     }
 
-    roaring64_bitmap_t *r = roaring64_bitmap_create();
-
-    // Flags.
-    if (maxbytes < sizeof(r->flags)) {
-        roaring64_bitmap_free(r);
+    uint8_t flags;
+    uint64_t capacity;
+    if (maxbytes < sizeof(flags) + sizeof(capacity)) {
         return NULL;
     }
-    memcpy(&r->flags, buf, sizeof(r->flags));
-    buf += sizeof(r->flags);
-    maxbytes -= sizeof(r->flags);
-    r->flags |= ROARING_FLAG_FROZEN;
+    memcpy(&flags, buf, sizeof(flags));
+    buf += sizeof(flags);
+    maxbytes -= sizeof(flags);
+    memcpy(&capacity, buf, sizeof(capacity));
+    buf += sizeof(capacity);
+    maxbytes -= sizeof(capacity);
 
-    // Container count.
-    if (maxbytes < sizeof(r->capacity)) {
-        roaring64_bitmap_free(r);
+    frozen_container_header_t *headers = NULL;
+    roaring64_bitmap_t *r = alloc_frozen_bitmap(capacity, &headers);
+    if (r == NULL) {
         return NULL;
     }
-    memcpy(&r->capacity, buf, sizeof(r->capacity));
-    buf += sizeof(r->capacity);
-    maxbytes -= sizeof(r->capacity);
-
-    r->containers =
-        (container_t **)roaring_malloc(r->capacity * sizeof(container_t *));
-    r->typecodes = (uint8_t *)roaring_malloc(r->capacity * sizeof(uint8_t));
-    if (r->capacity > 0) {
-        memset(r->containers, 0, r->capacity * sizeof(container_t *));
-    }
+    r->flags = flags | ROARING_FLAG_FROZEN | ROARING_FLAG_FROZEN_ART;
 
     // Container element counts.
-    if (maxbytes < r->capacity * sizeof(uint16_t)) {
+    if (maxbytes < capacity * sizeof(uint16_t)) {
         roaring64_bitmap_free(r);
         return NULL;
     }
     const char *elem_counts = buf;
-    buf += r->capacity * sizeof(uint16_t);
-    maxbytes -= r->capacity * sizeof(uint16_t);
+    buf += capacity * sizeof(uint16_t);
+    maxbytes -= capacity * sizeof(uint16_t);
 
     // Total container sizes.
     uint64_t total_sizes[4];
@@ -2804,6 +2895,10 @@ roaring64_bitmap_t *roaring64_bitmap_frozen_view(const char *buf,
     // Deserialize in ART iteration order.
     art_iterator_t it = art_init_iterator(&r->art, /*first=*/true);
     for (size_t i = 0; it.value != NULL; ++i) {
+        if (i >= capacity) {
+            roaring64_bitmap_free(r);
+            return NULL;
+        }
         leaf_t leaf = (leaf_t)*it.value;
         uint8_t typecode = get_typecode(leaf);
 
@@ -2814,10 +2909,17 @@ roaring64_bitmap_t *roaring64_bitmap_frozen_view(const char *buf,
 
         // The container index is unrelated to the iteration order.
         uint64_t index = get_index(leaf);
-        set_container_at(r, index,
-                         container_frozen_view(typecode, elem_count, &bitsets,
-                                               &arrays, &runs),
-                         typecode);
+        if (index >= capacity) {
+            roaring64_bitmap_free(r);
+            return NULL;
+        }
+        container_t *c = container_frozen_view_at(
+            headers + index, typecode, elem_count, &bitsets, &arrays, &runs);
+        if (c == NULL) {
+            roaring64_bitmap_free(r);
+            return NULL;
+        }
+        set_container_at(r, index, c, typecode);
 
         art_iterator_next(&it);
     }
@@ -2825,6 +2927,282 @@ roaring64_bitmap_t *roaring64_bitmap_frozen_view(const char *buf,
     // Padding to make overall size a multiple of required alignment.
     buf = CROARING_ALIGN_BUF(buf, CROARING_BITSET_ALIGNMENT);
 
+    r->first_free = r->capacity;
+    return r;
+}
+
+static bool view_one_portable32(roaring64_bitmap_t *r,
+                                frozen_container_header_t *headers,
+                                uint32_t high32, const char *buf,
+                                size_t maxbytes, size_t *consumed) {
+    *consumed = roaring_bitmap_portable_deserialize_size(buf, maxbytes);
+    if (*consumed == 0 || *consumed > maxbytes) {
+        return false;
+    }
+    const char *start = buf;
+    size_t remaining = *consumed;
+
+    uint32_t cookie;
+    memcpy(&cookie, buf, sizeof(cookie));
+    cookie = croaring_letoh32(cookie);
+    buf += sizeof(cookie);
+    remaining -= sizeof(cookie);
+
+    int32_t num_containers;
+    const char *run_flag_bitset = NULL;
+    bool hasrun = false;
+    bool has_offsets;
+
+    if (cookie == SERIAL_COOKIE_NO_RUNCONTAINER) {
+        if (remaining < sizeof(uint32_t)) {
+            return false;
+        }
+        uint32_t n_le;
+        memcpy(&n_le, buf, sizeof(n_le));
+        num_containers = (int32_t)croaring_letoh32(n_le);
+        buf += sizeof(uint32_t);
+        remaining -= sizeof(uint32_t);
+        has_offsets = true;
+    } else if ((cookie & 0xFFFF) == SERIAL_COOKIE) {
+        num_containers = (int32_t)(cookie >> 16) + 1;
+        hasrun = true;
+        int32_t run_flag_bitset_size = (num_containers + 7) / 8;
+        if (num_containers < 0 || remaining < (size_t)run_flag_bitset_size) {
+            return false;
+        }
+        run_flag_bitset = buf;
+        buf += run_flag_bitset_size;
+        remaining -= (size_t)run_flag_bitset_size;
+        has_offsets = num_containers >= NO_OFFSET_THRESHOLD;
+    } else {
+        return false;
+    }
+    if (num_containers < 0 || num_containers > (1 << 16)) {
+        return false;
+    }
+
+    size_t desc_bytes = (size_t)num_containers * 2 * sizeof(uint16_t);
+    if (remaining < desc_bytes) {
+        return false;
+    }
+    const char *keyscards = buf;
+    buf += desc_bytes;
+    remaining -= desc_bytes;
+
+    const char *offset_bytes = NULL;
+    if (has_offsets) {
+        size_t off_bytes = (size_t)num_containers * sizeof(uint32_t);
+        if (remaining < off_bytes) {
+            return false;
+        }
+        offset_bytes = buf;
+        buf += off_bytes;
+        remaining -= off_bytes;
+    }
+
+    int32_t last_key = -1;
+    uint64_t key_base = ((uint64_t)high32) << 32;
+
+    for (int32_t i = 0; i < num_containers; ++i) {
+        uint16_t key, card_m1;
+        memcpy(&key, keyscards + 4 * (size_t)i, sizeof(key));
+        key = croaring_letoh16(key);
+        memcpy(&card_m1, keyscards + 4 * (size_t)i + 2, sizeof(card_m1));
+        card_m1 = croaring_letoh16(card_m1);
+        if ((int32_t)key <= last_key) {
+            return false;
+        }
+        last_key = (int32_t)key;
+
+        uint32_t cardinality = (uint32_t)card_m1 + 1;
+        bool isbitmap = cardinality > DEFAULT_MAX_SIZE;
+        bool isrun = false;
+        if (hasrun && (run_flag_bitset[i / 8] & (1 << (i % 8))) != 0) {
+            isbitmap = false;
+            isrun = true;
+        }
+
+        const char *payload;
+        if (offset_bytes != NULL) {
+            uint32_t off;
+            memcpy(&off, offset_bytes + (size_t)i * sizeof(uint32_t),
+                   sizeof(off));
+            off = croaring_letoh32(off);
+            if ((size_t)off >= *consumed) {
+                return false;
+            }
+            payload = start + off;
+        } else {
+            payload = buf;
+        }
+
+        uint8_t typecode;
+        size_t payload_size;
+        if (isbitmap) {
+            typecode = BITSET_CONTAINER_TYPE;
+            payload_size = BITSET_CONTAINER_SIZE_IN_WORDS * sizeof(uint64_t);
+        } else if (isrun) {
+            typecode = RUN_CONTAINER_TYPE;
+            if ((size_t)(payload - start) + sizeof(uint16_t) > *consumed) {
+                return false;
+            }
+            uint16_t n_runs;
+            memcpy(&n_runs, payload, sizeof(n_runs));
+            n_runs = croaring_letoh16(n_runs);
+            payload_size = sizeof(uint16_t) + (size_t)n_runs * sizeof(rle16_t);
+        } else {
+            typecode = ARRAY_CONTAINER_TYPE;
+            payload_size = (size_t)cardinality * sizeof(uint16_t);
+        }
+        if ((size_t)(payload - start) + payload_size > *consumed) {
+            return false;
+        }
+
+        if (r->first_free >= r->capacity) {
+            return false;
+        }
+        uint64_t index = allocate_index(r);
+        frozen_container_header_t *header = headers + index;
+        container_t *c;
+        if (isbitmap) {
+            header->bitset.cardinality = (int32_t)cardinality;
+            header->bitset.words = (uint64_t *)payload;
+            c = (container_t *)&header->bitset;
+        } else if (isrun) {
+            uint16_t n_runs;
+            memcpy(&n_runs, payload, sizeof(n_runs));
+            n_runs = croaring_letoh16(n_runs);
+            header->run.n_runs = n_runs;
+            header->run.capacity = n_runs;
+            header->run.runs = (rle16_t *)(payload + sizeof(uint16_t));
+            c = (container_t *)&header->run;
+        } else {
+            header->array.cardinality = (int32_t)cardinality;
+            header->array.capacity = (int32_t)cardinality;
+            header->array.array = (uint16_t *)payload;
+            c = (container_t *)&header->array;
+        }
+        set_container_at(r, index, c, typecode);
+
+        uint8_t high48[ART_KEY_BYTES];
+        uint64_t high48_bits = key_base | ((uint64_t)key << 16);
+        split_key(high48_bits, high48);
+        art_insert(&r->art, high48, (art_val_t)create_leaf(index, typecode));
+
+        if (offset_bytes == NULL) {
+            buf += payload_size;
+            remaining -= payload_size;
+        }
+    }
+    (void)remaining;
+    return true;
+}
+
+CROARING_ALLOW_UNALIGNED
+roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_frozen(
+    const char *buf, size_t maxbytes) {
+    if (buf == NULL) {
+        return NULL;
+    }
+    const char *initial_buf = buf;
+    size_t remaining = maxbytes;
+
+    if (remaining < sizeof(uint64_t)) {
+        return NULL;
+    }
+    uint64_t buckets;
+    memcpy(&buckets, buf, sizeof(buckets));
+    buckets = croaring_letoh64(buckets);
+    buf += sizeof(buckets);
+    remaining -= sizeof(buckets);
+    if (buckets > UINT32_MAX) {
+        return NULL;
+    }
+
+    uint64_t ncontainers = 0;
+    const char *count_buf = buf;
+    size_t count_remaining = remaining;
+    int64_t previous_high32 = -1;
+    for (uint64_t bucket = 0; bucket < buckets; ++bucket) {
+        if (count_remaining < sizeof(uint32_t)) {
+            return NULL;
+        }
+        uint32_t high32;
+        memcpy(&high32, count_buf, sizeof(high32));
+        high32 = croaring_letoh32(high32);
+        count_buf += sizeof(high32);
+        count_remaining -= sizeof(high32);
+        if (high32 <= previous_high32) {
+            return NULL;
+        }
+        previous_high32 = high32;
+        size_t bitmap32_size = roaring_bitmap_portable_deserialize_size(
+            count_buf, count_remaining);
+        if (bitmap32_size == 0) {
+            return NULL;
+        }
+        uint32_t cookie;
+        if (count_remaining < sizeof(cookie)) {
+            return NULL;
+        }
+        memcpy(&cookie, count_buf, sizeof(cookie));
+        cookie = croaring_letoh32(cookie);
+        int32_t size;
+        if ((cookie & 0xFFFF) == SERIAL_COOKIE) {
+            size = (int32_t)(cookie >> 16) + 1;
+        } else if (cookie == SERIAL_COOKIE_NO_RUNCONTAINER) {
+            if (count_remaining < 2 * sizeof(uint32_t)) {
+                return NULL;
+            }
+            uint32_t size_le;
+            memcpy(&size_le, count_buf + sizeof(uint32_t), sizeof(size_le));
+            size = (int32_t)croaring_letoh32(size_le);
+        } else {
+            return NULL;
+        }
+        if (size < 0) {
+            return NULL;
+        }
+        ncontainers += (uint64_t)size;
+        count_buf += bitmap32_size;
+        count_remaining -= bitmap32_size;
+    }
+
+    frozen_container_header_t *headers = NULL;
+    roaring64_bitmap_t *r = alloc_frozen_bitmap(ncontainers, &headers);
+    if (r == NULL) {
+        return NULL;
+    }
+    // ART is owned; payloads alias buf.
+    r->flags = ROARING_FLAG_FROZEN;
+
+    previous_high32 = -1;
+    for (uint64_t bucket = 0; bucket < buckets; ++bucket) {
+        if (remaining < sizeof(uint32_t)) {
+            roaring64_bitmap_free(r);
+            return NULL;
+        }
+        uint32_t high32;
+        memcpy(&high32, buf, sizeof(high32));
+        high32 = croaring_letoh32(high32);
+        buf += sizeof(high32);
+        remaining -= sizeof(high32);
+        if (high32 <= previous_high32) {
+            roaring64_bitmap_free(r);
+            return NULL;
+        }
+        previous_high32 = high32;
+
+        size_t consumed = 0;
+        if (!view_one_portable32(r, headers, high32, buf, remaining,
+                                 &consumed)) {
+            roaring64_bitmap_free(r);
+            return NULL;
+        }
+        buf += consumed;
+        remaining -= consumed;
+    }
+    (void)initial_buf;
     return r;
 }
 

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -3115,6 +3115,13 @@ roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_frozen(
     if (buf == NULL) {
         return NULL;
     }
+#if CROARING_IS_BIG_ENDIAN
+    // The portable format is little-endian and this function uses the payload
+    // bytes where they sit, so there is no correct view of them here. Refuse
+    // rather than hand back a bitmap that silently reads byte-swapped values.
+    (void)maxbytes;
+    return NULL;
+#else
     size_t remaining = maxbytes;
 
     if (remaining < sizeof(uint64_t)) {
@@ -3213,6 +3220,7 @@ roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_frozen(
         remaining -= consumed;
     }
     return r;
+#endif
 }
 
 bool roaring64_bitmap_iterate(const roaring64_bitmap_t *r,

--- a/src/roaring64.c
+++ b/src/roaring64.c
@@ -109,13 +109,14 @@ typedef union {
     run_container_t run;
 } frozen_container_header_t;
 
-static void *arena_alloc(char **arena, size_t num_bytes) {
+static void *roaring64_arena_alloc(char **arena, size_t num_bytes) {
     char *res = *arena;
     *arena += num_bytes;
     return res;
 }
 
-static char *arena_pad(char *cursor, const char *base, size_t alignment) {
+static char *roaring64_arena_pad(char *cursor, const char *base,
+                                 size_t alignment) {
     uint64_t off = (uint64_t)(cursor - base);
     uint64_t aligned = (off + alignment - 1) & ~(uint64_t)(alignment - 1);
     return (char *)base + aligned;
@@ -2753,13 +2754,13 @@ static roaring64_bitmap_t *alloc_frozen_bitmap(
         return NULL;
     }
     char *cursor = base;
-    roaring64_bitmap_t *r =
-        (roaring64_bitmap_t *)arena_alloc(&cursor, sizeof(roaring64_bitmap_t));
+    roaring64_bitmap_t *r = (roaring64_bitmap_t *)roaring64_arena_alloc(
+        &cursor, sizeof(roaring64_bitmap_t));
     art_init_cleared(&r->art);
     r->flags = ROARING_FLAG_FROZEN;
     r->capacity = capacity;
     r->first_free = 0;
-    cursor = arena_pad(cursor, base, alignof(container_t *));
+    cursor = roaring64_arena_pad(cursor, base, alignof(container_t *));
     if (capacity == 0) {
         r->containers = NULL;
         r->typecodes = NULL;
@@ -2768,12 +2769,13 @@ static roaring64_bitmap_t *alloc_frozen_bitmap(
         }
         return r;
     }
-    r->containers = (container_t **)arena_alloc(&cursor, ptrs);
+    r->containers = (container_t **)roaring64_arena_alloc(&cursor, ptrs);
     memset(r->containers, 0, ptrs);
-    r->typecodes = (uint8_t *)arena_alloc(&cursor, codes);
-    cursor = arena_pad(cursor, base, alignof(frozen_container_header_t));
+    r->typecodes = (uint8_t *)roaring64_arena_alloc(&cursor, codes);
+    cursor =
+        roaring64_arena_pad(cursor, base, alignof(frozen_container_header_t));
     frozen_container_header_t *hdrs =
-        (frozen_container_header_t *)arena_alloc(&cursor, headers);
+        (frozen_container_header_t *)roaring64_arena_alloc(&cursor, headers);
     if (headers_out != NULL) {
         *headers_out = hdrs;
     }
@@ -2833,12 +2835,22 @@ roaring64_bitmap_t *roaring64_bitmap_frozen_view(const char *buf,
     buf += sizeof(capacity);
     maxbytes -= sizeof(capacity);
 
+    // The element counts alone need two bytes per container, so a capacity
+    // larger than that cannot be satisfied by this buffer. Checked before
+    // allocating, so a short buffer claiming a huge count cannot make us
+    // reserve (and clear) an arena sized from attacker-controlled bytes.
+    if (capacity > maxbytes / sizeof(uint16_t)) {
+        return NULL;
+    }
+
     frozen_container_header_t *headers = NULL;
     roaring64_bitmap_t *r = alloc_frozen_bitmap(capacity, &headers);
     if (r == NULL) {
         return NULL;
     }
-    r->flags = flags | ROARING_FLAG_FROZEN | ROARING_FLAG_FROZEN_ART;
+    // Only flags the format actually defines; the byte comes from the buffer.
+    r->flags = (uint8_t)(flags & ROARING_FLAG_COW) | ROARING_FLAG_FROZEN |
+               ROARING_FLAG_FROZEN_ART;
 
     // Container element counts.
     if (maxbytes < capacity * sizeof(uint16_t)) {
@@ -3094,7 +3106,6 @@ static bool view_one_portable32(roaring64_bitmap_t *r,
             remaining -= payload_size;
         }
     }
-    (void)remaining;
     return true;
 }
 
@@ -3104,7 +3115,6 @@ roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_frozen(
     if (buf == NULL) {
         return NULL;
     }
-    const char *initial_buf = buf;
     size_t remaining = maxbytes;
 
     if (remaining < sizeof(uint64_t)) {
@@ -3202,7 +3212,6 @@ roaring64_bitmap_t *roaring64_bitmap_portable_deserialize_frozen(
         buf += consumed;
         remaining -= consumed;
     }
-    (void)initial_buf;
     return r;
 }
 

--- a/src/roaring_array.c
+++ b/src/roaring_array.c
@@ -740,7 +740,7 @@ bool ra_portable_deserialize(roaring_array_t *answer, const char *buf,
                 return false;
             }
             // it is now safe to read
-            bitset_container_t *c = bitset_container_create();
+            bitset_container_t *c = bitset_container_create_uninitialized();
             if (c == NULL) {  // memory allocation failure
                 // Failed to allocate memory for a bitset container.
                 ra_clear(answer);  // we need to clear the containers already

--- a/tests/roaring64_serialization.cpp
+++ b/tests/roaring64_serialization.cpp
@@ -39,6 +39,12 @@ bool test_serialization(const std::string& filename) {
     }
     roaring64_bitmap_t* rf = roaring64_bitmap_portable_deserialize_frozen(
         buf1.data(), deserialized_size);
+#if CROARING_IS_BIG_ENDIAN
+    // No in-place view of a little-endian format on a big-endian host.
+    if (rf != nullptr) {
+        fail_msg("portable frozen view should be unavailable on big-endian");
+    }
+#else
     if (rf == nullptr) {
         fail_msg("portable frozen view failed on %s", filename.c_str());
     }
@@ -49,6 +55,7 @@ bool test_serialization(const std::string& filename) {
         fail_msg("portable frozen view disagrees with copy deserialize");
     }
     roaring64_bitmap_free(rf);
+#endif
 
     // Reserialize.
     size_t serialized_size = roaring64_bitmap_portable_size_in_bytes(r);

--- a/tests/roaring64_serialization.cpp
+++ b/tests/roaring64_serialization.cpp
@@ -37,6 +37,18 @@ bool test_serialization(const std::string& filename) {
     if (!roaring64_bitmap_internal_validate(r, &reason)) {
         fail_msg("Validation failed: %s", reason);
     }
+    roaring64_bitmap_t* rf = roaring64_bitmap_portable_deserialize_frozen(
+        buf1.data(), deserialized_size);
+    if (rf == nullptr) {
+        fail_msg("portable frozen view failed on %s", filename.c_str());
+    }
+    if (!roaring64_bitmap_internal_validate(rf, &reason)) {
+        fail_msg("Frozen validation failed: %s", reason);
+    }
+    if (!roaring64_bitmap_equals(r, rf)) {
+        fail_msg("portable frozen view disagrees with copy deserialize");
+    }
+    roaring64_bitmap_free(rf);
 
     // Reserialize.
     size_t serialized_size = roaring64_bitmap_portable_size_in_bytes(r);

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -2022,11 +2022,16 @@ void check_portable_serialization(const roaring64_bitmap_t* r1) {
 
     roaring64_bitmap_t* r3 = roaring64_bitmap_portable_deserialize_frozen(
         buf.data(), serialized_size);
+#if CROARING_IS_BIG_ENDIAN
+    // No in-place view of a little-endian format on a big-endian host.
+    assert_null(r3);
+#else
     assert_r64_valid(r3);
     assert_true(roaring64_bitmap_equals(r3, r1));
     roaring64_bitmap_free(r3);
     assert_null(roaring64_bitmap_portable_deserialize_frozen(
         buf.data(), serialized_size > 0 ? serialized_size - 1 : 0));
+#endif
 }
 
 DEFINE_TEST(test_portable_serialize) {

--- a/tests/roaring64_unit.cpp
+++ b/tests/roaring64_unit.cpp
@@ -2019,6 +2019,14 @@ void check_portable_serialization(const roaring64_bitmap_t* r1) {
     assert_r64_valid(r2);
     assert_true(roaring64_bitmap_equals(r2, r1));
     roaring64_bitmap_free(r2);
+
+    roaring64_bitmap_t* r3 = roaring64_bitmap_portable_deserialize_frozen(
+        buf.data(), serialized_size);
+    assert_r64_valid(r3);
+    assert_true(roaring64_bitmap_equals(r3, r1));
+    roaring64_bitmap_free(r3);
+    assert_null(roaring64_bitmap_portable_deserialize_frozen(
+        buf.data(), serialized_size > 0 ? serialized_size - 1 : 0));
 }
 
 DEFINE_TEST(test_portable_serialize) {
@@ -2036,6 +2044,13 @@ DEFINE_TEST(test_portable_serialize) {
     check_portable_serialization(r);
 
     roaring64_bitmap_add_range(r, 1ULL << 16, 1ULL << 32);
+    check_portable_serialization(r);
+
+    // Dense bitset container (cardinality > DEFAULT_MAX_SIZE).
+    roaring64_bitmap_add_range(r, 0, 5000);
+    check_portable_serialization(r);
+
+    roaring64_bitmap_run_optimize(r);
     check_portable_serialization(r);
 
     roaring64_bitmap_free(r);


### PR DESCRIPTION
## Summary

Cuts the cost of opening a 64-bit bitmap. **No serialization format changes** — the frozen bytes and the portable bytes are exactly what they were, and `shrink_to_fit` / ART leaf ordering are deliberately left alone so frozen output is unchanged.

Four things:

**1. `roaring64_bitmap_frozen_view` allocates once.** It used to `roaring_malloc` a header per container and free them one at a time. Now the bitmap, `containers[]`, `typecodes[]` and every container header live in a single arena, the way 32-bit `roaring_bitmap_frozen_view` already does, so opening is one allocation and closing is one `free`.

**2. Portable deserialize no longer walks each 32-bit bitmap twice.** `ra_portable_deserialize` already reports how many bytes it consumed; the 64-bit loop was throwing that away and calling `roaring_bitmap_portable_deserialize_size` to re-derive it. It also reserves `containers[]` per bucket instead of growing from 2, and no longer zeroes bitset words that `bitset_container_read` immediately overwrites (`bitset_container_create_uninitialized`, which also helps the 32-bit deserializer).

**3. New `roaring64_bitmap_portable_deserialize_frozen(buf, maxbytes)`** — the 64-bit analogue of `roaring_bitmap_portable_deserialize_frozen`. Headers and the ART are allocated; container payloads alias the buffer and are never copied. Unlike the 32-bit version it takes `maxbytes` and will not read past it.

**4. Hardening of the existing frozen path.** `roaring64_bitmap_frozen_view` now bounds-checks the container index it reads out of the buffer's own ART before using it — previously a crafted buffer could drive an out-of-bounds write through `set_container_at` — and it validates the declared container count against `maxbytes` before sizing its arena.

## Benchmarks

Xeon Gold 6548N, gcc `-O3 -march=native`, pinned. ns per bitmap over CRoaring's realdata sets.

Existing paths, master vs this PR:

| | `frozen_view` | | `portable_deserialize_safe` | |
|---|---:|---:|---:|---:|
| | master | this PR | master | this PR |
| census1881 | 248.4 | **108.2** (2.30×) | 1198.6 | 1112.1 (1.08×) |
| census-income | 159.7 | **77.9** (2.05×) | 775.7 | 685.0 (1.13×) |
| weather_sept_85 | 439.2 | **189.7** (2.32×) | 3257.7 | 3106.8 (1.05×) |

The new API against the existing portable open:

| | `portable_deserialize_safe` | `portable_deserialize_frozen` | |
|---|---:|---:|---:|
| census1881 | 1146.5 | 259.7 | **4.4×** |
| census-income | 736.6 | 158.7 | **4.6×** |
| weather_sept_85 | 3214.9 | 525.3 | **6.1×** |

## Safety contract

`portable_deserialize_frozen` promises only that it will not read outside `(buf, maxbytes)`, exactly like `portable_deserialize_safe`: array containers must be sorted and run containers sorted and non-overlapping for the result to behave sensibly, so **untrusted input must go through `roaring64_bitmap_internal_validate` before use**. That is documented on the function.

Checked rather than assumed: over 20,000 bit-flipped buffers the new entry point accepts 10,355 — fewer than `portable_deserialize_safe`'s 11,044 — and the 3,458 of those that pass `internal_validate` all iterate cleanly under ASan.

The buffer must outlive the bitmap and the result must not be mutated (its container array and headers share one allocation); both are documented.

## Endianness

The portable format is little-endian and this view uses payload bytes where they sit, so there is no correct in-place view on a big-endian host. `portable_deserialize_frozen` returns NULL there, and the header says to use `portable_deserialize_safe` instead, which converts as it copies. The tests assert that NULL rather than being skipped, so the contract stays covered on s390x.

(32-bit `roaring_bitmap_portable_deserialize_frozen` has the same property and handles it by compiling its test out unless `ROARING_UNSAFE_FROZEN_TESTS` is set. Refusing seemed better than returning values only a big-endian user would notice were wrong.)

## Test plan

- [x] full `ctest` suite, normal build: 27/27
- [x] full `ctest` suite under `-DROARING_SANITIZE_UNDEFINED=ON` (`-fsanitize=undefined -fno-sanitize-recover=all`): 27/27
- [x] amalgamation build, C and C++
- [x] clang-format 17
- [x] fuzzing of truncated (every prefix rejected), unaligned, and bit-flipped buffers under ASan and UBSan
- [x] big-endian branch verified by forcing `CROARING_IS_BIG_ENDIAN`: it is the branch the preprocessor keeps, it compiles clean, and it is dropped on little-endian
- [x] `roaring64_unit` extended: bitset, array and run containers through the new path, plus a truncated-buffer rejection
