### PR TITLE
Add RVV acceleration for bitset nocard operations

### DIFF
--- a/include/roaring/portability.h
+++ b/include/roaring/portability.h
@@ -172,6 +172,14 @@ extern "C" {  // portability definitions are in global scope, not a namespace
 #include <arm_neon.h>
 #endif
 
+#if defined(CROARING_IS_RISCV) && defined(__riscv_vector)
+#define CROARING_USERVV
+#endif
+
+#if defined(CROARING_USERVV)
+#include <riscv_vector.h>
+#endif
+
 #if defined(__e2k__)
 // we have an e2k (Elbrus-2000) processor
 #define CROARING_IS_E2K 1

--- a/src/containers/bitset.c
+++ b/src/containers/bitset.c
@@ -323,6 +323,21 @@ int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
     return vgetq_lane_u64(n, 0) + vgetq_lane_u64(n, 1);
 }
 
+#elif defined(CROARING_USERVV)
+int bitset_container_compute_cardinality(
+    const bitset_container_t *bitset) {
+    const uint64_t *words = bitset->words;
+    int32_t sum = 0;
+
+    for (size_t i = 0;i < BITSET_CONTAINER_SIZE_IN_WORDS;i += 4) {
+        sum += roaring_hamming(words[i]);
+        sum += roaring_hamming(words[i + 1]);
+        sum += roaring_hamming(words[i + 2]);
+        sum += roaring_hamming(words[i + 3]);
+    }
+    return sum;
+}
+
 #else  // CROARING_IS_X64
 
 /* Get the number of bits set (force computation) */
@@ -339,6 +354,31 @@ int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
 }
 
 #endif  // CROARING_IS_X64
+
+#if defined(CROARING_USERVV)
+
+#define CROARING_RVV_OP_and(a, b, vl) \
+    __riscv_vand_vv_u64m4((a), (b), (vl))
+
+#define CROARING_RVV_OP_intersection(a, b, vl) \
+    CROARING_RVV_OP_and((a), (b), (vl))
+
+#define CROARING_RVV_OP_or(a, b, vl) \
+    __riscv_vor_vv_u64m4((a), (b), (vl))
+
+#define CROARING_RVV_OP_union(a, b, vl) \
+    CROARING_RVV_OP_or((a), (b), (vl))
+
+#define CROARING_RVV_OP_xor(a, b, vl) \
+    __riscv_vxor_vv_u64m4((a), (b), (vl))
+
+#define CROARING_RVV_OP_andnot(a, b, vl) \
+    __riscv_vand_vv_u64m4(               \
+        (a),                              \
+        __riscv_vnot_v_u64m4((b), (vl)), \
+        (vl))
+#endif
+
 
 #if CROARING_IS_X64
 
@@ -758,9 +798,9 @@ SCALAR_BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
     } else {                                                                   \
       return _scalar_bitset_container_##opname##_justcard(src_1, src_2);       \
     }                                                                          \
-  }
+  }                                                                            \
 
-#else // CROARING_COMPILER_SUPPORTS_AVX512
+#else //  CROARING_COMPILER_SUPPORTS_AVX512
 
 
 #define CROARING_BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)   \
@@ -789,11 +829,11 @@ SCALAR_BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
     } else {                                                                   \
       return _scalar_bitset_container_##opname##_justcard(src_1, src_2);       \
     }                                                                          \
-  }
+  }                                                                            \
 
 #endif //  CROARING_COMPILER_SUPPORTS_AVX512
 
-#elif defined(CROARING_USENEON)
+#elif defined(CROARING_USENEON) // CROARING_IS_X64
 
 #define CROARING_BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)  \
 int bitset_container_##opname(const bitset_container_t *src_1,                \
@@ -879,9 +919,72 @@ int bitset_container_##opname##_justcard(const bitset_container_t *src_1,     \
     n = vaddq_u64(n, vpaddlq_u32(vpaddlq_u16(n2)));                           \
     n = vaddq_u64(n, vpaddlq_u32(vpaddlq_u16(n3)));                           \
     return vgetq_lane_u64(n, 0) + vgetq_lane_u64(n, 1);                       \
-}
+}                                                                             \
 
