### PR TITLE
Declare condition-code clobbers in x86-64 assembly

### DIFF
--- a/include/roaring/utilasm.h
+++ b/include/roaring/utilasm.h
@@ -48,6 +48,7 @@ namespace roaring {
           "+r"(count)                                       \
         :            /* read/write */                       \
         "r"(testBit) /* read only */                        \
+        : "cc"                                              \
     )
 
 #define ASM_CLEAR_BIT_DEC_WAS_SET(testByte, testBit, count) \
@@ -58,6 +59,7 @@ namespace roaring {
           "+r"(count)                                       \
         :            /* read/write */                       \
         "r"(testBit) /* read only */                        \
+        : "cc"                                              \
     )
 
 #define ASM_BT64(testByte, testBit, count) \
@@ -68,6 +70,7 @@ namespace roaring {
         :              /* write */         \
         "r"(testByte), /* read only */     \
         "r"(testBit)   /* read only */     \
+        : "cc"                              \
     )
 
 #endif


### PR DESCRIPTION
The x86-64 bit-manipulation helpers modify the condition-code register, but their inline assembly declarations do not list the `cc` clobber. Compilers can consequently assume that flags survive these blocks. FilC rejects the incomplete assembly contract at runtime when ClickHouse builds a text-index posting list.

Declare the clobber for all three macros that execute `bts`/`btr`/`bt` followed by `sbb`. With this change, the ClickHouse functional test `05059_text_index_lazy_multi_block_windows` passes under FilC; before it, FilC stops at `bitset_container_from_array` with `assembly sets flags but "cc" clobber is missing`.