-#else
+#elif defined(CROARING_USERVV) // CROARING_IS_X64
+
+#define CROARING_BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)                      \
+int bitset_container_##opname(const bitset_container_t *src_1,            \
+                              const bitset_container_t *src_2,            \
+                              bitset_container_t *dst) {                   \
+    const uint64_t *__restrict__ words_1 = src_1->words;                   \
+    const uint64_t *__restrict__ words_2 = src_2->words;                   \
+    uint64_t *out = dst->words;                                            \
+    int32_t sum = 0;                                                       \
+    for (size_t i = 0;i < BITSET_CONTAINER_SIZE_IN_WORDS;i += 2) {         \
+        const uint64_t word_1 =(words_1[i]) opsymbol (words_2[i]);         \
+        const uint64_t word_2 =(words_1[i + 1]) opsymbol (words_2[i + 1]); \
+        out[i] = word_1;                                                    \
+        out[i + 1] = word_2;                                                \
+        sum += roaring_hamming(word_1);                                    \
+        sum += roaring_hamming(word_2);                                    \
+    }                                                                      \
+    dst->cardinality = sum;                                                 \
+    return dst->cardinality;                                                \
+}                                                                          \
+                                                                           \
+int bitset_container_##opname##_nocard(                                    \
+        const bitset_container_t *src_1,                                   \
+        const bitset_container_t *src_2,                                   \
+        bitset_container_t *dst) {                                         \
+    const uint64_t *__restrict__ words_1 = src_1->words;                   \
+    const uint64_t *__restrict__ words_2 = src_2->words;                   \
+    uint64_t *out = dst->words;                                             \
+    size_t words_remaining = BITSET_CONTAINER_SIZE_IN_WORDS;               \
+                                                                           \
+    while (words_remaining != 0) {                                         \
+        size_t vl =__riscv_vsetvl_e64m4(words_remaining);                  \
+        vuint64m4_t va =__riscv_vle64_v_u64m4(words_1, vl);                \
+        vuint64m4_t vb =__riscv_vle64_v_u64m4(words_2, vl);                \
+        vuint64m4_t vr = CROARING_RVV_OP_##opname(va, vb, vl);             \
+        __riscv_vse64_v_u64m4(out, vr, vl);                                \
+                                                                           \
+        words_1 += vl;                                                      \
+        words_2 += vl;                                                      \
+        out += vl;                                                          \
+        words_remaining -= vl;                                              \
+    }                                                                      \
+                                                                           \
+    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;                         \
+    return dst->cardinality;                                                \
+}                                                                          \
+                                                                           \
+int bitset_container_##opname##_justcard(                                  \
+        const bitset_container_t *src_1,                                   \
+        const bitset_container_t *src_2) {                                 \
+    const uint64_t *__restrict__ words_1 = src_1->words;                   \
+    const uint64_t *__restrict__ words_2 = src_2->words;                   \
+    int32_t sum = 0;                                                       \
+    for (size_t i = 0;i < BITSET_CONTAINER_SIZE_IN_WORDS;i += 2) {         \
+        const uint64_t word_1 = (words_1[i]) opsymbol (words_2[i]);        \
+        const uint64_t word_2 =(words_1[i + 1]) opsymbol (words_2[i + 1]); \
+        sum += roaring_hamming(word_1);                                    \
+        sum += roaring_hamming(word_2);                                    \
+    }                                                                      \
+    return sum;                                                            \
+}                                                                           \
+
+#else // CROARING_IS_X64
 
 #define CROARING_BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic, neon_intrinsic)  \
 int bitset_container_##opname(const bitset_container_t *src_1,            \
@@ -926,9 +1029,10 @@ int bitset_container_##opname##_justcard(const bitset_container_t *src_1, \
         sum += roaring_hamming(word_2);                                    \
     }                                                                     \
     return sum;                                                           \
-}
+}                                                                         \
 
 #endif // CROARING_IS_X64
+
 
 // we duplicate the function because other containers use the "or" term, makes API more consistent
 CROARING_BITSET_CONTAINER_FN(or,    |, _mm256_or_si256, vorrq_u64)
@@ -938,8 +1042,9 @@ CROARING_BITSET_CONTAINER_FN(union, |, _mm256_or_si256, vorrq_u64)
 CROARING_BITSET_CONTAINER_FN(and,          &, _mm256_and_si256, vandq_u64)
 CROARING_BITSET_CONTAINER_FN(intersection, &, _mm256_and_si256, vandq_u64)
 
-CROARING_BITSET_CONTAINER_FN(xor,    ^,  _mm256_xor_si256,    veorq_u64)
-CROARING_BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256, vbicq_u64)
+CROARING_BITSET_CONTAINER_FN(xor,          ^, _mm256_xor_si256, veorq_u64)
+CROARING_BITSET_CONTAINER_FN(andnot,      &~, _mm256_andnot_si256, vbicq_u64)
+
 // clang-format On
 
 


### PR DESCRIPTION
## Summary

This PR adds an initial RISC-V Vector (RVV) implementation for bitset
no-cardinality operations.

The RVV path accelerates:

- `bitset_container_and_nocard`
- `bitset_container_intersection_nocard`
- `bitset_container_or_nocard`
- `bitset_container_union_nocard`
- `bitset_container_xor_nocard`
- `bitset_container_andnot_nocard`

The implementation is VLEN-agnostic and uses `vsetvl` with `e64,m4`.

Operations that compute cardinality remain on the existing scalar path.

## Why only no-cardinality operations?

Several RVV approaches for cardinality-related operations were evaluated during
development, including vector mask/popcount and software vector popcount
approaches.

On the tested hardware, these implementations did not consistently outperform
the existing scalar cardinality path.

This PR therefore keeps the scope limited to the no-cardinality operations,
where RVV shows clear performance improvements.

## LMUL selection

LMUL values 1, 2, 4, and 8 were evaluated on real RISC-V hardware.

LMUL=4 produced the best overall cycle measurements on the tested SpacemiT X60,
so the final implementation uses `e64,m4`.

This is a measured choice for the tested microarchitecture rather than a claim
that LMUL=4 is optimal on every RVV implementation.

## Benchmark

Hardware:

- Banana Pi BPI-F3
- SpacemiT X60
- RV64
- RVV 1.0
- VLEN = 256 bits
- GCC 14.2.0
- benchmark pinned to CPU 4

Scalar build:

    -O3 -DNDEBUG -fno-tree-vectorize
    -march=rv64gc_zba_zbb_zbc_zbs
    -mabi=lp64d

RVV build:

    -O3 -DNDEBUG -fno-tree-vectorize
    -march=rv64gcv_zba_zbb_zbc_zbs
    -mabi=lp64d

`-fno-tree-vectorize` was used for both builds so that the comparison isolates
the explicitly written RVV implementation from GCC auto-vectorization.

Measurements were collected using `perf stat -r 10`.

| Operation | Scalar cycles | RVV m4 cycles | Speedup | Cycle reduction |
|---|---:|---:|---:|---:|
| AND nocard | 2,088,781,742 | 993,730,877 | 2.10x | 52.4% |
| OR nocard | 2,066,148,045 | 1,021,895,779 | 2.02x | 50.5% |
| XOR nocard | 2,059,230,593 | 979,486,320 | 2.10x | 52.4% |
| ANDNOT nocard | 2,410,211,011 | 964,258,441 | 2.50x | 60.0% |

The geometric mean cycle speedup across these four operations is approximately
2.17x.

The number of retired instructions is also substantially reduced. For
AND/OR/XOR, the benchmark drops from approximately 3.36 billion instructions
on the scalar implementation to approximately 0.24 billion with RVV.

Although the reported RVV IPC is lower, the much larger reduction in retired
instruction count results in substantially fewer total execution cycles.

No CPU migrations were observed during these measurements.

## Correctness

The final implementation passed the CRoaring test suite.

The generated RISC-V assembly was also inspected to verify that:

- the no-cardinality kernels use `e64,m4`;
- normal and cardinality-related paths remain scalar;
- no experimental mask-cardinality / `vcpop.m` implementation remains.

## Scope

This PR intentionally does not include:

- RVV cardinality
- RVV normal / `justcard` operations
- experimental mask-popcount or vector SWAR implementations
- runtime dispatch
- array-container RVV optimizations

Those can be considered separately if future measurements show clear benefits.

## AI assistance

AI tools were used during development for discussion and for drafting and
reviewing text.

